### PR TITLE
Renamed the "new element" button

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -3470,7 +3470,7 @@ window.addEvent(\'domready\', function() {
 		if (!\Input::get('act') || \Input::get('act') == 'paste' || \Input::get('act') == 'select')
 		{
 			// Header
-			$imagePasteNew = $this->generateImage('new.gif', $GLOBALS['TL_LANG'][$this->strTable]['pasteafter'][0]);
+			$imagePasteNew = $this->generateImage('new.gif', $GLOBALS['TL_LANG'][$this->strTable]['pastenew'][0]);
 			$imagePasteAfter = $this->generateImage('pasteafter.gif', $GLOBALS['TL_LANG'][$this->strTable]['pasteafter'][0]);
 			$imageEditHeader = $this->generateImage('edit.gif', $GLOBALS['TL_LANG'][$this->strTable]['editheader'][0]);
 


### PR DESCRIPTION
In mode 4 when having sorting, there is a "add new at the top" button. The label currently
links to the message "Paste at the top". By applying this change, it will say "Add new at the top".
