### PR TITLE
Eventlist: Headline lose the dynamic component like year

### DIFF
--- a/system/modules/calendar/ModuleEventlist.php
+++ b/system/modules/calendar/ModuleEventlist.php
@@ -313,6 +313,7 @@ class ModuleEventlist extends Events
 			$strEvents = "\n" . '<div class="empty">' . $strEmpty . '</div>' . "\n";
 		}
 
+		$this->Template->headline = $this->headline;
 		$this->Template->events = $strEvents;
 
 		// Clear the $_GET array (see #2445)


### PR DESCRIPTION
there could be changes on headline in dynamic list (year/month/day) see line 118, without this commit they get lost
