### PR TITLE
Bug generate subpalettes

### DIFF
--- a/system/drivers/DC_Table.php
+++ b/system/drivers/DC_Table.php
@@ -2753,7 +2753,7 @@ window.addEvent(\'domready\', function() {
 					}
 				}
 
-				$names = $this->combiner($sValues);
+				$names = $this->combiner(array_values($sValues));
 			}
 			else
 			{


### PR DESCRIPTION
Unsetting selectors that trigger subplattes getting unset which generates holes in the array-key-numbering. But DataContainer::combiner() uses a for-loop.
