### PR TITLE
Fixed some little issues in the front end preview

### DIFF
--- a/system/modules/backend/templates/be_switch.html5
+++ b/system/modules/backend/templates/be_switch.html5
@@ -6,7 +6,7 @@
 <base href="<?php echo $this->base; ?>">
 <link rel="stylesheet" href="<?php
   $objCombiner = new Combiner();
-  $objCombiner->add('plugins/stylect/css/stylect.css');
+  $objCombiner->add('plugins/mootools/stylect/css/stylect.css');
   $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
   $objCombiner->add('system/themes/'. $this->theme .'/switch.css');
   echo $objCombiner->getCombinedFile();
@@ -17,7 +17,7 @@
   $objCombiner = new Combiner();
   $objCombiner->add('plugins/mootools/core/' . MOOTOOLS . '/mootools-core.js', MOOTOOLS);
   $objCombiner->add('plugins/mootools/more/' . MOOTOOLS . '/mootools-more.js', MOOTOOLS);
-  $objCombiner->add('plugins/stylect/js/stylect.js');
+  $objCombiner->add('plugins/mootools/stylect/js/stylect.js');
   $objCombiner->add('plugins/mootools/request/Request.Contao.js');
   $objCombiner->add('system/modules/backend/html/contao.js');
   echo $objCombiner->getCombinedFile();


### PR DESCRIPTION
I got the following error message after switching to the front end preview:

```
Fatal error: Uncaught exception Exception with message File plugins/stylect/css/stylect.css does not exist thrown in contao/system/library/Contao/Combiner.php on line 116

#0 system/modules/backend/templates/be_switch.html5(9): Contao/Combiner->add('plugins/stylect...')
#1 system/library/Contao/Template.php(255): include('htdoc...')
#2 system/modules/backend/BackendTemplate.php(54): Contao/Template->parse()
#3 system/modules/backend/BackendTemplate.php(157): Contao/BackendTemplate->parse()
#4 contao/switch.php(178): Contao/BackendTemplate->output()
#5 contao/switch.php(187): PreviewSwitch->run()
#6 {main}
```

Attached the pull request with commit 74edc71bd6ef28756a4e431c6dbd95a6a813136c

Further, I changed the _"Close"_ icon `close.gif` ![close icon](https://github.com/contao/core/raw/3.0.x/system/themes/default/images/close.gif) a little bit so that the background is transparent now. You can download the modified icon [here](http://www.xup.in/dl,20004972/close.zip).
