### PR TITLE
Select options with value "0" get never selected.

### DIFF
--- a/system/libraries/Controller.php
+++ b/system/libraries/Controller.php
@@ -3254,7 +3254,7 @@ abstract class Controller extends System
 	 */
 	protected function optionSelected($strName, $varValue)
 	{
-		if ($strName == '')
+		if ($strName === '')
 		{
 			return '';
 		}


### PR DESCRIPTION
I have a strange issue. I have a select field with one `<option value="0">`.
In the Controller.php there is a normal compare `$strName == ''` but if `$strName = 0` php evaluate this as **true**!
This option get never selected.

```
$ php -r 'var_dump(0 == "");'
bool(true)
$ php -r 'var_dump(0 === "");'
bool(false)
```

Changing the compare to explizit `===` solve this problem.
