### PR TITLE
Detailed Browserversions

### DIFF
--- a/system/config/agents.php
+++ b/system/config/agents.php
@@ -57,17 +57,17 @@ $GLOBALS['TL_CONFIG']['os'] = array
  */
 $GLOBALS['TL_CONFIG']['browser'] = array
 (
-	'MSIE'       => array('browser'=>'ie',           'shorty'=>'ie', 'version'=>'/^.*?MSIE (\d+).*$/'),
-	'Firefox'    => array('browser'=>'firefox',      'shorty'=>'fx', 'version'=>'/^.*Firefox\/(\d+).*$/'),
-	'Chrome'     => array('browser'=>'chrome',       'shorty'=>'ch', 'version'=>'/^.*Chrome\/(\d+).*$/'),
-	'OmniWeb'    => array('browser'=>'omniweb',      'shorty'=>'ow', 'version'=>'/^.*Version\/(\d+).*$/'),
-	'Safari'     => array('browser'=>'safari',       'shorty'=>'sf', 'version'=>'/^.*Version\/(\d+).*$/'),
-	'Opera Mini' => array('browser'=>'opera-mini',   'shorty'=>'oi', 'version'=>'/^.*Opera Mini\/(\d+).*$/'),
-	'Opera Mobi' => array('browser'=>'opera-mobile', 'shorty'=>'om', 'version'=>'/^.*Version\/(\d+).*$/'),
-	'Opera'      => array('browser'=>'opera',        'shorty'=>'op', 'version'=>'/^.*Version\/(\d+).*$/'),
-	'IEMobile'   => array('browser'=>'ie-mobile',    'shorty'=>'im', 'version'=>'/^.*IEMobile (\d+).*$/'),
-	'Camino'     => array('browser'=>'camino',       'shorty'=>'ca', 'version'=>'/^.*Camino\/(\d+).*$/'),
-	'Konqueror'  => array('browser'=>'konqueror',    'shorty'=>'ko', 'version'=>'/^.*Konqueror\/(\d+).*$/')
+	'MSIE'       => array('browser'=>'ie',           'shorty'=>'ie', 'version'=>'/^.*?MSIE (\d+(\.\d+)*).*$/'),
+	'Firefox'    => array('browser'=>'firefox',      'shorty'=>'fx', 'version'=>'/^.*Firefox\/(\d+(\.\d+)*).*$/'),
+	'Chrome'     => array('browser'=>'chrome',       'shorty'=>'ch', 'version'=>'/^.*Chrome\/(\d+(\.\d+)*).*$/'),
+	'OmniWeb'    => array('browser'=>'omniweb',      'shorty'=>'ow', 'version'=>'/^.*Version\/(\d+(\.\d+)*).*$/'),
+	'Safari'     => array('browser'=>'safari',       'shorty'=>'sf', 'version'=>'/^.*Version\/(\d+(\.\d+)*).*$/'),
+	'Opera Mini' => array('browser'=>'opera-mini',   'shorty'=>'oi', 'version'=>'/^.*Opera Mini\/(\d+(\.\d+)*).*$/'),
+	'Opera Mobi' => array('browser'=>'opera-mobile', 'shorty'=>'om', 'version'=>'/^.*Version\/(\d+(\.\d+)*).*$/'),
+	'Opera'      => array('browser'=>'opera',        'shorty'=>'op', 'version'=>'/^.*Version\/(\d+(\.\d+)*).*$/'),
+	'IEMobile'   => array('browser'=>'ie-mobile',    'shorty'=>'im', 'version'=>'/^.*IEMobile (\d+(\.\d+)*).*$/'),
+	'Camino'     => array('browser'=>'camino',       'shorty'=>'ca', 'version'=>'/^.*Camino\/(\d+(\.\d+)*).*$/'),
+	'Konqueror'  => array('browser'=>'konqueror',    'shorty'=>'ko', 'version'=>'/^.*Konqueror\/(\d+(\.\d+)*).*$/')
 );
 
 ?>

--- a/system/libraries/Environment.php
+++ b/system/libraries/Environment.php
@@ -458,6 +458,9 @@ class Environment
 			}
 		}
 
+		$versions = explode('.', $version);
+		$version  = $versions[0];
+
 		$return->class = $os . ' ' . $browser;
 
 		// Add the version number if available
@@ -472,10 +475,11 @@ class Environment
 			$return->class .= ' mobile';
 		}
 
-		$return->browser = $browser;
-		$return->shorty  = $shorty;
-		$return->version = $version;
-		$return->mobile  = $mobile;
+		$return->browser  = $browser;
+		$return->shorty   = $shorty;
+		$return->version  = $version;
+		$return->versions = $versions;
+		$return->mobile   = $mobile;
 
 		return $return;
 	}


### PR DESCRIPTION
I added a versions property contains the complete numeric version of a browser splittet into an array. I need this because I have to check an explizit browser version (in my case only major and minor, but maybe i need more).

Please dont ask me, why git says **\ No newline at end of file** for the **system/config/agents.php** file, i don't change the last line and as far as i can see with a hex editor, there is no difference from my file to your file in the last line. But for the **system/libraries/Environment.php** there is no last line ending conflict ... i'm a bit confused about this O.o
Maybe there is a single CR (without NL), that i don't see in my version. Please have a look with a hex editor into your version of the agents.php file, for a single CR in the last line. I have this problem with another project and I was only able to see the single CR with a hex editor.
