### PR TITLE
Warnings und Errors im Theme editor

### DIFF
--- a/system/library/Contao/Controller.php
+++ b/system/library/Contao/Controller.php
@@ -116,7 +116,15 @@ abstract class Controller extends \System
 
 			if ($objTheme !== null && $objTheme->templates != '')
 			{
-				$strTplFolder = $objTheme->templates;
+				$strTplFolder = '';
+				if ((int) $objTheme->templates > 0) {
+					$result = $this->Database->prepare('SELECT `path` FROM `tl_files` WHERE `id` = ?')
+											 ->execute($objTheme->templates)->fetchAssoc();
+					$strTplFolder = $result['path'];
+				}
+				if (!$strTplFolder) {
+					$strTplFolder = $objTheme->templates;
+				}
 			}
 		}
 


### PR DESCRIPTION
Commit Msg auf DE:
Wenn beim erstellen eines Themes ein Templates Ordner zugewiesen wird, wird die ID zu einem tl_files record gespeichert, der controller nimmt diese ID als Pfadname und PHP wirft einen haufen warnings wie
"Cannot open directory /home/trenker/www/contao-test/1"
Dieser Patch tested auf einen integer und versucht das entsprechende record.
