### PR TITLE
[StyleSheet generator] support data: URIs

### DIFF
--- a/system/modules/backend/StyleSheets.php
+++ b/system/modules/backend/StyleSheets.php
@@ -463,7 +463,7 @@ class StyleSheets extends Backend
 			// Try to shorten the definition
 			if ($row['bgimage'] != '' && $row['bgposition'] != '' && $row['bgrepeat'] != '')
 			{
-				$glue = (strncmp($row['bgimage'], '/', 1) !== 0) ? $strGlue : '';
+				$glue = (strncmp($row['bgimage'], 'data:', 5) !== 0 && strncmp($row['bgimage'], '/', 1) !== 0) ? $strGlue : '';
 				$return .= $lb . 'background:' . (($bgColor[0] != '') ? $this->compileColor($bgColor, $blnWriteToFile, $vars) . ' ' : '') . 'url("' . $glue . $row['bgimage'] . '") ' . $row['bgposition'] . ' ' . $row['bgrepeat'] . ';';
 			}
 			else
@@ -481,7 +481,7 @@ class StyleSheets extends Backend
 				}
 				elseif ($row['bgimage'] != '')
 				{
-					$glue = (strncmp($row['bgimage'], '/', 1) !== 0) ? $strGlue : '';
+					$glue = (strncmp($row['bgimage'], 'data:', 5) !== 0 && strncmp($row['bgimage'], '/', 1) !== 0) ? $strGlue : '';
 					$return .= $lb . 'background-image:url("' . $glue . $row['bgimage'] . '");';
 				}
 
@@ -511,7 +511,7 @@ class StyleSheets extends Backend
 					// CSS3 PIE only supports -pie-background, so if there is a background image, include it here, too.
 					if ($row['bgimage'] != '' && $row['bgposition'] != '' && $row['bgrepeat'] != '')
 					{
-						$glue = (strncmp($row['bgimage'], '/', 1) !== 0) ? $strGlue : '';
+						$glue = (strncmp($row['bgimage'], 'data:', 5) !== 0 && strncmp($row['bgimage'], '/', 1) !== 0) ? $strGlue : '';
 						$bgImage = 'url("' . $glue . $row['bgimage'] . '") ' . $row['bgposition'] . ' ' . $row['bgrepeat'] . ',';
 					}
 
@@ -977,7 +977,7 @@ class StyleSheets extends Backend
 			}
 			elseif ($row['liststyleimage'] != '')
 			{
-				$glue = (strncmp($row['liststyleimage'], '/', 1) !== 0) ? $strGlue : '';
+				$glue = (strncmp($row['liststyleimage'], 'data:', 5) !== 0 && strncmp($row['liststyleimage'], '/', 1) !== 0) ? $strGlue : '';
 				$return .= $lb . 'list-style-image:url("' . $glue . $row['liststyleimage'] . '");';
 			}
 		}
@@ -992,7 +992,7 @@ class StyleSheets extends Backend
 		if ($row['own'] != '')
 		{
 			$own = trim($this->String->decodeEntities($row['own']));
-			$own = preg_replace('/url\("([^\/])/', 'url("' . $strGlue . "$1", $own);
+			$own = preg_replace('/url\("([^\/])(?!(?<=d)ata:)/', 'url("' . $strGlue . "$1", $own);
 			$own = preg_split('/[\n\r]+/i', $own);
 			$return .= $lb . implode(($blnWriteToFile ? '' : $lb), $own);
 		}

--- a/system/modules/backend/StyleSheets.php
+++ b/system/modules/backend/StyleSheets.php
@@ -463,6 +463,7 @@ class StyleSheets extends Backend
 			// Try to shorten the definition
 			if ($row['bgimage'] != '' && $row['bgposition'] != '' && $row['bgrepeat'] != '')
 			{
+				$row['bgimage'] = handleSpecialCharsForUrl($row['bgimage']);
 				$glue = (strncmp($row['bgimage'], 'data:', 5) !== 0 && strncmp($row['bgimage'], '/', 1) !== 0) ? $strGlue : '';
 				$return .= $lb . 'background:' . (($bgColor[0] != '') ? $this->compileColor($bgColor, $blnWriteToFile, $vars) . ' ' : '') . 'url("' . $glue . $row['bgimage'] . '") ' . $row['bgposition'] . ' ' . $row['bgrepeat'] . ';';
 			}
@@ -481,6 +482,7 @@ class StyleSheets extends Backend
 				}
 				elseif ($row['bgimage'] != '')
 				{
+					$row['bgimage'] = handleSpecialCharsForUrl($row['bgimage']);
 					$glue = (strncmp($row['bgimage'], 'data:', 5) !== 0 && strncmp($row['bgimage'], '/', 1) !== 0) ? $strGlue : '';
 					$return .= $lb . 'background-image:url("' . $glue . $row['bgimage'] . '");';
 				}
@@ -977,6 +979,7 @@ class StyleSheets extends Backend
 			}
 			elseif ($row['liststyleimage'] != '')
 			{
+				$row['liststyleimage'] = handleSpecialCharsForUrl($row['liststyleimage']);	
 				$glue = (strncmp($row['liststyleimage'], 'data:', 5) !== 0 && strncmp($row['liststyleimage'], '/', 1) !== 0) ? $strGlue : '';
 				$return .= $lb . 'list-style-image:url("' . $glue . $row['liststyleimage'] . '");';
 			}
@@ -1092,6 +1095,19 @@ class StyleSheets extends Backend
 		}
 
 		return $rgb;
+	}
+
+
+	/**
+	 * Decode special chars (encoded by Input::encodeSpecialChars()), urlencode some for using in url()
+	 * @param  string
+	 * @return string
+	 */
+	protected function handleSpecialCharsForUrl($strUrl)
+	{
+		$arrSearch  = array('&#35;', '&#60;', '&#62;', '&#40;', '&#41;', '&#92;', '&#61;');
+		$arrReplace = array('%23', '%3C', '%3E', '%28', '%29', '\\', '=');
+		return str_replace($arrSearch, $arrReplace, $strUrl);
 	}
 
 


### PR DESCRIPTION
Currently, the StyleSheet generator adds `../` to any url() path without a leading `/`. This also affects [`data:` URIs](https://developer.mozilla.org/en/data_URIs), which renders them unusable. Thus, I added some more checks. 

Additionally, I fixed character encoding for url() values: Previously, it was impossible to use e. g. `images.php?id=324e2c&width=32` as a background image, or a Widows-style path. This bug also affected some `data:` URIs. 
