### PR TITLE
Debug color

### DIFF
--- a/system/libraries/Template.php
+++ b/system/libraries/Template.php
@@ -290,7 +290,7 @@ abstract class Template extends Controller
 		// Debug information
 		if ($GLOBALS['TL_CONFIG']['debugMode'])
 		{
-			echo "\n\n" . '<pre id="debug" style="width:80%;overflow:auto;margin:24px auto;padding:9px;background:#fff">' . "\n";
+			echo "\n\n" . '<pre id="debug" style="width:80%;overflow:auto;margin:24px auto;padding:9px;background:#fff;color:#000">' . "\n";
 			echo "<strong>Debug information</strong>\n\n";
 			print_r($GLOBALS['TL_DEBUG']);
 			echo '</pre>';


### PR DESCRIPTION
If the page has a different color (in my case, white on body), the debug output might not be visible. Because we're already setting background color and everything else, we should also define a font color.
