### PR TITLE
DC_Table listview mode3 sorting

### DIFF
--- a/system/drivers/DC_Table.php
+++ b/system/drivers/DC_Table.php
@@ -3750,26 +3750,14 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 		// Join parent table and sort by it
 		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 3)
 		{
-			$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
-
-			// select table fields
-			$select = $this->strTable . '.*';
-			// select parent label as pid
-			$select .= ',' . $this->ptable . '.' . $showFields[0] . ' AS pid';
-
-			$join        = ' INNER JOIN ' . $this->ptable . ' ON ' . $this->ptable . '.id=' . $this->strTable . '.pid';
-			$joinOrderBy = $this->ptable . '.' . $showFields[0];
-
 			$firstOrderBy = 'pid';
+			
+			$query = "SELECT " . $this->strTable . ".* FROM " . $this->strTable . " INNER JOIN " . $this->ptable . " ON " . $this->ptable . ".id=" . $this->strTable . ".pid";
 		}
 		else
 		{
-			$select      = '*';
-			$join        = '';
-			$joinOrderBy = '';
+			$query = "SELECT * FROM " . $this->strTable;
 		}
-
-		$query = "SELECT " . $select . " FROM " . $this->strTable . $join;
 
 		if (!empty($this->procedure))
 		{
@@ -3809,9 +3797,11 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 				}
 			}
 
-			if ($join)
+			if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 3)
 			{
-				$query .= " ORDER BY " . $joinOrderBy . ', ' . $this->strTable . '.' . implode(', ' . $this->strTable . '.', $orderBy);
+				$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
+				
+				$query .= " ORDER BY " . $this->ptable . "." . $showFields[0] . ", " . $this->strTable . "." . implode(', ' . $this->strTable . '.', $orderBy);
 			}
 			else
 			{

--- a/system/drivers/DC_Table.php
+++ b/system/drivers/DC_Table.php
@@ -3742,7 +3742,7 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 
 			if (!$this->User->isAdmin)
 			{
-				$this->procedure[] = $this->strTable . '.pid=?';
+				$this->procedure[] = 'pid=?';
 				$this->values[] = $this->User->id;
 			}
 		}

--- a/system/drivers/DC_Table.php
+++ b/system/drivers/DC_Table.php
@@ -3809,9 +3809,12 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 				}
 			}
 
-			if ($join) {
+			if ($join)
+			{
 				$query .= " ORDER BY " . $joinOrderBy . ', ' . $this->strTable . '.' . implode(', ' . $this->strTable . '.', $orderBy);
-			} else {
+			}
+			else
+			{
 				$query .= " ORDER BY " . implode(', ', $orderBy);
 			}
 		}

--- a/system/drivers/DC_Table.php
+++ b/system/drivers/DC_Table.php
@@ -3793,6 +3793,11 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 				$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
 				
 				$query .= " ORDER BY (SELECT " . $showFields[0] . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy);
+				
+				// Set the foreignKey so that the label is translated (also for backwards compatibility)
+				if ($GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'] == '')
+				{
+					$GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'] = $this->ptable . '.' . $showFields[0];
 			}
 			else
 			{

--- a/system/drivers/DC_Table.php
+++ b/system/drivers/DC_Table.php
@@ -3747,7 +3747,7 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 			}
 		}
 
-			$query = "SELECT * FROM " . $this->strTable;
+		$query = "SELECT * FROM " . $this->strTable;
 
 		if (!empty($this->procedure))
 		{
@@ -3791,13 +3791,18 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 			{
 				$firstOrderBy = 'pid';
 				$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
-				
+
 				$query .= " ORDER BY (SELECT " . $showFields[0] . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy);
 				
 				// Set the foreignKey so that the label is translated (also for backwards compatibility)
 				if ($GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'] == '')
 				{
 					$GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'] = $this->ptable . '.' . $showFields[0];
+				}
+				
+				// Remove the parent field from label fields
+				array_shift($showFields);
+				$GLOBALS['TL_DCA'][$table]['list']['label']['fields'] = $showFields;
 			}
 			else
 			{

--- a/system/drivers/DC_Table.php
+++ b/system/drivers/DC_Table.php
@@ -3748,7 +3748,7 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 		}
 
 		// Join parent table and sort by it
-		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 3 && $this->Database->fieldExists('pid', $this->strTable))
+		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 3)
 		{
 			$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
 

--- a/system/drivers/DC_Table.php
+++ b/system/drivers/DC_Table.php
@@ -3747,17 +3747,7 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 			}
 		}
 
-		// Join parent table and sort by it
-		if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 3)
-		{
-			$firstOrderBy = 'pid';
-			
-			$query = "SELECT " . $this->strTable . ".* FROM " . $this->strTable . " INNER JOIN " . $this->ptable . " ON " . $this->ptable . ".id=" . $this->strTable . ".pid";
-		}
-		else
-		{
 			$query = "SELECT * FROM " . $this->strTable;
-		}
 
 		if (!empty($this->procedure))
 		{
@@ -3799,9 +3789,10 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 
 			if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 3)
 			{
+				$firstOrderBy = 'pid';
 				$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
 				
-				$query .= " ORDER BY " . $this->ptable . "." . $showFields[0] . ", " . $this->strTable . "." . implode(', ' . $this->strTable . '.', $orderBy);
+				$query .= " ORDER BY (SELECT " . $showFields[0] . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy);
 			}
 			else
 			{


### PR DESCRIPTION
The sorting of the children table get crashed by array_multisort. In my scenario the child table is sorted by pid and id after the array_multisort was applied. As far as i understand array_multisort, we are unable to forecast the sorting of elements with the same group! (or we have to add every child table sorting field to the sort array)
I rewrite the sorting to use INNER JOIN, the sorting is now done by the database and should improve the performance a little bit because there is only 1 Query and before there are 1 + n queries for n rows.
