### PR TITLE
Border radius hints

### DIFF
--- a/system/themes/default/src/iefixes.css
+++ b/system/themes/default/src/iefixes.css
@@ -198,3 +198,27 @@ fieldset.nolegend {
 	padding-top:12px;
 	background-position:left top;
 }
+.ie6 #ctrl_borderradius_top,
+.ie7 #ctrl_borderradius_top,
+.ie8 #ctrl_borderradius_top {
+	background-image: url("images/hints.gif") !important;
+	background-position: 47px -39px !important;
+}
+.ie6 #ctrl_borderradius_right,
+.ie7 #ctrl_borderradius_right,
+.ie8 #ctrl_borderradius_right {
+	background-image: url("images/hints.gif") !important;
+	background-position: 47px -59px !important;
+}
+.ie6 #ctrl_borderradius_bottom,
+.ie7 #ctrl_borderradius_bottom,
+.ie8 #ctrl_borderradius_bottom {
+	background-image: url("images/hints.gif") !important;
+	background-position: 47px -79px !important;
+}
+.ie6 #ctrl_borderradius_left,
+.ie7 #ctrl_borderradius_left,
+.ie8 #ctrl_borderradius_left {
+	background-image: url("images/hints.gif") !important;
+	background-position: 47px -99px !important;
+}

--- a/system/themes/default/src/main.css
+++ b/system/themes/default/src/main.css
@@ -1089,6 +1089,22 @@ a.navigation,.header_home,.header_user,.header_preview,.header_clipboard,.header
 #ctrl_shadowsize_left {
 	background-position:46px -179px !important;
 }
+#ctrl_borderradius_top {
+	background-image: url("images/hints.gif"), url("images/hints.gif");
+	background-position: 37px -39px, 47px -99px !important;
+}
+#ctrl_borderradius_right {
+	background-image: url("images/hints.gif"), url("images/hints.gif");
+	background-position: 37px -39px, 47px -59px !important;
+}
+#ctrl_borderradius_bottom {
+	background-image: url("images/hints.gif"), url("images/hints.gif");
+	background-position: 37px -79px, 47px -59px !important;
+}
+#ctrl_borderradius_left {
+	background-image: url("images/hints.gif"), url("images/hints.gif");
+	background-position: 37px -79px, 47px -99px !important;
+}
 
 /* Error messages */
 label.error,legend.error {


### PR DESCRIPTION
The border radius hints are not totally correct for border radius. The fields are not `top, right, bottom, left`, they are `top-left, top-right, bottom-right, bottom-left`. I've added the hint image twice to make it better.

Here's what it looks like:
![Border Radius Hints](http://f.cl.ly/items/1K0J0f1v053v1r1d3P3i/Bildschirmfoto%202012-05-24%20um%2012.48.55.png)
