### PR TITLE
Improvement of the alias element

### DIFF
--- a/system/modules/frontend/ContentAlias.php
+++ b/system/modules/frontend/ContentAlias.php
@@ -68,8 +68,22 @@ class ContentAlias extends ContentElement
 		$objElement = new $strClass($objElement);
 
 		// Overwrite spacing and CSS ID
-		$objElement->space = $this->space;
-		$objElement->cssID = $this->cssID;
+		if($this->space != '')
+		{
+			$arrSpace = $objElement->space;
+			foreach($this->space as $k=>$v)
+			{
+				if($v != '') $arrSpace[$k] = $v;
+			}
+			$objElement->space = $arrSpace;
+		}
+		
+		$arrCssID = $objElement->cssID;
+		foreach($this->cssID as $k=>$v)
+		{
+			if($v != '') $arrCssID[$k] = $v;
+		}
+		$objElement->cssID = $arrCssID;
 
 		return $objElement->generate();
 	}


### PR DESCRIPTION
First of all, it's my first request, so I hope everything works.

The problem:
If you use the alias of an content element, the settings for spacing and css ID and class are not taken from the aliased element.

The solution:
instead of just overwriting the two values with the maybe empty values from the new element, it is checked, if the new element has values.

The same works for the ContentModule.php.
