### PR TITLE
Regex validation

### DIFF
--- a/contao/errors.php
+++ b/contao/errors.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ * Copyright (C) 2005-2012 Leo Feyer
+ *
+ * Formerly known as TYPOlight Open Source CMS.
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program. If not, please visit the Free
+ * Software Foundation website at <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5.3
+ * @copyright  Leo Feyer 2005-2012
+ * @author     Leo Feyer <http://www.contao.org>
+ * @package    Backend
+ * @license    LGPL
+ */
+
+
+/**
+ * Initialize the system
+ */
+define('TL_MODE', 'BE');
+require_once '../system/initialize.php';
+
+
+/**
+ * Class Errors
+ *
+ * Back end error display.
+ * @copyright  Leo Feyer 2005-2012
+ * @author     Leo Feyer <http://www.contao.org>
+ * @author     Yanick Witschi <yanick.witschi@certo-net.ch>
+ * @package    Controller
+ */
+class Errors extends Backend
+{
+
+	/**
+	 * Initialize the controller
+	 * 
+	 * 1. Import the user
+	 * 2. Call the parent constructor
+	 * 3. Authenticate the user
+	 * 4. Load the language files
+	 * DO NOT CHANGE THIS ORDER!
+	 */
+	public function __construct()
+	{
+		$this->import('BackendUser', 'User');
+		parent::__construct();
+
+		$this->User->authenticate();
+		
+		$this->loadLanguageFile('default');
+	}
+
+
+	/**
+	 * Run the controller and parse the template
+	 * @return void
+	 */
+	public function run()
+	{
+		$this->Template = new BackendTemplate('be_errors');
+		$this->Template->theme = $this->getTheme();
+		$this->Template->base = $this->Environment->base;
+		$this->Template->language = $GLOBALS['TL_LANGUAGE'];
+		$this->Template->title = $GLOBALS['TL_CONFIG']['websiteTitle'];
+		$this->Template->charset = $GLOBALS['TL_CONFIG']['characterSet'];
+		
+		$this->import('Session');
+		$arrData = $this->Session->get('backend_errors');
+		$arrData = $arrData[$this->Input->get('hash')];
+		
+		$this->Template->headline = specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['errorOverview'], $arrData['field']));
+		$this->Template->errors = $arrData['errors'];
+
+		$this->Template->output();
+	}
+}
+
+
+/**
+ * Instantiate the controller
+ */
+$objErrors = new Errors();
+$objErrors->run();

--- a/system/library/Contao/ClassLoader.php
+++ b/system/library/Contao/ClassLoader.php
@@ -86,6 +86,7 @@ class ClassLoader
 		'Contao\\System'       => 'system/library/Contao/System.php',
 		'Contao\\Template'     => 'system/library/Contao/Template.php',
 		'Contao\\User'         => 'system/library/Contao/User.php',
+		'Contao\\Validator'    => 'system/library/Contao/Validator.php',
 		'Contao\\Widget'       => 'system/library/Contao/Widget.php',
 		'Contao\\ZipReader'    => 'system/library/Contao/ZipReader.php',
 		'Contao\\ZipWriter'    => 'system/library/Contao/ZipWriter.php',

--- a/system/library/Contao/System.php
+++ b/system/library/Contao/System.php
@@ -933,7 +933,8 @@ abstract class System
 	 */
 	protected function isValidEmailAddress($strEmail)
 	{
-		return preg_match('/^(\w+[!#\$%&\'\*\+\-\/=\?^_`\.\{\|\}~]*)+(?<!\.)@\w+([_\.-]*\w+)*\.[a-z]{2,6}$/i', $strEmail);
+		// backwards compatibility
+		return Validator::isEmail($strEmail);
 	}
 
 

--- a/system/library/Contao/Validator.php
+++ b/system/library/Contao/Validator.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ * Copyright (C) 2005-2012 Leo Feyer
+ *
+ * Formerly known as TYPOlight Open Source CMS.
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program. If not, please visit the Free
+ * Software Foundation website at <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5.3
+ * @copyright  Leo Feyer 2005-2012
+ * @author     Leo Feyer <http://www.contao.org>
+ * @package    System
+ * @license    LGPL
+ */
+
+
+/**
+ * Run in a custom namespace, so the class can be replaced
+ */
+namespace Contao;
+
+
+/**
+ * Class Validator
+ *
+ * Provide methods to validate values
+ * @copyright  Leo Feyer 2005-2012
+ * @author     Leo Feyer <http://www.contao.org>
+ * @author     Yanick Witschi <yanick.witschi@certo-net.ch>
+ * @package    Library
+ */
+class Validator extends \System
+{
+	
+	/**
+	 * Validates for digits
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isDigits($varValue)
+	{
+		return preg_match('/^[\d \.-]*$/', $varValue);
+	}
+
+
+	/**
+	 * Validates for alphabetical values
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isAlpha($varValue)
+	{
+		if (function_exists('mb_eregi'))
+		{
+			return mb_eregi('^[[:alpha:] \.-]*$', $varValue);
+		}
+		else
+		{
+			return preg_match('/^[\pL \.-]*$/u', $varValue);
+		}
+	}
+
+
+	/**
+	 * Validates for alphanumerical values
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isAlnum($varValue)
+	{
+		if (function_exists('mb_eregi'))
+		{
+			return mb_eregi('^[[:alnum:] \._-]*$', $varValue);
+		}
+		else
+		{
+			return preg_match('/^[\pN\pL \._-]*$/u', $varValue);
+		}
+	}
+
+
+	/**
+	 * Validates for characters that are usually encoded by class Input [=<>()#/])
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isExtnd($varValue)
+	{
+		return preg_match('/[#\(\)\/<=>]/', html_entity_decode($varValue));
+	}
+
+
+	/**
+	 * Validates for a date format
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isDate($varValue)
+	{
+		$objDate = new \Date();
+		return preg_match('~^'. $objDate->getRegexp($GLOBALS['TL_CONFIG']['dateFormat']) .'$~i', $varValue);
+	}
+
+
+	/**
+	 * Validates for a time format
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isTime($varValue)
+	{
+		$objDate = new \Date();
+		return preg_match('~^'. $objDate->getRegexp($GLOBALS['TL_CONFIG']['timeFormat']) .'$~i', $varValue);
+	}
+
+
+	/**
+	 * Validates for a datetime format
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isDatim($varValue)
+	{
+		$objDate = new \Date();
+		return preg_match('~^'. $objDate->getRegexp($GLOBALS['TL_CONFIG']['datimFormat']) .'$~i', $varValue);
+	}
+
+
+	/**
+	 * Validates for an email
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isEmail($varValue)
+	{
+		$varValue = $this->idnaEncodeEmail($varValue);
+		return preg_match('/^(\w+[!#\$%&\'\*\+\-\/=\?^_`\.\{\|\}~]*)+(?<!\.)@\w+([_\.-]*\w+)*\.[a-z]{2,6}$/i', $varValue);
+	}
+
+
+	/**
+	 * Validates for an url
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isUrl($varValue)
+	{
+		$varValue = $this->idnaEncodeUrl($varValue);
+		return preg_match('/^[a-zA-Z0-9\.\+\/\?#%:,;\{\}\(\)\[\]@&=~_-]*$/', $varValue);
+	}
+
+
+	/**
+	 * Validates for an alias
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isAlias($varValue)
+	{
+		return preg_match('/^[\pN\pL\._-]*$/', $varValue);
+	}
+
+
+	/**
+	 * Validates for a folder alias
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isFolderAlias($varValue)
+	{
+		return preg_match('/^[\pN\pL\/\._-]*$/', $varValue);
+	}
+
+
+	/**
+	 * Validates for a phone number
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isPhone($varValue)
+	{
+		return preg_match('/^(\+|\()?(\d+[ \+\(\)\/-]*)+$/', html_entity_decode($varValue));
+	}
+
+
+	/**
+	 * Validates for a per cent value
+	 * @param mixed input
+	 * @return boolean
+	 */
+	public static function isPercent($varValue)
+	{
+		return (is_numeric($varValue) && $varValue >= 0 && $varValue <= 100);
+	}
+}

--- a/system/library/Contao/Widget.php
+++ b/system/library/Contao/Widget.php
@@ -397,6 +397,48 @@ abstract class Widget extends Controller
 
 
 	/**
+	 * Return all errors as HTML string
+	 * @return string
+	 */
+	public function getErrorsAsHTML()
+	{
+		$count = count($this->arrErrors);
+		if (!$count)
+		{
+			return '';
+		}
+		
+		if ($count == 1)
+		{
+			return $this->getErrorAsHTML();
+		}
+		
+		// return a nice div for the front end
+		if (TL_MODE == 'FE')
+		{
+			return '<div class="errors"><p class="error">' . implode('</p><p class="error">', $this->arrErrors) . '</p></div>';
+		}
+		
+		// otherwise we show the back end specific error page (javascript fallback is there too)
+		$strHash = sha1(time() . uniqid());
+		$arrErrors = array();
+		$arrErrors[$strHash] = array
+		(
+			'field'  => $this->strLabel,
+			'errors' => $this->arrErrors	
+		);
+		
+		$this->Session->set('backend_errors', $arrErrors);
+
+		$strLabel = specialchars(sprintf($GLOBALS['TL_LANG']['ERR']['numberOfErrors'], $count));
+		$strTitle = specialchars(sprintf($GLOBALS['TL_LANG']['MSC']['errorOverview'], $this->strLabel));
+		$strUrl = 'contao/errors.php?hash=' . $strHash;
+
+		return '<p class="tl_error"><a href="' . $strUrl . '" onclick="Backend.openModalIframe({\'width\':735,\'height\':405,\'title\':\''. $strTitle . '\',\'url\':this.href});return false">' . $strLabel . '</a></p>';
+	}
+
+
+	/**
 	 * Return true if the current input shall be submitted
 	 * @return boolean
 	 */
@@ -464,9 +506,9 @@ abstract class Widget extends Controller
 	public function generateWithError($blnSwitchOrder=false)
 	{
 		$strWidget = $this->generate();
-		$strError = $this->getErrorAsHTML();
+		$strErrors = $this->getErrorsAsHTML();
 
-		return $blnSwitchOrder ? $strWidget . $strError : $strError . $strWidget;
+		return $blnSwitchOrder ? $strWidget . $strErrors : $strErrors . $strWidget;
 	}
 
 

--- a/system/library/Contao/Widget.php
+++ b/system/library/Contao/Widget.php
@@ -694,6 +694,7 @@ abstract class Widget extends Controller
 		{
 			switch ($this->rgxp)
 			{
+				// @todo: can we put that in the validator class as well?
 				// Special validation rule for style sheets
 				case (strncmp($this->rgxp, 'digit_', 6) === 0):
 					$textual = explode('_', $this->rgxp);
@@ -707,7 +708,7 @@ abstract class Widget extends Controller
 
 				// Numeric characters (including full stop [.] minus [-] and space [ ])
 				case 'digit':
-					if (!preg_match('/^[\d \.-]*$/', $varInput))
+					if (!Validator::isDigit($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['digit'], $this->strLabel));
 					}
@@ -715,43 +716,23 @@ abstract class Widget extends Controller
 
 				// Alphabetic characters (including full stop [.] minus [-] and space [ ])
 				case 'alpha':
-					if (function_exists('mb_eregi'))
+					if (!Validator::isAlpha($varInput))
 					{
-						if (!mb_eregi('^[[:alpha:] \.-]*$', $varInput))
-						{
 							$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['alpha'], $this->strLabel));
-						}
-					}
-					else
-					{
-						if (!preg_match('/^[\pL \.-]*$/u', $varInput))
-						{
-							$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['alpha'], $this->strLabel));
-						}
 					}
 					break;
 
 				// Alphanumeric characters (including full stop [.] minus [-], underscore [_] and space [ ])
 				case 'alnum':
-					if (function_exists('mb_eregi'))
+					if (!Validator::isAlnum($varInput))
 					{
-						if (!mb_eregi('^[[:alnum:] \._-]*$', $varInput))
-						{
-							$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['alnum'], $this->strLabel));
-						}
-					}
-					else
-					{
-						if (!preg_match('/^[\pN\pL \._-]*$/u', $varInput))
-						{
-							$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['alnum'], $this->strLabel));
-						}
+						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['alnum'], $this->strLabel));
 					}
 					break;
 
 				// Do not allow any characters that are usually encoded by class Input [=<>()#/])
 				case 'extnd':
-					if (preg_match('/[#\(\)\/<=>]/', html_entity_decode($varInput)))
+					if (!Validator::isExtnd($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['extnd'], $this->strLabel));
 					}
@@ -759,9 +740,7 @@ abstract class Widget extends Controller
 
 				// Check whether the current value is a valid date format
 				case 'date':
-					$objDate = new \Date();
-
-					if (!preg_match('~^'. $objDate->getRegexp($GLOBALS['TL_CONFIG']['dateFormat']) .'$~i', $varInput))
+					if (!Validator::isDate($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['date'], $objDate->getInputFormat($GLOBALS['TL_CONFIG']['dateFormat'])));
 					}
@@ -769,9 +748,7 @@ abstract class Widget extends Controller
 
 				// Check whether the current value is a valid time format
 				case 'time':
-					$objDate = new \Date();
-
-					if (!preg_match('~^'. $objDate->getRegexp($GLOBALS['TL_CONFIG']['timeFormat']) .'$~i', $varInput))
+					if (!Validator::isTime($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['time'], $objDate->getInputFormat($GLOBALS['TL_CONFIG']['timeFormat'])));
 					}
@@ -779,9 +756,7 @@ abstract class Widget extends Controller
 
 				// Check whether the current value is a valid date and time format
 				case 'datim':
-					$objDate = new \Date();
-
-					if (!preg_match('~^'. $objDate->getRegexp($GLOBALS['TL_CONFIG']['datimFormat']) .'$~i', $varInput))
+					if (!Validator::isDatim($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['dateTime'], $objDate->getInputFormat($GLOBALS['TL_CONFIG']['datimFormat'])));
 					}
@@ -794,9 +769,7 @@ abstract class Widget extends Controller
 
 				// Check whether the current value is a valid e-mail address
 				case 'email':
-					$varInput = $this->idnaEncodeEmail($varInput);
-
-					if (!$this->isValidEmailAddress($varInput))
+					if (!Validator::isEmail($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['email'], $this->strLabel));
 					}
@@ -812,9 +785,7 @@ abstract class Widget extends Controller
 
 					foreach ($arrEmails as $strEmail)
 					{
-						$strEmail = $this->idnaEncodeEmail($strEmail);
-
-						if (!$this->isValidEmailAddress($strEmail))
+						if (!Validator::isEmail($strEmail))
 						{
 							$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['emails'], $this->strLabel));
 							break;
@@ -824,9 +795,7 @@ abstract class Widget extends Controller
 
 				// Check whether the current value is a valid URL
 				case 'url':
-					$varInput = $this->idnaEncodeUrl($varInput);
-
-					if (!preg_match('/^[a-zA-Z0-9\.\+\/\?#%:,;\{\}\(\)\[\]@&=~_-]*$/', $varInput))
+					if (!Validator::isUrl($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['url'], $this->strLabel));
 					}
@@ -834,7 +803,7 @@ abstract class Widget extends Controller
 
 				// Check whether the current value is a valid alias
 				case 'alias':
-					if (!preg_match('/^[\pN\pL\._-]*$/', $varInput))
+					if (!Validator::isAlias($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['alias'], $this->strLabel));
 					}
@@ -842,7 +811,7 @@ abstract class Widget extends Controller
 
 				// Check whether the current value is a valid folder URL alias
 				case 'folderalias':
-					if (!preg_match('/^[\pN\pL\/\._-]*$/', $varInput))
+					if (!Validator::isFolderAlias($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['folderalias'], $this->strLabel));
 					}
@@ -850,7 +819,7 @@ abstract class Widget extends Controller
 
 				// Phone numbers (numeric characters, space [ ], plus [+], minus [-], parentheses [()] and slash [/])
 				case 'phone':
-					if (!preg_match('/^(\+|\()?(\d+[ \+\(\)\/-]*)+$/', html_entity_decode($varInput)))
+					if (!Validator::isPhone($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['phone'], $this->strLabel));
 					}
@@ -858,7 +827,7 @@ abstract class Widget extends Controller
 
 				// Check whether the current value is a percent value
 				case 'prcnt':
-					if (!is_numeric($varInput) || $varInput < 0 || $varInput > 100)
+					if (!Validator::isPercent($varInput))
 					{
 						$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['prcnt'], $this->strLabel));
 					}

--- a/system/modules/backend/config/autoload.php
+++ b/system/modules/backend/config/autoload.php
@@ -90,6 +90,7 @@ TemplateLoader::addFiles(array
 	'be_error'         => 'system/modules/backend/templates',
 	'be_files'         => 'system/modules/backend/templates',
 	'be_help'          => 'system/modules/backend/templates',
+	'be_errors'        => 'system/modules/backend/templates',
 	'be_install'       => 'system/modules/backend/templates',
 	'be_live_update'   => 'system/modules/backend/templates',
 	'be_login'         => 'system/modules/backend/templates',

--- a/system/modules/backend/languages/de/default.php
+++ b/system/modules/backend/languages/de/default.php
@@ -81,7 +81,7 @@ $GLOBALS['TL_LANG']['ERR']['topLevelRoot']      = 'Seiten in der obersten Ebene 
 $GLOBALS['TL_LANG']['ERR']['topLevelRegular']   = 'Auf der obersten Ebene befinden sich Seiten, die keine Website-Startpunkte sind. Webseiten ohne Startpunkt werden nicht mehr unterstützt, daher stellen Sie bitte sicher, dass alle Seiten unter einem Startpunkt gruppiert sind.';
 $GLOBALS['TL_LANG']['ERR']['invalidTokenUrl']   = 'Der Link, den Sie aufgerufen haben, konnte nicht verifiziert werden. Wenn Sie den Link selbst aufgerufen oder von einer vertauenswürdigen Person erhalten haben, können Sie den Vorgang fortsetzen.';
 $GLOBALS['TL_LANG']['ERR']['version2format']    = 'Dieses Element verwendet noch das alte Contao 2 SRC-Format. Haben Sie die Datenbank aktualisiert?';
-
+$GLOBALS['TL_LANG']['ERR']['numberOfErrors']    = 'Es sind %s Fehler aufgetreten. Klicken Sie für die Details.';
 
 /**
  * Page types
@@ -443,6 +443,7 @@ $GLOBALS['TL_LANG']['MSC']['ascending']         = 'aufsteigend';
 $GLOBALS['TL_LANG']['MSC']['descending']        = 'absteigend';
 $GLOBALS['TL_LANG']['MSC']['default']           = 'Standard';
 $GLOBALS['TL_LANG']['MSC']['helpWizard']        = 'Hilfe-Assistent';
+$GLOBALS['TL_LANG']['MSC']['errorOverview']     = 'Fehlerübersicht für das Feld "%s"';
 $GLOBALS['TL_LANG']['MSC']['noCookies']         = 'Für die Nutzung von Contao müssen Cookies erlaubt sein.';
 $GLOBALS['TL_LANG']['MSC']['copyOf']            = '%s (Kopie)';
 $GLOBALS['TL_LANG']['MSC']['coreOnlyMode']      = 'Contao befindet sich momentan im <strong>abgesicherten Modus</strong>, in dem nur Core-Module geladen werden. Dieser Modus ist z.B. nach einem Live Update aktiv, um eventuellen Fehlern durch inkompatible Third-Party-Erweiterungen vorzubeugen. Sie können den Betriebsmodus nach der Prüfung der installierten Third-Party-Erweiterungen in den Backend-Einstellungen anpassen.';

--- a/system/modules/backend/languages/en/default.php
+++ b/system/modules/backend/languages/en/default.php
@@ -81,6 +81,7 @@ $GLOBALS['TL_LANG']['ERR']['topLevelRoot']      = 'Top-level pages must be websi
 $GLOBALS['TL_LANG']['ERR']['topLevelRegular']   = 'There are pages on the top-level which are not website root pages. Creating websites without a website root page is no longer supported, so please ensure that all pages are grouped under a website root page.';
 $GLOBALS['TL_LANG']['ERR']['invalidTokenUrl']   = 'The link you were trying to open could not be verified. If you have clicked the link yourself or have received it by a trustworthy person, you can confirm the process below.';
 $GLOBALS['TL_LANG']['ERR']['version2format']    = 'This element still uses the old Contao 2 SRC format. Did you upgrade the database?';
+$GLOBALS['TL_LANG']['ERR']['numberOfErrors']    = 'There are %s errors for this field. Click for details';
 
 /**
  * Page types
@@ -442,6 +443,7 @@ $GLOBALS['TL_LANG']['MSC']['ascending']         = 'ascending';
 $GLOBALS['TL_LANG']['MSC']['descending']        = 'descending';
 $GLOBALS['TL_LANG']['MSC']['default']           = 'Default';
 $GLOBALS['TL_LANG']['MSC']['helpWizard']        = 'Help wizard';
+$GLOBALS['TL_LANG']['MSC']['errorOverview']     = 'Error overview for the field "%s"';
 $GLOBALS['TL_LANG']['MSC']['noCookies']         = 'You have to allow cookies to use Contao.';
 $GLOBALS['TL_LANG']['MSC']['copyOf']            = '%s (copy)';
 $GLOBALS['TL_LANG']['MSC']['coreOnlyMode']      = 'Contao is currently running in <strong>safe mode</strong>, in which only core modules are loaded. This operation mode is e.g. activated after a Live Update to prevent possible incompatibilities with third-party extensions. You can deactivate it in the back end settings after you have checked the installed third-party extensions.';

--- a/system/modules/backend/templates/be_errors.html5
+++ b/system/modules/backend/templates/be_errors.html5
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>">
+<head>
+<meta charset="<?php echo $this->charset; ?>">
+<title><?php echo $this->title; ?> - Contao Open Source CMS <?php echo VERSION; ?></title>
+<base href="<?php echo $this->base; ?>">
+<link rel="stylesheet" href="<?php
+  $objCombiner = new Combiner();
+  $objCombiner->add('system/themes/'. $this->theme .'/basic.css');
+  $objCombiner->add('system/themes/'. $this->theme .'/errors.css');
+  echo $objCombiner->getCombinedFile();
+?>" media="all">
+<!--[if IE]><link rel="stylesheet" href="<?php echo TL_SCRIPT_URL; ?>system/themes/<?php echo $this->theme; ?>/iefixes.css"><![endif]-->
+</head>
+<body class="__ua__ popup">
+
+<div id="container">
+<div id="main">
+
+<h2><?php echo $this->headline; ?></h2>
+
+<?php if (!empty($this->errors)): ?>
+<table class="tl_error_table">
+<?php foreach ($this->errors as $k => $error): ?>
+  <tr>
+    <td class="tl_label">#<?php echo ($k+1); ?></td>
+    <td><?php echo $error; ?></td>
+  </tr>
+<?php endforeach; ?>
+</table>
+<?php endif; ?>
+
+</div>
+</div>
+
+</body>
+</html>

--- a/system/themes/default/errors.css
+++ b/system/themes/default/errors.css
@@ -1,0 +1,1 @@
+body{background:#fff;padding:6px 12px}h1{display:none}h2{margin:18px 18px 9px;padding:7px 0 7px 36px;background:url("images/error.gif") no-repeat left center;font-size:14px;color:#C55}.tl_error_table{margin:0 18px 18px}.tl_error_table td{padding:12px 0;vertical-align:top;border-bottom:1px solid #e6e6e6;line-height:16px}.tl_label{width:50px;font-weight:bold}

--- a/system/themes/default/src/error.css
+++ b/system/themes/default/src/error.css
@@ -1,0 +1,59 @@
+/**
+ * Contao Open Source CMS
+ * Copyright (C) 2005-2012 Leo Feyer
+ *
+ * Formerly known as TYPOlight Open Source CMS.
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program. If not, please visit the Free
+ * Software Foundation website at <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5.3
+ * @copyright  Leo Feyer 2005-2012
+ * @author     Leo Feyer <http://www.contao.org>
+ * @package    System
+ * @license    LGPL
+ */
+
+/* Body */
+body {
+	background:#fff;
+	padding:6px 12px;
+}
+
+/* Headline */
+h1 {
+	display:none;
+}
+h2 {
+	margin:18px 18px 9px;
+	padding:7px 0 7px 36px;
+	background:url("images/error.gif") no-repeat left center;
+	font-size:14px;
+	color:#C55;
+}
+
+/* Table */
+.tl_error_table {
+	margin:0 18px 18px;
+}
+.tl_error_table td {
+	padding:12px 0;
+	vertical-align:top;
+	border-bottom:1px solid #e6e6e6;
+	line-height:16px;
+}
+.tl_label {
+	width:50px;
+	font-weight:bold;
+}


### PR DESCRIPTION
Hi Leo

The first commit is a proposal of how we could allow to display more than one error message per field in the DCA. The current behaviour is a bit strange:
1. Enter invalid data that produces 2 or more errors (I don't know if that's even possible in the core)
2. Fix the error you are notified about (but you only know about one, because only one message gets displayed)
3. Send the form again -> it will again tell you that the value is incorrect which is a bit tedious ;)

The first commit fixes this and provides the number of errors and a popup view for all the details if you click on the message :)

In fact this is a product of my attempt to allow more than one regular expression on a field. I tried but I couldn't really come up with a good solution as the current implementation is really inflexible.
There are a lot of 

```
if ($arrData['eval']['rgxp'] == 'date')
```

comparisons in the code and I think a lot of extensions use this too. So I thought about the problem again and I think that the real problem is that if we want to use an existing rgxp, we have to copy the whole code and so I ended up creating a new class called "Validator" that contains all the methods to check for different things.
This way one can easily reuse and combine different methods in his own rgxp which is still not perfect but a huge improvement already. A proper implementation where the validation goes into the Model can be considered for Contao Reloaded.

The code as is does not properly work, because in the Validator class I need to call methods (idnaEncode etc.) that are currently not static yet. So in fact you'd need to make all the methods static that do not need the object context. But that was a goal of Contao 3 anyway and some of it has already been done by Andreas (https://github.com/contao/core/pull/3898) :)

Thx for implementing and improving!
