### PR TITLE
Empty style set breaks CSS

### DIFF
--- a/system/modules/backend/StyleSheets.php
+++ b/system/modules/backend/StyleSheets.php
@@ -1030,7 +1030,12 @@ class StyleSheets extends Backend
 		if ($blnWriteToFile)
 		{
 			$nl = $blnDebug ? "\n" : '';
-			$return = substr($return, 0, -1);
+
+			if (substr($return, -1) !== '{')
+			{
+				$return = substr($return, 0, -1);
+			}
+
 			$return .= $nl . '}' . $nl;
 		}
 		else


### PR DESCRIPTION
If there is no definition in a style set, the opening tag is removed and therefore the CSS is broken.
