### PR TITLE
Verhalten von getImage Verbessern, wenn $target genutzt wird.

### DIFF
--- a/system/libraries/Controller.php
+++ b/system/libraries/Controller.php
@@ -942,10 +942,28 @@ abstract class Controller extends System
 
 		$strCacheName = 'system/html/' . $objFile->filename . '-' . substr(md5('-w' . $width . '-h' . $height . '-' . $image . '-' . $mode . '-' . $objFile->mtime), 0, 8) . '.' . $objFile->extension;
 
-		// Return the path of the new image if it exists already
-		if (!$GLOBALS['TL_CONFIG']['debugMode'] && file_exists(TL_ROOT . '/' . $strCacheName))
-		{
-			return $this->urlEncode($strCacheName);
+		if (!$GLOBALS['TL_CONFIG']['debugMode']) {
+			// Using a custom target image
+			if ($target)
+			{
+				// Return if the target image allready exists
+				if (file_exists(TL_ROOT . '/' . $target))
+				{
+					return $this->urlEncode($target);
+				}
+				// Copy cache file if exists
+				else if ($target && file_exists(TL_ROOT . '/' . $strCacheName))
+				{
+					$this->import('Files');
+					$this->Files->copy($strCacheName, $target);
+					return $this->urlEncode($target);
+				}
+			}
+			// Return the path of the new image if it exists already
+			else if (file_exists(TL_ROOT . '/' . $strCacheName))
+			{
+				return $this->urlEncode($strCacheName);
+			}
 		}
 
 		// HOOK: add custom logic
@@ -1197,7 +1215,7 @@ abstract class Controller extends System
 		if ($target)
 		{
 			$this->import('Files');
-			$this->Files->rename($strCacheName, $target);
+			$this->Files->copy($strCacheName, $target);
 			return $this->urlEncode($target);
 		}
 

--- a/system/libraries/Controller.php
+++ b/system/libraries/Controller.php
@@ -926,7 +926,7 @@ abstract class Controller extends System
 		// No resizing required
 		if ($objFile->width == $width && $objFile->height == $height)
 		{
-			return $image;
+			return $this->urlEncode($image);
 		}
 
 		// No mode given

--- a/system/libraries/Controller.php
+++ b/system/libraries/Controller.php
@@ -958,7 +958,9 @@ abstract class Controller extends System
 			if ($target)
 			{
 				// Return if the target image allready exists
-				if (file_exists(TL_ROOT . '/' . $target) && !$targetForce)
+				if (file_exists(TL_ROOT . '/' . $target) &&
+					filemtime(TL_ROOT . '/' . $image) <= filemtime(TL_ROOT . '/' . $target) &&
+					!$targetForce)
 				{
 					return $this->urlEncode($target);
 				}

--- a/system/libraries/Controller.php
+++ b/system/libraries/Controller.php
@@ -929,7 +929,8 @@ abstract class Controller extends System
 			if ($target)
 			{
 				// copy if target image not exists or is older than source
-				if (!file_exists(TL_ROOT . '/' . $target) || filemtime(TL_ROOT . '/' . $image) > filemtime(TL_ROOT . '/' . $target)) {
+				if (!file_exists(TL_ROOT . '/' . $target) ||
+					$objFile->mtime > filemtime(TL_ROOT . '/' . $target)) {
 					$this->import('Files');
 					$this->Files->copy($image, $target);
 				}
@@ -959,7 +960,7 @@ abstract class Controller extends System
 			{
 				// Return if the target image allready exists
 				if (file_exists(TL_ROOT . '/' . $target) &&
-					filemtime(TL_ROOT . '/' . $image) <= filemtime(TL_ROOT . '/' . $target) &&
+					$objFile->mtime <= filemtime(TL_ROOT . '/' . $target) &&
 					!$targetForce)
 				{
 					return $this->urlEncode($target);

--- a/system/libraries/Controller.php
+++ b/system/libraries/Controller.php
@@ -883,7 +883,7 @@ abstract class Controller extends System
 	 */
 	protected function resizeImage($image, $width, $height, $mode='')
 	{
-		return $this->getImage($image, $width, $height, $mode, $image) ? true : false;
+		return $this->getImage($image, $width, $height, $mode, $image, true) ? true : false;
 	}
 
 
@@ -894,9 +894,10 @@ abstract class Controller extends System
 	 * @param integer
 	 * @param string
 	 * @param string
+	 * @param bool Force resize even if $target allready exists
 	 * @return string|null
 	 */
-	protected function getImage($image, $width, $height, $mode='', $target=null)
+	protected function getImage($image, $width, $height, $mode='', $target=null, $targetForce=false)
 	{
 		if ($image == '')
 		{
@@ -947,7 +948,7 @@ abstract class Controller extends System
 			if ($target)
 			{
 				// Return if the target image allready exists
-				if (file_exists(TL_ROOT . '/' . $target))
+				if (file_exists(TL_ROOT . '/' . $target) && !$targetForce)
 				{
 					return $this->urlEncode($target);
 				}

--- a/system/libraries/Controller.php
+++ b/system/libraries/Controller.php
@@ -926,6 +926,16 @@ abstract class Controller extends System
 		// No resizing required
 		if ($objFile->width == $width && $objFile->height == $height)
 		{
+			if ($target)
+			{
+				// copy if target image not exists or is older than source
+				if (!file_exists(TL_ROOT . '/' . $target) || filemtime(TL_ROOT . '/' . $image) > filemtime(TL_ROOT . '/' . $target)) {
+					$this->import('Files');
+					$this->Files->copy($image, $target);
+				}
+				return $this->urlEncode($target);
+			}
+
 			return $this->urlEncode($image);
 		}
 


### PR DESCRIPTION
(heute mal ein Ticket auf Deutsch, das auf English zu beschreiben liegt mir grade nicht)

Wenn `Controller::getImage()` mit dem Parameter `$target` genutzt wird, treten 2 Fehler auf.
**1.** Das Caching funktioniert nicht mehr richtig.
Das Problem ist das in Zeile [943](https://github.com/contao/core/blob/2.11.x/system/libraries/Controller.php#L943) der Cache Dateiname ermittelt wird, ohne $target zu Berücksichtigen. Wenn allerdings $target verwendet wird, wird die [Cache Datei verschoben](https://github.com/contao/core/blob/2.11.x/system/libraries/Controller.php#L1200) wodurch die Caching Bedingung nicht zum tragen kommt.
Das kann man ganz einfach überprüfen, wenn man folgenden Code verwendet

``` php
<?php
$source = 'tl_files/music_academy/campus/campus_building.jpg';
$target = 'tl_files/campus_building.jpg';
$image = $this->getImage($source, 150, 150, 'crop', $target);
echo '<p>' . $this->generateImage($image, '') . '</p>';
echo '<p>' . filemtime($image) . '</p>';
```

wird das Bild **immer** neu gerendert, weil die Caching Bedingung nicht zum tragen kommt. Das sieht man durch die Ausgabe der Modification Time sehr deutlich.

**2.** Die Datei $target wird **niemals** erstellt, wenn die Cache Datei existiert.
Das kann man an folgendem Beispiel gut zeigen:

``` php
$source = 'tl_files/music_academy/campus/campus_hall.jpg';
$target = 'tl_files/campus_hall.jpg';                                                                                                                                                                                                          

$a = $this->getImage($source, 150, 150, 'crop');
echo '<p>' . $this->generateImage($a, '') . '</p>';
echo '<p>' . filemtime($a) . '</p>';

$b = $this->getImage($source, 150, 150, 'crop', $target);
echo '<p>' . $this->generateImage($b, '') . '</p>';
echo '<p>' . filemtime($b) . '</p>';
```

Eigentlich würde ich erwarten, dass `$a` den Pfad zur Caching Datei beinhaltet und `$b` sollte `$target` enthalten. In Wirklichkeit enthält `$b` aber ebenfalls den Pfad zur Caching Datei und die Datei `$target` wird niemals erstellt.

---

Ich ändere das Verhalten so, dass `$target` entsprechend Berücksichtigt wird. Außerdem kopiere ich die Caching Datei, um das Caching Problem zu beheben.
