### PR TITLE
The datepicker is not shown anymore for the member 'date of birth' field

### DIFF
--- a/system/modules/backend/dca/tl_member.php
+++ b/system/modules/backend/dca/tl_member.php
@@ -172,7 +172,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_member']['dateOfBirth'],
 			'exclude'                 => true,
 			'inputType'               => 'text',
-			'eval'                    => array('rgxp'=>'date', 'datepcker'=>true, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'personal', 'tl_class'=>'w50 wizard'),
+			'eval'                    => array('rgxp'=>'date', 'datepicker'=>true, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'personal', 'tl_class'=>'w50 wizard'),
 			'sql'                     => "varchar(11) NOT NULL default ''"
 		),
 		'gender' => array


### PR DESCRIPTION
The datepicker is not shown anymore for the member _"date of birth"_ field.

I fixed this in commit 1def752dcbd8a14c5f46d8d2b18c3ca4fc1f4ac1
