### PR TITLE
Prepare form data hook

### DIFF
--- a/system/modules/core/forms/Form.php
+++ b/system/modules/core/forms/Form.php
@@ -244,6 +244,16 @@ class Form extends \Hybrid
 	 */
 	protected function processFormData($arrSubmitted, $arrLabels)
 	{
+		// HOOK: prepare form data callback
+		if (isset($GLOBALS['TL_HOOKS']['prepareFormData']) && is_array($GLOBALS['TL_HOOKS']['prepareFormData']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['prepareFormData'] as $callback)
+			{
+				$this->import($callback[0]);
+				$this->$callback[0]->$callback[1]($arrSubmitted, $arrLabels, $this);
+			}
+		}
+
 		// Send form data via e-mail
 		if ($this->sendViaEmail)
 		{


### PR DESCRIPTION
Dieser HOOK erlaubt das Ändern der Daten bevor Routinen wie der E-Mail-Versand oder die Tabellenspeicherung durchgeführt werden.
