### PR TITLE
Prevent intIndex to be increased by 2 on every next().

### DIFF
--- a/system/libraries/Database.php
+++ b/system/libraries/Database.php
@@ -1089,10 +1089,11 @@ abstract class Database_Result
 
 		if (!$this->arrCache[++$this->intIndex])
 		{
+			--$this->intIndex;
+
 			if (($arrRow = $this->fetchAssoc()) == false)
 			{
 				$this->blnDone = true;
-				--$this->intIndex;
 
 				return false;
 			}


### PR DESCRIPTION
Also next() AND fetchAssoc() increment intIndex by one, so intIndex get
increased by 2 on every next() call.

This makes prev() unusable, because its only decrease intIndex by 1!
