### PR TITLE
Added missing labels in the articles, newsletter and comments module

### DIFF
--- a/system/modules/comments/dca/tl_comments.php
+++ b/system/modules/comments/dca/tl_comments.php
@@ -220,6 +220,7 @@ $GLOBALS['TL_DCA']['tl_comments'] = array
 		),
 		'ip' => array
 		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_comments']['ip'],
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		)
 	)

--- a/system/modules/comments/languages/de/tl_comments.php
+++ b/system/modules/comments/languages/de/tl_comments.php
@@ -25,6 +25,7 @@ $GLOBALS['TL_LANG']['tl_comments']['addReply']  = array('Antwort hinzufügen', '
 $GLOBALS['TL_LANG']['tl_comments']['author']    = array('Autor', 'Hier können Sie den Autor der Antwort ändern.');
 $GLOBALS['TL_LANG']['tl_comments']['reply']     = array('Antwort', 'Hier können Sie Ihre Antwort eingeben.');
 $GLOBALS['TL_LANG']['tl_comments']['published'] = array('Kommentar veröffentlichen', 'Den Kommentar auf der Webseite anzeigen.');
+$GLOBALS['TL_LANG']['tl_comments']['ip']        = array('IP Adresse', 'IP-Adresse des Autors.');
 
 
 /**

--- a/system/modules/comments/languages/en/tl_comments.php
+++ b/system/modules/comments/languages/en/tl_comments.php
@@ -25,6 +25,7 @@ $GLOBALS['TL_LANG']['tl_comments']['addReply']  = array('Add a reply', 'Here you
 $GLOBALS['TL_LANG']['tl_comments']['author']    = array('Author', 'Here you can change the author of the reply.');
 $GLOBALS['TL_LANG']['tl_comments']['reply']     = array('Reply', 'Here you can enter the reply.');
 $GLOBALS['TL_LANG']['tl_comments']['published'] = array('Publish comment', 'Make the comment publicly visible on the website.');
+$GLOBALS['TL_LANG']['tl_comments']['ip']        = array('IP address', 'IP address of the author.');
 
 
 /**

--- a/system/modules/core/dca/tl_content.php
+++ b/system/modules/core/dca/tl_content.php
@@ -524,6 +524,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 		),
 		'orderSRC' => array
 		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_content']['orderSRC'],
 			'sql'                     => "text NULL"
 		),
 		'useHomeDir' => array

--- a/system/modules/core/languages/de/tl_content.php
+++ b/system/modules/core/languages/de/tl_content.php
@@ -53,6 +53,7 @@ $GLOBALS['TL_LANG']['tl_content']['embed']         = array('Den Link einbetten',
 $GLOBALS['TL_LANG']['tl_content']['rel']           = array('Lightbox', 'Hier können Sie ein rel-Attribut eingeben, um die Lightbox anzusteuern.');
 $GLOBALS['TL_LANG']['tl_content']['useImage']      = array('Einen Bildlink erstellen', 'Ein Bild anstatt des Link-Textes verwenden.');
 $GLOBALS['TL_LANG']['tl_content']['multiSRC']      = array('Quelldateien', 'Bitte wählen Sie eine oder mehr Dateien oder Ordner aus der Dateiübersicht. Wenn Sie einen Ordner auswählen, werden die darin enthaltenen Dateien automatisch eingefügt.');
+$GLOBALS['TL_LANG']['tl_content']['orderSRC']      = array('Quelldateien Sortierreihenfolge', 'Die Sortierreihenfolge der Quelldateien.');
 $GLOBALS['TL_LANG']['tl_content']['useHomeDir']    = array('Benutzerverzeichnis verwenden', 'Das Benutzerverzeichnis als Dateiquelle verwenden, wenn sich ein Benutzer angemeldet hat.');
 $GLOBALS['TL_LANG']['tl_content']['perRow']        = array('Vorschaubilder pro Reihe', 'Die Anzahl an Vorschaubildern pro Reihe.');
 $GLOBALS['TL_LANG']['tl_content']['perPage']       = array('Elemente pro Seite', 'Die Anzahl an Elementen pro Seite. Geben Sie 0 ein, um den automatischen Seitenumbruch zu deaktivieren.');

--- a/system/modules/core/languages/en/tl_content.php
+++ b/system/modules/core/languages/en/tl_content.php
@@ -53,6 +53,7 @@ $GLOBALS['TL_LANG']['tl_content']['embed']         = array('Embed the link', 'Us
 $GLOBALS['TL_LANG']['tl_content']['rel']           = array('Lightbox', 'To trigger the lightbox, enter a rel attribute here.');
 $GLOBALS['TL_LANG']['tl_content']['useImage']      = array('Create an image link', 'Use an image instead of the link title.');
 $GLOBALS['TL_LANG']['tl_content']['multiSRC']      = array('Source files', 'Please select one or more files or folders from the files directory. If you select a folder, its files will be included automatically.');
+$GLOBALS['TL_LANG']['tl_content']['orderSRC']      = array('Source files sort order', 'The sort order of the source files.');
 $GLOBALS['TL_LANG']['tl_content']['useHomeDir']    = array('Use home directory', 'Use the home directory as file source if there is an authenticated user.');
 $GLOBALS['TL_LANG']['tl_content']['perRow']        = array('Thumbnails per row', 'The number of image thumbnails per row.');
 $GLOBALS['TL_LANG']['tl_content']['perPage']       = array('Items per page', 'The number of items per page. Set to 0 to disable pagination.');

--- a/system/modules/newsletter/dca/tl_newsletter_recipients.php
+++ b/system/modules/newsletter/dca/tl_newsletter_recipients.php
@@ -175,6 +175,7 @@ $GLOBALS['TL_DCA']['tl_newsletter_recipients'] = array
 		),
 		'token' => array
 		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_newsletter_recipients']['token'],
 			'sql'                     => "varchar(32) NOT NULL default ''"
 		)
 	)

--- a/system/modules/newsletter/languages/de/tl_newsletter_recipients.php
+++ b/system/modules/newsletter/languages/de/tl_newsletter_recipients.php
@@ -16,8 +16,9 @@
  */
 $GLOBALS['TL_LANG']['tl_newsletter_recipients']['email']   = array('E-Mail-Adresse', 'Bitte geben Sie die E-Mail-Adresse des Abonnenten ein.');
 $GLOBALS['TL_LANG']['tl_newsletter_recipients']['active']  = array('Abonnenten aktivieren', 'Abonnenten werden normalerweise automatisch aktiviert (double-opt-in).');
-$GLOBALS['TL_LANG']['tl_newsletter_recipients']['ip']      = array('IP-Adresse', 'Die IP-Adresse des Abonnenten.');
 $GLOBALS['TL_LANG']['tl_newsletter_recipients']['addedOn'] = array('Registrierungsdatum', 'Das Datum des Abonnements.');
+$GLOBALS['TL_LANG']['tl_newsletter_recipients']['ip']      = array('IP-Adresse', 'Die IP-Adresse des Abonnenten.');
+$GLOBALS['TL_LANG']['tl_newsletter_recipients']['token']   = array('Token', 'Der Sende-Token des Newsletters.');
 
 
 /**

--- a/system/modules/newsletter/languages/en/tl_newsletter_recipients.php
+++ b/system/modules/newsletter/languages/en/tl_newsletter_recipients.php
@@ -16,8 +16,9 @@
  */
 $GLOBALS['TL_LANG']['tl_newsletter_recipients']['email']   = array('E-mail address', 'Please enter the recipient\'s e-mail address.');
 $GLOBALS['TL_LANG']['tl_newsletter_recipients']['active']  = array('Activate recipient', 'Recipients are usually activated automatically (double-opt-in).');
-$GLOBALS['TL_LANG']['tl_newsletter_recipients']['ip']      = array('IP address', 'The IP address of the subscriber.');
 $GLOBALS['TL_LANG']['tl_newsletter_recipients']['addedOn'] = array('Subscription date', 'The date of subscription.');
+$GLOBALS['TL_LANG']['tl_newsletter_recipients']['ip']      = array('IP address', 'The IP address of the subscriber.');
+$GLOBALS['TL_LANG']['tl_newsletter_recipients']['token']   = array('Token key', 'The newsletter send token key.');
 
 
 /**


### PR DESCRIPTION
I added a few missing labels in the articles, newsletter and comments module (see the respective record details).

[Contao 3.0.beta1, Commit: 21a45c0f94071e4117aa24e101b80adc7e2b641a]
