### PR TITLE
Data container combine

### DIFF
--- a/system/modules/backend/DataContainer.php
+++ b/system/modules/backend/DataContainer.php
@@ -470,14 +470,14 @@ class DataContainer extends Backend
 	{
 		$return = array('');
 
-		for ($i=0; $i<count($names); $i++)
+		foreach ($names as $name)
 		{
 			$buffer = array();
 
 			foreach ($return as $k=>$v)
 			{
-				$buffer[] = ($k%2 == 0) ? $v : $v.$names[$i];
-				$buffer[] = ($k%2 == 0) ? $v.$names[$i] : $v;
+				$buffer[] = ($k%2 == 0) ? $v : $v.$name;
+				$buffer[] = ($k%2 == 0) ? $v.$name : $v;
 			}
 
 			$return = $buffer;


### PR DESCRIPTION
There is a critical error in the DataContainer::combiner() method.
To improve the performance of this method, you reduce the variable $sValues in DC_Table::2752, but in DataContainer::combiner()::473 you walk over this array by a natural incremented index.

I have the following problem, after DC_Table::2752 the variable $sValues may looks like:

``` php
array(
    0 => 'trigger1',
    3 => 'trigger2',
   21 => 'trigger3'
)
```

The indexes of the array is not natural, but the DataContainer::combiner() method require this.
I changed the DataContainer::combiner() to use foreach, instead of for($i.., $i++)
