### PR TITLE
getPageDetails called for root page fail

### DIFF
--- a/system/libraries/Controller.php
+++ b/system/libraries/Controller.php
@@ -696,7 +696,7 @@ abstract class Controller extends System
 			$objPage->rootIsFallback = ($objParentPage->fallback != '');
 		}
 		// No root page found
-		elseif (TL_MODE == 'FE')
+		elseif ($objPage->type != 'root' && TL_MODE == 'FE')
 		{
 			header('HTTP/1.1 404 Not Found');
 			$this->log('Page ID "'. $objPage->id .'" does not belong to a root page', 'Controller getPageDetails()', TL_ERROR);


### PR DESCRIPTION
Calling getPageDetails for root page, will end in a 404 Not Found "No root page found" error!
