### PR TITLE
kleine Bilder im CSS Editor automatisch als base64 encoden

### DIFF
--- a/system/libraries/Database.php
+++ b/system/libraries/Database.php
@@ -767,20 +767,21 @@ abstract class Database_Statement
 			return;
 		}
 
-		$arrData[] = $this->strQuery;
+		$arrData['query'] = $this->strQuery;
+		$arrData['rows_num'] = $this->affectedRows;
 
 		if ($objResult === null || strncmp(strtoupper($this->strQuery), 'SELECT', 6) !== 0)
 		{
-			$arrData[] = sprintf('%d rows affected', $this->affectedRows);
+			$arrData['rows'] = sprintf('%d rows affected', $this->affectedRows);
 			$GLOBALS['TL_DEBUG'][] = $arrData;
 		}
 		else
 		{
-			$arrData[] = sprintf('%s rows returned', $objResult->numRows);
+			$arrData['rows'] = sprintf('%s rows returned', $objResult->numRows);
 
 			if (($arrExplain = $this->explain()) != false)
 			{
-				$arrData[] = $arrExplain;
+				$arrData['explain'] = $arrExplain;
 			}
 
 			$GLOBALS['TL_DEBUG'][] = $arrData;

--- a/system/libraries/Template.php
+++ b/system/libraries/Template.php
@@ -290,8 +290,22 @@ abstract class Template extends Controller
 		// Debug information
 		if ($GLOBALS['TL_CONFIG']['debugMode'])
 		{
+			$intQuerys = 0;
+			$intRows = 0;
+
+			// calc some debug stats
+			foreach ($GLOBALS['TL_DEBUG'] as &$v)
+			{
+				$intQuerys++;
+				$intRows += $v['rows_num'];
+
+				unset($v['rows_num']);
+			}
+
 			echo "\n\n" . '<pre id="debug" style="width:80%;overflow:auto;margin:24px auto;padding:9px;background:#fff">' . "\n";
 			echo "<strong>Debug information</strong>\n\n";
+			echo '<span>' . $intQuerys . " querys executed.</span>\n";
+			echo '<span>' . $intRows . " rows returned.</span>\n\n";
 			print_r($GLOBALS['TL_DEBUG']);
 			echo '</pre>';
 		}

--- a/system/modules/backend/config/database.sql
+++ b/system/modules/backend/config/database.sql
@@ -587,6 +587,8 @@ CREATE TABLE `tl_style_sheet` (
   `tstamp` int(10) unsigned NOT NULL default '0',
   `name` varchar(64) NOT NULL default '',
   `cc` varchar(32) NOT NULL default '',
+  `embeddedImages` char(1) NOT NULL default '',
+  `embeddedImagesSize` int(20) NOT NULL default '500',
   `media` varchar(255) NOT NULL default '',
   `mediaQuery` varchar(255) NOT NULL default '',
   `vars` text NULL,

--- a/system/modules/backend/dca/tl_style_sheet.php
+++ b/system/modules/backend/dca/tl_style_sheet.php
@@ -136,7 +136,14 @@ $GLOBALS['TL_DCA']['tl_style_sheet'] = array
 	// Palettes
 	'palettes' => array
 	(
-		'default'                     => '{title_legend},name,cc;{media_legend},media,mediaQuery;{vars_legend},vars'
+		'__selector__'                => array('embeddedImages'),
+		'default'                     => '{title_legend},name,cc;{optimize_legend},embeddedImages;{media_legend},media,mediaQuery;{vars_legend},vars'
+	),
+
+	// Sub Palettes
+	'subpalettes' => array
+	(
+		'embeddedImages'              => 'embeddedImagesSize',
 	),
 
 	// Fields
@@ -162,6 +169,20 @@ $GLOBALS['TL_DCA']['tl_style_sheet'] = array
 			(
 				array('tl_style_sheet', 'sanitizeCc')
 			)
+		),
+		'embeddedImages' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_style_sheet']['embeddedImages'],
+			'inputType'               => 'checkbox',
+			'exclude'                 => true,
+			'eval'                    => array('tl_class'=>'w50 m12', 'submitOnChange'=>true)
+		),
+		'embeddedImagesSize' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_style_sheet']['embeddedImagesSize'],
+			'inputType'               => 'text',
+			'exclude'                 => true,
+			'eval'                    => array('tl_class'=>'clr w50', 'rgxp'=>'digit', 'maxlength'=>20)
 		),
 		'media' => array
 		(

--- a/system/modules/backend/languages/de/tl_style_sheet.php
+++ b/system/modules/backend/languages/de/tl_style_sheet.php
@@ -32,21 +32,24 @@
 /**
  * Fields
  */
-$GLOBALS['TL_LANG']['tl_style_sheet']['name']       = array('Name', 'Bitte geben Sie den Namen des Stylesheets ein.');
-$GLOBALS['TL_LANG']['tl_style_sheet']['cc']         = array('Conditional Comment', 'Conditional Comments ermöglichen die Erstellung Internet Explorer-spezifischer Stylesheets (z.B. <em>if lt IE 9</em>).');
-$GLOBALS['TL_LANG']['tl_style_sheet']['media']      = array('Medientypen', 'Hier können Sie die Medientypen auswählen, für die das Stylesheet gültig ist.');
-$GLOBALS['TL_LANG']['tl_style_sheet']['mediaQuery'] = array('Media-Query', 'Hier können Sie den Medientyp mit Hilfe eines Media-Querys wie z.B. <em>screen and (min-width: 800px)</em> festlegen. Die oben ausgewählten Medientypen werden dadurch überschrieben.');
-$GLOBALS['TL_LANG']['tl_style_sheet']['vars']       = array('Globale Variablen', 'Hier können Sie globale Variablen für das Stylesheet definieren (z.B. <em>$rot</em> -> <em>c00</em> oder <em>$abstand</em> -> <em>12px</em>).');
-$GLOBALS['TL_LANG']['tl_style_sheet']['source']     = array('Quelldateien', 'Bitte wählen Sie eine oder mehrere Dateien aus der Dateiübersicht.');
-$GLOBALS['TL_LANG']['tl_style_sheet']['tstamp']     = array('Änderungsdatum', 'Datum und Uhrzeit der letzten Änderung');
+$GLOBALS['TL_LANG']['tl_style_sheet']['name']               = array('Name', 'Bitte geben Sie den Namen des Stylesheets ein.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['cc']                 = array('Conditional Comment', 'Conditional Comments ermöglichen die Erstellung Internet Explorer-spezifischer Stylesheets (z.B. <em>if lt IE 9</em>).');
+$GLOBALS['TL_LANG']['tl_style_sheet']['embeddedImages']     = array('Bilder einbetten', 'Aktivieren Sie diese Option um Bilder automatisch base64 kodiert einzubinden. Dies minimiert die Anzahl der Requests beim Seitenaufruf und sorgt für ein besseres PageSpeed Ranking.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['embeddedImagesSize'] = array('Maximale Bildgröße', 'Bitte geben Sie die maximale Bildgröße in kb an, ab welcher ein Bild NICHT mehr base64 kodiert werden soll.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['media']              = array('Medientypen', 'Hier können Sie die Medientypen auswählen, für die das Stylesheet gültig ist.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['mediaQuery']         = array('Media-Query', 'Hier können Sie den Medientyp mit Hilfe eines Media-Querys wie z.B. <em>screen and (min-width: 800px)</em> festlegen. Die oben ausgewählten Medientypen werden dadurch überschrieben.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['vars']               = array('Globale Variablen', 'Hier können Sie globale Variablen für das Stylesheet definieren (z.B. <em>$rot</em> -> <em>c00</em> oder <em>$abstand</em> -> <em>12px</em>).');
+$GLOBALS['TL_LANG']['tl_style_sheet']['source']             = array('Quelldateien', 'Bitte wählen Sie eine oder mehrere Dateien aus der Dateiübersicht.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['tstamp']             = array('Änderungsdatum', 'Datum und Uhrzeit der letzten Änderung');
 
 
 /**
  * Legends
  */
-$GLOBALS['TL_LANG']['tl_style_sheet']['title_legend'] = 'Name';
-$GLOBALS['TL_LANG']['tl_style_sheet']['media_legend'] = 'Medieneinstellungen';
-$GLOBALS['TL_LANG']['tl_style_sheet']['vars_legend']  = 'Globale Variablen';
+$GLOBALS['TL_LANG']['tl_style_sheet']['title_legend']    = 'Name';
+$GLOBALS['TL_LANG']['tl_style_sheet']['optimize_legend'] = 'Optimierungen';
+$GLOBALS['TL_LANG']['tl_style_sheet']['media_legend']    = 'Medieneinstellungen';
+$GLOBALS['TL_LANG']['tl_style_sheet']['vars_legend']     = 'Globale Variablen';
 
 
 /**

--- a/system/modules/backend/languages/en/tl_style_sheet.php
+++ b/system/modules/backend/languages/en/tl_style_sheet.php
@@ -32,21 +32,24 @@
 /**
  * Fields
  */
-$GLOBALS['TL_LANG']['tl_style_sheet']['name']       = array('Name', 'Please enter the style sheet name.');
-$GLOBALS['TL_LANG']['tl_style_sheet']['cc']         = array('Conditional comment', 'Conditional comments allow you to create Internet Explorer specific style sheets (e.g. <em>if lt IE 9</em>).');
-$GLOBALS['TL_LANG']['tl_style_sheet']['media']      = array('Media types', 'Here you can choose the media types the style sheet applies to.');
-$GLOBALS['TL_LANG']['tl_style_sheet']['mediaQuery'] = array('Media query', 'Here you can define the media type using a media query like <em>screen and (min-width: 800px)</em>. The media types defined above will then be overwritten.');
-$GLOBALS['TL_LANG']['tl_style_sheet']['vars']       = array('Global variables', 'Here you can define global variables for the style sheet (e.g. <em>$red</em> -> <em>c00</em> or <em>$margin</em> -> <em>12px</em>).');
-$GLOBALS['TL_LANG']['tl_style_sheet']['source']     = array('Source files', 'Please choose one or more files from the files directory.');
-$GLOBALS['TL_LANG']['tl_style_sheet']['tstamp']     = array('Revision date', 'Date and time of the latest revision');
+$GLOBALS['TL_LANG']['tl_style_sheet']['name']               = array('Name', 'Please enter the style sheet name.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['cc']                 = array('Conditional comment', 'Conditional comments allow you to create Internet Explorer specific style sheets (e.g. <em>if lt IE 9</em>).');
+$GLOBALS['TL_LANG']['tl_style_sheet']['embeddedImages']     = array('embedded images', 'Select this option to automaticly embedd images base64 encodet. This helps minimizing your http requests and improve your page speed ranking.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['embeddedImagesSize'] = array('embedded size', 'Please insert a max image size with sould not be base64 encodet.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['media']              = array('Media types', 'Here you can choose the media types the style sheet applies to.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['mediaQuery']         = array('Media query', 'Here you can define the media type using a media query like <em>screen and (min-width: 800px)</em>. The media types defined above will then be overwritten.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['vars']               = array('Global variables', 'Here you can define global variables for the style sheet (e.g. <em>$red</em> -> <em>c00</em> or <em>$margin</em> -> <em>12px</em>).');
+$GLOBALS['TL_LANG']['tl_style_sheet']['source']             = array('Source files', 'Please choose one or more files from the files directory.');
+$GLOBALS['TL_LANG']['tl_style_sheet']['tstamp']             = array('Revision date', 'Date and time of the latest revision');
 
 
 /**
  * Legends
  */
-$GLOBALS['TL_LANG']['tl_style_sheet']['title_legend'] = 'Name';
-$GLOBALS['TL_LANG']['tl_style_sheet']['media_legend'] = 'Media settings';
-$GLOBALS['TL_LANG']['tl_style_sheet']['vars_legend']  = 'Global variables';
+$GLOBALS['TL_LANG']['tl_style_sheet']['title_legend']    = 'Name';
+$GLOBALS['TL_LANG']['tl_style_sheet']['optimize_legend'] = 'optimize settings';
+$GLOBALS['TL_LANG']['tl_style_sheet']['media_legend']    = 'Media settings';
+$GLOBALS['TL_LANG']['tl_style_sheet']['vars_legend']     = 'Global variables';
 
 
 /**


### PR DESCRIPTION
Hi Leo,
mit dem angehängten Pull werden Bilder aus dem internen CSS Editor ab einer gewissen größe automatisch als base64 encodet eingefügt. Damit erspart man sich eine ganze Menge an requests. Ich habe das schon bei mir laufen und es ist echt super.

Ich würde dich bitten das noch in die 2.11 aufzunehmen, da ich das dringend brauchen würde. Es wird hiermit keine Kompatibilität gebrochen.

Danke und viele Grüße
Leo
