### PR TITLE
Remove @ before include to not suppress errors.

### DIFF
--- a/system/functions.php
+++ b/system/functions.php
@@ -49,7 +49,7 @@ function __autoload($strClassName)
 	// Try to load the class name from the session cache
 	if (!$GLOBALS['TL_CONFIG']['debugMode'] && isset($objCache->$strClassName))
 	{
-		if (@include_once(TL_ROOT . '/' . $objCache->$strClassName))
+		if (include_once(TL_ROOT . '/' . $objCache->$strClassName))
 		{
 			return; // The class could be loaded
 		}


### PR DESCRIPTION
When developing class files and you make non-syntax errors like overwrite a class property with a lower visibility than in the parent class, a Fatal error is triggered but never shown because it is suppressed by the @ modifier.

This only comes in conjunction to the file cache, if the file is not in the cache the errors are not suppressed.

Short code example:

``` php
<?php

class A {
    protected $foo;
}
class B extends A {
    private $foo;
}
```
