### PR TITLE
Fixed a wrong parent table name in the newsletter module

### DIFF
--- a/system/modules/newsletter/dca/tl_newsletter.php
+++ b/system/modules/newsletter/dca/tl_newsletter.php
@@ -122,7 +122,7 @@ $GLOBALS['TL_DCA']['tl_newsletter'] = array
 		),
 		'pid' => array
 		(
-			'foreignKey'              => 'tl_newsletter.title',
+			'foreignKey'              => 'tl_newsletter_channel.title',
 			'sql'                     => "int(10) unsigned NOT NULL default '0'",
 			'relation'                => array('type'=>'belongsTo', 'load'=>'eager')
 		),


### PR DESCRIPTION
When retrieving the details of a given newsletter we get the following fatal error:

```
Fatal error: Uncaught exception Exception with message Query error: Unknown column 'title' in 'field list' (SELECT title AS value FROM tl_newsletter WHERE id='1' LIMIT 0,1) thrown in system/library/Contao/Database/Statement.php on line 317
#0 system/library/Contao/Database/Statement.php(261): Contao/Database_Statement->query()
#1 system/modules/core/drivers/DC_Table.php(442): Contao/Database_Statement->execute('1')
#2 system/modules/core/classes/Backend.php(386): Contao/DC_Table->show()
#3 contao/main.php(108): Contao/Backend->getBackendModule('newsletter')
#4 contao/main.php(283): Main->run()
#5 {main}
```

I fixed the wrong parent table name in the corresponding DCA `tl_newsletter.php` (cf. [e11b06](https://github.com/contao/core/commit/e11b065d6baac5ecbd41af844847e6fa65b0f7cb#diff-18)).

[Contao 3.0.beta1, Commit: 21a45c0f94071e4117aa24e101b80adc7e2b641a]
