### PR TITLE
Methode hasToWait unterbindet die minütliche Ausführung

### DIFF
--- a/system/cron/cron.php
+++ b/system/cron/cron.php
@@ -163,7 +163,7 @@ class CronJob extends Frontend
 		}
 
 		// Last execution was less than five minutes ago
-		if ($objCron->tstamp > (time() - 300))
+		if ($objCron->tstamp > (time() - 60))
 		{
 			$this->Database->unlockTables();
 			return true;


### PR DESCRIPTION
Da eine Prüfung der Cronjobs ja erst nach frühestens jeweils 300 Sekunden möglich ist. Ggf. sollte man den Wert sogar auf 59 setzen.

Über den Logeintrag sollte man sich auch noch Gedanken machen. Bei wöchentlich, oder stündlich ist das kein Thema, das sind am Tag ja max 24 Einträge bzw. 48
Bei minütlich sind es aber jedoch schon 1440 bzw. 2880 Einträge im Log.
