### PR TITLE
first draft of making module templates customizable

### DIFF
--- a/system/modules/core/dca/tl_module.php
+++ b/system/modules/core/dca/tl_module.php
@@ -101,28 +101,28 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 	(
 		'__selector__'                => array('type', 'defineRoot', 'source', 'interactive', 'protected', 'reg_assignDir', 'reg_activate'),
 		'default'                     => '{title_legend},name,type',
-		'navigation'                  => '{title_legend},name,headline,type;{nav_legend},levelOffset,showLevel,hardLimit,showProtected;{reference_legend:hide},defineRoot;{template_legend:hide},navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'customnav'                   => '{title_legend},name,headline,type;{nav_legend},showProtected,pages;{template_legend:hide},navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'breadcrumb'                  => '{title_legend},name,headline,type;{nav_legend},showHidden;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'quicknav'                    => '{title_legend},name,headline,type;{nav_legend},customLabel,showLevel,hardLimit,showProtected,showHidden;{reference_legend:hide},rootPage;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'quicklink'                   => '{title_legend},name,headline,type;{nav_legend},customLabel,pages;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'booknav'                     => '{title_legend},name,headline,type;{nav_legend},showProtected,showHidden,rootPage;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'articlenav'                  => '{title_legend},name,headline,type;{config_legend},loadFirst;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'sitemap'                     => '{title_legend},name,headline,type;{nav_legend},showProtected,showHidden;{reference_legend:hide},rootPage;{template_legend:hide},navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'languageSwitch'              => '{title_legend},name,headline,type;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'login'                       => '{title_legend},name,headline,type;{config_legend},autologin;{redirect_legend},jumpTo,redirectBack;{template_legend:hide},cols;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'logout'                      => '{title_legend},name,headline,type;{redirect_legend},jumpTo,redirectBack;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'personalData'                => '{title_legend},name,headline,type;{config_legend},editable;{redirect_legend},jumpTo;{template_legend:hide},memberTpl,tableless;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'registration'                => '{title_legend},name,headline,type;{config_legend},editable,newsletters,disableCaptcha;{account_legend},reg_groups,reg_allowLogin,reg_assignDir;{redirect_legend},jumpTo;{email_legend:hide},reg_activate;{template_legend:hide},memberTpl,tableless;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'lostPassword'                => '{title_legend},name,headline,type;{config_legend},reg_skipName,disableCaptcha;{redirect_legend},jumpTo;{email_legend:hide},reg_jumpTo,reg_password;{template_legend:hide},tableless;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'closeAccount'                => '{title_legend},name,headline,type;{config_legend},reg_close;{redirect_legend},jumpTo;{template_legend:hide},tableless;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'form'                        => '{title_legend},name,headline,type;{include_legend},form;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'search'                      => '{title_legend},name,headline,type;{config_legend},queryType,fuzzy,contextLength,totalLength,perPage,searchType;{redirect_legend:hide},jumpTo;{reference_legend:hide},rootPage;{template_legend:hide},searchTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'articleList'                 => '{title_legend},name,headline,type;{config_legend},skipFirst,inColumn;{reference_legend:hide},defineRoot;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'flash'                       => '{title_legend},name,headline,type;{config_legend},size,transparent,flashvars,altContent;{source_legend},source;{interact_legend:hide},interactive;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'randomImage'                 => '{title_legend},name,headline,type;{config_legend},imgSize,useCaption,fullsize;{source_legend},multiSRC;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
-		'html'                        => '{title_legend},name,type;{html_legend},html;{protected_legend:hide},protected;{expert_legend:hide},guests',
-		'rss_reader'                  => '{title_legend},name,headline,type;{config_legend},rss_feed,numberOfItems,perPage,skipFirst,rss_cache;{template_legend:hide},rss_template;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space'
+		'navigation'                  => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{nav_legend},levelOffset,showLevel,hardLimit,showProtected;{reference_legend:hide},defineRoot;{template_legend:hide},navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'customnav'                   => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{nav_legend},showProtected,pages;{template_legend:hide},navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'breadcrumb'                  => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{nav_legend},showHidden;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'quicknav'                    => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{nav_legend},customLabel,showLevel,hardLimit,showProtected,showHidden;{reference_legend:hide},rootPage;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'quicklink'                   => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{nav_legend},customLabel,pages;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'booknav'                     => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{nav_legend},showProtected,showHidden,rootPage;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'articlenav'                  => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},loadFirst;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'sitemap'                     => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{nav_legend},showProtected,showHidden;{reference_legend:hide},rootPage;{template_legend:hide},navigationTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'languageSwitch'              => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'login'                       => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},autologin;{redirect_legend},jumpTo,redirectBack;{template_legend:hide},cols;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'logout'                      => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{redirect_legend},jumpTo,redirectBack;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'personalData'                => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},editable;{redirect_legend},jumpTo;{template_legend:hide},memberTpl,tableless;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'registration'                => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},editable,newsletters,disableCaptcha;{account_legend},reg_groups,reg_allowLogin,reg_assignDir;{redirect_legend},jumpTo;{email_legend:hide},reg_activate;{template_legend:hide},memberTpl,tableless;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'lostPassword'                => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},reg_skipName,disableCaptcha;{redirect_legend},jumpTo;{email_legend:hide},reg_jumpTo,reg_password;{template_legend:hide},tableless;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'closeAccount'                => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},reg_close;{redirect_legend},jumpTo;{template_legend:hide},tableless;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'form'                        => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{include_legend},form;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'search'                      => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},queryType,fuzzy,contextLength,totalLength,perPage,searchType;{redirect_legend:hide},jumpTo;{reference_legend:hide},rootPage;{template_legend:hide},searchTpl;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'articleList'                 => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},skipFirst,inColumn;{reference_legend:hide},defineRoot;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'flash'                       => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},size,transparent,flashvars,altContent;{source_legend},source;{interact_legend:hide},interactive;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'randomImage'                 => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},imgSize,useCaption,fullsize;{source_legend},multiSRC;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space',
+		'html'                        => '{title_legend},name,type;{modtpl_legend},modtpl;{html_legend},html;{protected_legend:hide},protected;{expert_legend:hide},guests',
+		'rss_reader'                  => '{title_legend},name,headline,type;{modtpl_legend},modtpl;{config_legend},rss_feed,numberOfItems,perPage,skipFirst,rss_cache;{template_legend:hide},rss_template;{protected_legend:hide},protected;{expert_legend:hide},guests,cssID,space'
 	),
 
 	// Subpalettes
@@ -186,6 +186,15 @@ $GLOBALS['TL_DCA']['tl_module'] = array
 			'inputType'               => 'select',
 			'options_callback'        => array('tl_module', 'getModules'),
 			'reference'               => &$GLOBALS['TL_LANG']['FMD'],
+			'eval'                    => array('helpwizard'=>true, 'chosen'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50'),
+			'sql'                     => "varchar(64) NOT NULL default ''"
+		),
+		'modtpl' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_module']['modtpl'],
+			'exclude'                 => true,
+			'inputType'               => 'select',
+			'options_callback'        => array('tl_module', 'getModuleTemplates'),
 			'eval'                    => array('helpwizard'=>true, 'chosen'=>true, 'submitOnChange'=>true, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(64) NOT NULL default ''"
 		),
@@ -856,6 +865,38 @@ class tl_module extends Backend
 		return $arrForms;
 	}
 
+
+	/**
+	 * Return all module templates as array
+	 * @param \DataContainer
+	 * @return array
+	 */
+	public function getModuleTemplates(DataContainer $dc)
+	{
+
+		$strClass = $this->findFrontendModule($dc->activeRecord->type);
+
+		if (!$strClass)
+		{
+			return array();
+		}
+
+		$objModel = \ModuleModel::findByPk($dc->id);
+		if (!$objModel)
+		{
+			return array();
+		}
+
+		$objModule = new $strClass($objModel);
+		$intPid = $dc->activeRecord->pid;
+
+		if (Input::get('act') == 'overrideAll')
+		{
+			$intPid = Input::get('id');
+		}
+
+		return $this->getTemplateGroup($objModule->template, $intPid);
+	}
 
 	/**
 	 * Return all navigation templates as array

--- a/system/modules/core/languages/de/tl_module.php
+++ b/system/modules/core/languages/de/tl_module.php
@@ -17,6 +17,7 @@
 $GLOBALS['TL_LANG']['tl_module']['name']           = array('Titel', 'Bitte geben Sie den Titel des Moduls ein.');
 $GLOBALS['TL_LANG']['tl_module']['headline']       = array('Überschrift', 'Hier können Sie dem Modul eine Überschrift hinzufügen.');
 $GLOBALS['TL_LANG']['tl_module']['type']           = array('Modultyp', 'Bitte wählen Sie den Typ des Moduls.');
+$GLOBALS['TL_LANG']['tl_module']['modtpl']         = array('Modul-Template', 'Bitte wählen Sie das Modul-Template aus.');
 $GLOBALS['TL_LANG']['tl_module']['levelOffset']    = array('Startlevel', 'Geben Sie einen Wert größer 0 ein, um nur Untermenüpunkte darzustellen.');
 $GLOBALS['TL_LANG']['tl_module']['showLevel']      = array('Stoplevel', 'Geben Sie einen Wert größer 0 ein, um die Verschachtelungstiefe des Menüs zu beschränken.');
 $GLOBALS['TL_LANG']['tl_module']['hardLimit']      = array('Hard Limit', 'Niemals Menüpunkte jenseits des Stoplevels anzeigen.');
@@ -93,6 +94,7 @@ $GLOBALS['TL_LANG']['tl_module']['reg_password']   = array('Bestätigungsmail', 
  * Legends
  */
 $GLOBALS['TL_LANG']['tl_module']['title_legend']     = 'Titel und Typ';
+$GLOBALS['TL_LANG']['tl_module']['modtpl_legend']    = 'Modul-Template-Einstellungen';
 $GLOBALS['TL_LANG']['tl_module']['nav_legend']       = 'Menü-Konfiguration';
 $GLOBALS['TL_LANG']['tl_module']['reference_legend'] = 'Referenzseite';
 $GLOBALS['TL_LANG']['tl_module']['redirect_legend']  = 'Weiterleitung';

--- a/system/modules/core/languages/en/tl_module.php
+++ b/system/modules/core/languages/en/tl_module.php
@@ -17,6 +17,7 @@
 $GLOBALS['TL_LANG']['tl_module']['name']           = array('Title', 'Please enter the module title.');
 $GLOBALS['TL_LANG']['tl_module']['headline']       = array('Headline', 'Here you can add a headline to the module.');
 $GLOBALS['TL_LANG']['tl_module']['type']           = array('Module type', 'Please choose the type of module.');
+$GLOBALS['TL_LANG']['tl_module']['modtpl']         = array('Module template', 'Please choose the module template.');
 $GLOBALS['TL_LANG']['tl_module']['levelOffset']    = array('Start level', 'Enter a value greater than 0 to show only submenu items.');
 $GLOBALS['TL_LANG']['tl_module']['showLevel']      = array('Stop level', 'Enter a value greater than 0 to limit the nesting level of the menu.');
 $GLOBALS['TL_LANG']['tl_module']['hardLimit']      = array('Hard limit', 'Never show any menu items beyond the stop level.');
@@ -93,6 +94,7 @@ $GLOBALS['TL_LANG']['tl_module']['reg_password']   = array('Password message', '
  * Legends
  */
 $GLOBALS['TL_LANG']['tl_module']['title_legend']     = 'Title and type';
+$GLOBALS['TL_LANG']['tl_module']['modtpl_legend']    = 'Module template settings';
 $GLOBALS['TL_LANG']['tl_module']['nav_legend']       = 'Navigation settings';
 $GLOBALS['TL_LANG']['tl_module']['reference_legend'] = 'Reference page';
 $GLOBALS['TL_LANG']['tl_module']['redirect_legend']  = 'Redirect settings';

--- a/system/modules/core/modules/Module.php
+++ b/system/modules/core/modules/Module.php
@@ -107,6 +107,11 @@ abstract class Module extends \Frontend
 			return $this->arrData[$strKey];
 		}
 
+		if ($strKey == 'template')
+		{
+			return $this->strTemplate;
+		}
+
 		return parent::__get($strKey);
 	}
 
@@ -138,7 +143,7 @@ abstract class Module extends \Frontend
 			$this->arrStyle[] = 'margin-bottom:'.$this->arrData['space'][1].'px;';
 		}
 
-		$this->Template = new \FrontendTemplate($this->strTemplate);
+		$this->Template = new \FrontendTemplate(($this->modtpl) ?: $this->strTemplate);
 		$this->Template->setData($this->arrData);
 
 		$this->compile();


### PR DESCRIPTION
This is my idea of how we could try to make every module's template configurable by the users.
This would give us **_so much more**_ flexibility, I can't even emphasize this enough!

In this PR I tried to use the `$strTemplate` variable of every module and it works perfectly fine. Every module gets a new `modtpl` field in `tl_module`.
Obviously this is not really backward compatible as - to make it a proper implementation - we would need to rename some of the templates, I guess.
E.g. the search module has different templates you can choose from in the "template settings". They'd become completely obsolete as this is in fact exactly the module template overriding possibility we want to have in every module.

Also I don't know whether taking `$strTemplate` from every module's class is a good idea. Probably it would be better to make this configurable with a global array. Or even better:
Make a `Module::getTemplateChoices` that returns `$strTemplate` by default and can be overwritten in every module. If it returns `null` then the field doesn't need to be displayed in the module options. But this option came to my mind while writing this comment so I'm not gonna change it again as it's a PoC anyway :)

Again, it's a foundation so other developers and maybe also @leofeyer have a common ground to start from for discussions and improvements.

Feel free to fork my branch and send me pull requests so this one gets automatically updated :-)
