### PR TITLE
Echte Namespaces für Contao Extensions 2

### DIFF
--- a/system/library/Contao/ClassLoader.php
+++ b/system/library/Contao/ClassLoader.php
@@ -258,7 +258,7 @@ class ClassLoader
 
 			if (strpos($class, '\\') !== false && !preg_match('#^Runtime\\\\#', $class))
 			{
-				trigger_error('You should the runtime namespace when using your class, please prepend Runtime\\ to your namespaced class ' . $class . '!', E_USER_WARNING);
+				trigger_error('You should use the runtime namespace when using your class, please prepend Runtime\\ to your namespaced class ' . $class . '!', E_USER_WARNING);
 			}
 
 			include TL_ROOT . '/' . self::$classes[$class];

--- a/system/library/Contao/ClassLoader.php
+++ b/system/library/Contao/ClassLoader.php
@@ -256,6 +256,11 @@ class ClassLoader
 				$GLOBALS['TL_DEBUG']['classes_set'][] = $class;
 			}
 
+			if (strpos($class, '\\') !== false && !preg_match('#^Runtime\\\\#', $class))
+			{
+				trigger_error('You should the runtime namespace when using your class, please prepend Runtime\\ to your namespaced class ' . $class . '!', E_USER_WARNING);
+			}
+
 			include TL_ROOT . '/' . self::$classes[$class];
 		}
 

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -133,14 +133,13 @@ class ModuleAutoload extends \BackendModule
 
 							if ($strNamespace != 'Contao')
 							{
-								$arrNamespaces[] = $strNamespace;
-							}
-							else
-							{
-								$arrCompat[$strModule][] = basename($strFile, '.php');
+								$arrNamespaces[$strNamespace] = $strNamespace;
 							}
 
 							$strNamespace .=  '\\';
+
+							$strClass = basename($strFile, '.php');
+							$arrCompat[$strModule][$strClass] = $strNamespace . $strClass;
 						}
 
 						$strKey = $strNamespace . basename($strFile, '.php');
@@ -350,7 +349,8 @@ EOT
 
 					if (is_file(TL_ROOT . '/system/library/Contao/' . $strFile))
 					{
-						$arrLibrary[] = basename($strFile, '.php');
+						$strClass = basename($strFile, '.php');
+						$arrLibrary[$strClass] = 'Contao\\' . $strClass;
 					}
 					elseif ($strFile != 'Database')
 					{
@@ -358,7 +358,8 @@ EOT
 						{
 							if (is_file(TL_ROOT . '/system/library/Contao/' . $strFile . '/' . $strSubfile))
 							{
-								$arrLibrary[] = basename($strFile, '.php') . '_' . basename($strSubfile, '.php');
+								$strClass = basename($strFile, '.php') . '_' . basename($strSubfile, '.php');
+								$arrLibrary[$strClass] = 'Contao\\' . $strClass;
 							}
 						}
 					}
@@ -374,7 +375,8 @@ EOT
 
 					if (is_file(TL_ROOT . '/system/library/Contao/Database/' . $strFile))
 					{
-						$arrLibrary[] = 'Database_' . basename($strFile, '.php');
+						$strClass = 'Database_' . basename($strFile, '.php');
+						$arrLibrary[$strClass] = 'Contao\\' . $strClass;
 					}
 					else
 					{
@@ -382,7 +384,8 @@ EOT
 						{
 							if (is_file(TL_ROOT . '/system/library/Contao/Database/' . $strFile . '/' . $strSubfile))
 							{
-								$arrLibrary[] = 'Database_' . basename($strFile, '.php') . '_' . basename($strSubfile, '.php');
+								$strClass = 'Database_' . basename($strFile, '.php') . '_' . basename($strSubfile, '.php');
+								$arrLibrary[$strClass] = 'Contao\\' . $strClass;
 							}
 						}
 					}
@@ -396,9 +399,9 @@ EOT
 				{
 					$objFile->append("\n// " . ($strModule ?: 'library'));
 
-					foreach ($arrClasses as $strClass)
+					foreach ($arrClasses as $strClass => $strBase)
 					{
-						$objFile->append((in_array($strClass, $arrIsAbstract) ? 'abstract ' : '') . "class $strClass extends Contao\\$strClass {}");
+						$objFile->append((in_array($strClass, $arrIsAbstract) ? 'abstract ' : '') . "class $strClass extends $strBase {}");
 					}
 				}
 

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -331,6 +331,26 @@ EOT
 			// IDE compatibility
 			if (\Input::post('ide_compat'))
 			{
+				// Reverse mapping classes to modules and remove duplicate classes
+				$arrModules = array_keys($arrCompat);
+				$arrClasses = array();
+				foreach ($arrModules as $strModule)
+				{
+					$arrModuleClasses = array_combine(
+						array_keys($arrCompat[$strModule]),
+						array_fill(0, count($arrCompat[$strModule]), $strModule)
+					);
+					$arrIntersect = array_intersect_key($arrClasses, $arrModuleClasses);
+
+					// Remove classes from previous modules
+					foreach ($arrIntersect as $strClass => $strInModules)
+					{
+						unset($arrCompat[$strInModules][$strClass]);
+					}
+
+					$arrClasses = array_merge($arrClasses, $arrModuleClasses);
+				}
+
 				$objFile = new \File('system/helper/ide_compat.php');
 				$objFile->write(
 <<<EOT

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -437,11 +437,35 @@ EOT
 				foreach ($arrCompat as $strModule=>$arrClasses)
 				{
 					$objFile->append("\n// " . ($strModule ?: 'library'));
+					$strNamespace = false;
+					$strIndent = '';
 
 					foreach ($arrClasses as $strClass => $strBase)
 					{
-						$objFile->append((in_array($strClass, $arrIsAbstract) ? 'abstract ' : '') . "class $strClass extends $strBase {}");
+						if (strpos($strClass, '\\') !== false)
+						{
+							$strNewNamespace = preg_replace('#\\\\[^\\\\]+$#', '', $strClass);
+						}
+						else
+						{
+							$strNewNamespace = '';
+						}
+						if ($strNamespace !== $strNewNamespace)
+						{
+							if ($strNamespace !== false)
+							{
+								$objFile->append("}");
+							}
+
+							$strNamespace = $strNewNamespace;
+							$strClass = preg_replace('#^.*\\\\#', '', $strClass);
+							$objFile->append("namespace $strNamespace {");
+						}
+
+						$objFile->append("\t" . (in_array($strClass, $arrIsAbstract) ? 'abstract ' : '') . "class $strClass extends $strBase {}");
 					}
+
+					$objFile->append("}");
 				}
 
 				$objFile->close();


### PR DESCRIPTION
Nachdem @aschempp und ich ein paar Stunden über meinen [ersten Vorschlag für echte Namespaces](https://github.com/contao/core/pull/4514) diskutiert hatten, gibt es jetzt eine aktualisierte Version. 

Die Idee, anstatt dem `_vendor_` Part im Namespace, fügen wir einen virtuellen Namespace-Teil hinzu.
Ich habe mich für `Runtime\` entschieden, @aschempp hatte zwar `Contao\` Vorgeschlagen, aber `Contao\` würde einen Konflikt mit dem Contao Framework verursachen, der auch unter dem Namespace `Contao\` firmiert. (Außerdem hätten wir dann beim Framework Contao doppelt im Namespace, z.B. `Contao\Contao\Controller`).
Außerdem macht der Begriff `Runtime` deutlich, dass es sich hier um etwas handelt, das nur zur Laufzeit existiert und vermutlich niemals von einem Entwickler als Namespace genutzt werden wird.

Es ist jetzt also so, dass man beim benutzen einer NS-Klasse, immer `Runtime\` voraus stellen muss, z.B.: `Runtime\Namespaces\NamespaceClass` anstelle von `Namespaces\NamespaceClass`.
Sollte man doch mal das `Runtime\` vergessen, erinnert der ClassLoader einen daran, in dem er eine Warning triggert.

**Vorteil dieser Lösung**: Es ist kein `_vendor_` Part mehr im Namespace der entfällt.

**Nachteil dieser Lösung**: Man muss beim Überschreiben einer Klasse explizit angeben, welche Klasse man überschreiben will.

**Variante 1**: von Hand in der autoload.php:

In der ursprünglich definierenden Erweiterung wird definiert:

``` php
<?php
ClassLoader::addClassMappings(array
(
    'Runtime\Namespaces\NamespaceClass' => 'Namespaces\NamespaceClass',
));
```

In der überschreibenden Erweiterung wird definiert:

``` php
<?php
ClassLoader::addClassMappings(array
(
    'Runtime\Namespaces\NamespaceClass' => 'Namespaces\Extension\NamespaceClass',
));
```

Das Mapping besagt, dass die Klasse `Runtime\Namespaces\NamespaceClass` ein Alias auf `Namespaces\Extension\NamespaceClass` darstellt. Die Klasse `Namespaces\Extension\NamespaceClass` kann dann wiederum `Namespaces\NamespaceClass` extenden, das Original bleibt also wieder erhalten.

Eine Beispiel-Implementierung gibt es wieder in den beiden Demo Extensions, die ich für diesen POC aktualisiert habe:
Original: https://github.com/InfinitySoft/contao3-poc-namespaces
Erweitert: https://github.com/InfinitySoft/contao3-poc-namespaces-extension

**Variante 2**: via Annotation:

Ich weiß, @leofeyer mag keine Annotations, aber in diesem Fall bleibt nichts anderes übrig, um dem Autoload-Generator zu sagen, welche Klasse eigentlich überschrieben werden soll.

Das ganze sieht dann so aus:

``` php
<?php

namespace Namespaces\Extension;

/**
 * @Overwrite \Namespaces\NamespaceClass
 */
class NamespaceClass extends \Namespaces\NamespaceClass
{
    ...
}
```

Das `@Overwrite` sagt, dass die Klasse `Namespaces\Extension\NamespaceClass` die Klasse `Namespaces\NamespaceClass` überschreibt. Das Dev-Tool generiert dann das Mapping, wie man es oben gesehen hat automatisch.

Dieses Schema könnte man jetzt natürlich auch noch auf den Contao Core übernehmen und sogar auf Klassen, die eigentlich gar keinen Namespace haben!
