### PR TITLE
Fix case sensitive search with umlauts

### DIFF
--- a/system/drivers/DC_Table.php
+++ b/system/drivers/DC_Table.php
@@ -4194,7 +4194,7 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 		// Set search value from session
 		elseif (strlen($session['search'][$this->strTable]['value']))
 		{
-			$this->procedure[] = "CAST(".$session['search'][$this->strTable]['field']." AS CHAR) REGEXP ?";
+			$this->procedure[] = "LOWER(CAST(".$session['search'][$this->strTable]['field']." AS CHAR)) REGEXP LOWER(?)";
 			$this->values[] = $session['search'][$this->strTable]['value'];
 		}
 


### PR DESCRIPTION
In my current case, tl_member.lastname is written in uppercase, then the search fails with umlauts. This will allow to search for "köppel" and find "KÖPPEL".
