### PR TITLE
Added some more missing MooTools tips and the static script URL parameter in the page templates

### DIFF
--- a/contao/popup.php
+++ b/contao/popup.php
@@ -174,6 +174,7 @@ class Popup extends Backend
 		$this->Template->label_atime = $GLOBALS['TL_LANG']['MSC']['fileAccessed'];
 		$this->Template->label_path = $GLOBALS['TL_LANG']['MSC']['filePath'];
 		$this->Template->download = specialchars($GLOBALS['TL_LANG']['MSC']['fileDownload']);
+		$this->Template->downloadTitle = specialchars($GLOBALS['TL_LANG']['MSC']['fileDownloadTitle']);
 
 		$this->Template->output();
 	}

--- a/system/modules/backend/languages/de/default.php
+++ b/system/modules/backend/languages/de/default.php
@@ -422,6 +422,7 @@ $GLOBALS['TL_LANG']['MSC']['fileCreated']       = 'Erstellt am';
 $GLOBALS['TL_LANG']['MSC']['fileModified']      = 'Zuletzt geändert am';
 $GLOBALS['TL_LANG']['MSC']['fileAccessed']      = 'Letzter Zugriff am';
 $GLOBALS['TL_LANG']['MSC']['fileDownload']      = 'Herunterladen';
+$GLOBALS['TL_LANG']['MSC']['fileDownloadTitle'] = 'Diese Datei herunterladen';
 $GLOBALS['TL_LANG']['MSC']['fileImageSize']     = 'Breite/Höhe in Pixeln';
 $GLOBALS['TL_LANG']['MSC']['filePath']          = 'Relativer Pfad';
 $GLOBALS['TL_LANG']['MSC']['version']           = 'Version';

--- a/system/modules/backend/languages/en/default.php
+++ b/system/modules/backend/languages/en/default.php
@@ -421,6 +421,7 @@ $GLOBALS['TL_LANG']['MSC']['fileCreated']       = 'Created';
 $GLOBALS['TL_LANG']['MSC']['fileModified']      = 'Last modified';
 $GLOBALS['TL_LANG']['MSC']['fileAccessed']      = 'Last accessed';
 $GLOBALS['TL_LANG']['MSC']['fileDownload']      = 'Download';
+$GLOBALS['TL_LANG']['MSC']['fileDownloadTitle'] = 'Download this file';
 $GLOBALS['TL_LANG']['MSC']['fileImageSize']     = 'Width/height in pixel';
 $GLOBALS['TL_LANG']['MSC']['filePath']          = 'Relative path';
 $GLOBALS['TL_LANG']['MSC']['version']           = 'Version';

--- a/system/modules/backend/templates/be_help.html5
+++ b/system/modules/backend/templates/be_help.html5
@@ -11,6 +11,14 @@
   echo $objCombiner->getCombinedFile();
 ?>" media="all">
 <!--[if IE]><link rel="stylesheet" href="<?php echo TL_SCRIPT_URL; ?>system/themes/<?php echo $this->theme; ?>/iefixes.css"><![endif]-->
+<script src="<?php
+  $objCombiner = new Combiner();
+  $objCombiner->add('plugins/mootools/core/' . MOOTOOLS . '/mootools-core.js', MOOTOOLS);
+  $objCombiner->add('plugins/mootools/more/' . MOOTOOLS . '/mootools-more.js', MOOTOOLS);
+  $objCombiner->add('plugins/mootools/mootao/Mootao.js');
+  $objCombiner->add('system/modules/backend/html/contao.js');
+  echo $objCombiner->getCombinedFile();
+?>"></script>
 </head>
 <body class="__ua__ popup">
 

--- a/system/modules/backend/templates/be_popup.html5
+++ b/system/modules/backend/templates/be_popup.html5
@@ -11,6 +11,14 @@
   echo $objCombiner->getCombinedFile();
 ?>" media="all">
 <!--[if IE]><link rel="stylesheet" href="<?php echo TL_SCRIPT_URL; ?>system/themes/<?php echo $this->theme; ?>/iefixes.css"><![endif]-->
+<script src="<?php
+  $objCombiner = new Combiner();
+  $objCombiner->add('plugins/mootools/core/' . MOOTOOLS . '/mootools-core.js', MOOTOOLS);
+  $objCombiner->add('plugins/mootools/more/' . MOOTOOLS . '/mootools-more.js', MOOTOOLS);
+  $objCombiner->add('plugins/mootools/mootao/Mootao.js');
+  $objCombiner->add('system/modules/backend/html/contao.js');
+  echo $objCombiner->getCombinedFile();
+?>"></script>
 </head>
 <body class="__ua__ popup">
 
@@ -51,7 +59,7 @@
 </table>
 
 <div id="download">
-<img src="system/themes/<?php echo $this->theme; ?>/images/<?php echo $this->icon; ?>" width="18" height="18" alt="<?php echo $this->mime; ?>" class="mime_icon"> <a href="<?php echo $this->href; ?>" title="<?php echo $this->download; ?>"><?php echo $this->download; ?></a>
+<a href="<?php echo $this->href; ?>" title="<?php echo $this->downloadTitle; ?>"><img src="system/themes/<?php echo $this->theme; ?>/images/<?php echo $this->icon; ?>" width="18" height="18" alt="<?php echo $this->mime; ?>" class="mime_icon"> <?php echo $this->download; ?></a>
 </div>
 <?php if ($this->isImage): ?>
 

--- a/system/modules/frontend/templates/analytics_google.html5
+++ b/system/modules/frontend/templates/analytics_google.html5
@@ -1,8 +1,7 @@
 <?php
 
 /**
- * To use this script, please fill in your Google Analytics ID below and make
- * sure to insert the template as the last moo_ script (!) of your page.
+ * To use this script, please fill in your Google Analytics ID below
  */
 $GoogleAnalyticsId = 'UA-XXXXX-X';
 

--- a/system/modules/frontend/templates/analytics_google.xhtml
+++ b/system/modules/frontend/templates/analytics_google.xhtml
@@ -1,8 +1,7 @@
 <?php
 
 /**
- * To use this script, please fill in your Google Analytics ID below and make
- * sure to insert the template as the last moo_ script (!) of your page.
+ * To use this script, please fill in your Google Analytics ID below
  */
 $GoogleAnalyticsId = 'UA-XXXXX-X';
 

--- a/system/modules/frontend/templates/analytics_piwik.html5
+++ b/system/modules/frontend/templates/analytics_piwik.html5
@@ -2,7 +2,6 @@
 
 /**
  * To use this script, please fill in your Piwik site ID and Piwik URL below
- * and make sure to insert the template as the last j_ script (!) of your page.
  */
 $PiwikSite = 0;
 $PiwikPath = 'www.domain.tld/piwik/';

--- a/system/modules/frontend/templates/analytics_piwik.xhtml
+++ b/system/modules/frontend/templates/analytics_piwik.xhtml
@@ -2,7 +2,6 @@
 
 /**
  * To use this script, please fill in your Piwik site ID and Piwik URL below
- * and make sure to insert the template as the last j_ script (!) of your page.
  */
 $PiwikSite = 0;
 $PiwikPath = 'www.domain.tld/piwik/';

--- a/system/modules/frontend/templates/fe_page.html5
+++ b/system/modules/frontend/templates/fe_page.html5
@@ -67,7 +67,7 @@
 <?php echo $this->mootools; ?>
 <?php if (!$this->disableCron): ?>
 
-<script src="assets/contao/scheduler.js"></script>
+<script src="<?php echo TL_SCRIPT_URL; ?>assets/contao/scheduler.js"></script>
 <?php endif; ?>
 
 </body>

--- a/system/modules/frontend/templates/fe_page.xhtml
+++ b/system/modules/frontend/templates/fe_page.xhtml
@@ -68,7 +68,7 @@
 <?php echo $this->mootools; ?>
 <?php if (!$this->disableCron): ?>
 
-<script type="text/javascript" src="assets/contao/scheduler.js"></script>
+<script type="text/javascript" src="<?php echo TL_SCRIPT_URL; ?>assets/contao/scheduler.js"></script>
 <?php endif; ?>
 
 </body>


### PR DESCRIPTION
I added the static script URL parameter `TL_SCRIPT_URL` for the Contao `scheduler.js` in the page templates and replaced some default browser tooltips with the new MooTools tips (actually, there are even a few more, but I do not know if they really matter at all).

Further, I changed a little bit the explanation texts in the `analytics_*` template files, since they are now inserted always at last (cf. commit 53a34be09b2a5eec5dcf46218db83f45a11f128c).
