### PR TITLE
Panel layout extended

### DIFF
--- a/system/docs/CHANGELOG.md
+++ b/system/docs/CHANGELOG.md
@@ -4,6 +4,33 @@ Contao Open Source CMS Changelog
 Version 3.1.beta1 (XXXX-XX-XX)
 ------------------------------
 
+### New
+The filter panel can now be used multiple times so fields can be grouped.
+You can still use "true" which is going to be automatically assigned to the first filter panel.
+Example:
+
+```
+$GLOBALS['TL_DCA']['tl_member']['list']['sorting']['panelLayout'] = 'filter;sort;filter;limit;filter';
+$GLOBALS['TL_DCA']['tl_member']['fields']['country']['filter'] = 2;
+$GLOBALS['TL_DCA']['tl_member']['fields']['groups']['filter'] = 3;
+```
+
+### New
+Added a panel_layout callback that allows defining own panels. Example:
+
+```
+$GLOBALS['TL_DCA']['tl_member']['list']['sorting']['panelLayout'] = 'filter;foobar;';
+$GLOBALS['TL_DCA']['tl_member']['list']['sorting']['panel_callback']['foobar'] = array('tl_member_foobar', 'addFoobarPanel');
+
+class tl_member_foobar extends Backend
+{
+	public function addFoobarPanel(DataContainer $dc)
+	{
+		return '<div class="tl_sorting tl_subpanel"><strong>foobar panel</strong></div>';
+	}
+}
+```
+
 ### Changed
 Moved the Transifex `.xlf` files to the `languages` folders of the modules and
 tweaked the `System::loadLanguageFile()` method to handle them (see #5005).

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -4312,11 +4312,11 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 				else
 				{
 					$arrCallback = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panel_callback'][$strSubPanel];
-						if (is_array($arrCallback))
-						{
-							$this->import($arrCallback[0]);
+					if (is_array($arrCallback))
+					{
+						$this->import($arrCallback[0]);
 						$panel = $this->$arrCallback[0]->$arrCallback[1]($this);
-						}
+					}
 				}
 
 				if ($panel != '')

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -4294,7 +4294,7 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 			$arrSubPanels = trimsplit(',', $strPanel);
 
 			foreach ($arrSubPanels as $strSubPanel)
-		{
+			{
 				$panel = '';
 
 				// Regular panels
@@ -4305,11 +4305,10 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 
 				// Multiple filter subpanels can be defined to split the fields across panels
 				elseif ($strSubPanel == 'filter')
-						{
+				{
 					$panel = $this->{$strSubPanel . 'Menu'}(++$intFilterPanel);
-						}
-					
-					// call the panel_callback
+				}
+				// call the panel_callback
 				else
 				{
 					$arrCallback = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panel_callback'][$strSubPanel];
@@ -4330,7 +4329,7 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 			{
 				$arrPanels[] = $panels;
 			}
-			}
+		}
 
 		if (empty($arrPanels))
 		{

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -4283,12 +4283,11 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 		{
 			return '';
 		}
-		
-		$panelLayout = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout'];
-		$arrPanels = trimsplit(';', $panelLayout);
+
+		$arrPanels = array();
 		$intFilterPanel = 0;
 
-		foreach ($arrPanels as $strPanel)
+		foreach (trimsplit(';', $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout']) as $strPanel)
 		{
 			$panels = '';
 			$arrSubPanels = trimsplit(',', $strPanel);

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -4300,7 +4300,7 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 					case 'sort':
 						$arrPanels[$k][$kk] = $this->{$strSubPanelKey . 'Menu'}();
 					
-					// call the panelLayout_callbacck
+					// call the panel_callback
 					default:
 						$arrCallback = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panel_callback'][$strSubPanelKey];
 						if (is_array($arrCallback))

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -4302,7 +4302,7 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 					
 					// call the panelLayout_callbacck
 					default:
-						$arrCallback = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout_callback'][$strSubPanelKey];
+						$arrCallback = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panel_callback'][$strSubPanelKey];
 						if (is_array($arrCallback))
 						{
 							$this->import($arrCallback[0]);

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -4288,27 +4288,26 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 		$arrPanels = $this->preparePanelArray();
 
 		// prepare the default panels
-		$arrDefaultPanels = array('filter', 'search', 'limit', 'sort');
 		foreach ($arrPanels as $k => $arrSubPanels)
 		{
-			foreach ($arrSubPanels as $strSubPanelKey => $strSubPanelHtml)
+			foreach ($arrSubPanels as $kk => $strSubPanelKey)
 			{
-				if (in_array($strSubPanelKey, $arrDefaultPanels))
+				switch ($strSubPanelKey)
 				{
-					$arrPanels[$k][$strSubPanelKey] = $this->{$strSubPanelKey . 'Menu'}();
-				}
-			}
-		}
-
-		// call the panelLayout_callbacck
-		if (is_array($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout_callback']))
-		{
-			foreach ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout_callback'] as $callback)
-			{
-				if (is_array($callback))
-				{
-					$this->import($callback[0]);
-					$arrPanels = $this->$callback[0]->$callback[1]($arrPanels, $this);
+					case 'filter':
+					case 'search':
+					case 'limit':
+					case 'sort':
+						$arrPanels[$k][$kk] = $this->{$strSubPanelKey . 'Menu'}();
+					
+					// call the panelLayout_callbacck
+					default:
+						$arrCallback = $GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['panelLayout_callback'][$strSubPanelKey];
+						if (is_array($arrCallback))
+						{
+							$this->import($arrCallback[0]);
+							$arrPanels[$k][$kk] = $this->$arrCallback[0]->$arrCallback[1]($this);
+						}
 				}
 			}
 		}
@@ -4383,7 +4382,7 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 					continue;
 				}
 
-				$arrReturn[$intPanelKey][$strSubPanel] = '';
+				$arrReturn[$intPanelKey][$intSubPanelKey] = $strSubPanel;
 			}
 		}
 		


### PR DESCRIPTION
As discussed with @contao/workgroup-core here is my new pull request.

It contains the panel_callback and the possibility to use the "filter" panel multiple times and assign the fields to them.
## Testcase

Create a new module in `system/modules/test` and add the following code to `/dca/tl_member.php`:

```
<?php

/**
 * Prepare both tests
 * Add a custom "foobar" panel to demonstrate the callback
 * Use "filter" multiple times to demonstrate how to assign them
 */
$GLOBALS['TL_DCA']['tl_member']['list']['sorting']['panelLayout'] = 'filter;sort,search;filter;foobar;limit;filter';

/**
 * panel_callback test
 */
$GLOBALS['TL_DCA']['tl_member']['list']['sorting']['panel_callback']['foobar'] = array('tl_member_test', 'addFoobarPanel');

class tl_member_test extends Backend
{
    public function addFoobarPanel(DataContainer $dc)
    {
        return '<div class="tl_sorting tl_subpanel"><strong>TEST</strong></div>';
    }
}

/**
 * Filter assignment test
 */
$GLOBALS['TL_DCA']['tl_member']['fields']['country']['filter'] = 2;
$GLOBALS['TL_DCA']['tl_member']['fields']['groups']['filter'] = 3;
```
