### PR TITLE
added $this param to the getImage hook

### DIFF
--- a/system/library/Contao/Image.php
+++ b/system/library/Contao/Image.php
@@ -136,7 +136,7 @@ class Image
 		{
 			foreach ($GLOBALS['TL_HOOKS']['getImage'] as $callback)
 			{
-				$return = \System::importStatic($callback[0])->$callback[1]($image, $width, $height, $mode, $strCacheName, $objFile, $target);
+				$return = \System::importStatic($callback[0])->$callback[1]($image, $width, $height, $mode, $strCacheName, $objFile, $target, $this);
 
 				if (is_string($return))
 				{


### PR DESCRIPTION
This is useful to check where the call is coming from.
E.g.

``` php
<?php
public function preventCropping($image, &$width, &$height, $mode, $strCacheName, $objFile, $target, $objCaller)
{
    if ($objCaller instanceof IsotopeGallery)
```
