### PR TITLE
extend get countries hook

### DIFF
--- a/system/libraries/Controller.php
+++ b/system/libraries/Controller.php
@@ -831,7 +831,7 @@ abstract class Controller extends System
 			foreach ($GLOBALS['TL_HOOKS']['getCountries'] as $callback)
 			{
 				$this->import($callback[0]);
-				$return = $this->$callback[0]->$callback[1]($return);
+				$return = $this->$callback[0]->$callback[1]($return, $countries);
 			}
 		}
 


### PR DESCRIPTION
The getCountries hook is nice to change the order of the countries. But it's impossible to hide countries that are not needed. In most cases i never need or want all the countries in the country selection list.
Adding `$countries` as second parameter to the hook call, make it possible to remove not needed or unwanted countries from the selection.

The hook may look like this:

``` php
class MyClass
{
    public function hookGetCountries($return, &$countries = array())
    {
        unset($countries['de']); // remove germany from the countries list
        return $return;
    }
}
```

This change is absolutely backwards compatible, but make the hook more usefull.
(The function above is also compatible to contao versions without this patch!)

According to this commit please have a look at my new [countries configurator extension](https://github.com/InfinitySoft/contao-countries-configurator), there i need this change to hide countries that are not configured. In contao extensions without this patch i only change the order.
