### PR TITLE
Improve dca save performance

### DIFF
--- a/system/drivers/DC_Table.php
+++ b/system/drivers/DC_Table.php
@@ -1704,7 +1704,7 @@ class DC_Table extends DataContainer implements listable, editable
 					}
 
 					// Build row
-					$blnAjax ? $strAjax .= $this->row() : $return .= $this->row();
+					$blnAjax ? $strAjax .= $this->row($this->strPalette) : $return .= $this->row($this->strPalette);
 				}
 
 				$class = 'tl_box block';

--- a/system/modules/backend/DataContainer.php
+++ b/system/modules/backend/DataContainer.php
@@ -155,7 +155,7 @@ class DataContainer extends Backend
 	 * Render a row of a box and return it as HTML string
 	 * @return string
 	 */
-	protected function row()
+	protected function row($strPalette = false)
 	{
 		$arrData = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField];
 
@@ -259,7 +259,7 @@ class DataContainer extends Backend
 			// Calculate the current palette
 			$postPaletteFields = implode(',', $this->Input->post($key));
 			$postPaletteFields = array_unique(trimsplit('[,;]', $postPaletteFields));
-			$newPaletteFields = trimsplit('[,;]', $this->getPalette());
+			$newPaletteFields = trimsplit('[,;]', $strPalette ? $strPalette : $this->getPalette());
 
 			if ($this->Input->get('act') == 'editAll')
 			{


### PR DESCRIPTION
Die Methode DC_Table::edit() ruft DataContainer::row() für jede Box und jedes Feld auf.
Die Methode DataContainer::row() selbst ruft wiederum DC_Table::getPalette() bei jedem Aufruf auf. (die bereits in DC_Table::edit() einmal aufgerufen wurde).
Bei komplexen Paletten (viele **selector** Felder) steigt der Aufwand für jeden Speichervorgang exponentiell an. Bei 16 Feldern rennt mein Server bereits in die 30 Sekunden max_execution_time.
Der Patch übergibt die Palette an DataContainer::row() und verhindert so den erneuten Aufruf von DC_Table::getPalette() bei jedem Aufruf.

Alternativ könnte man auch das Ergebnis von DC_Table::getPalette() auch cachen, ich weiß aber nicht, ob das eventuell noch weitere Nebeneffekte hätte.
