### PR TITLE
No need to replace "domain.com" with this improvement.

### DIFF
--- a/.htaccess.default
+++ b/.htaccess.default
@@ -181,10 +181,10 @@ FileETag None
 
   ##
   # Uncomment the following lines and replace "domain.com" with your domain
-  # name to redirect requests without "www" to the correct domain. 
+  # name to redirect requests with "www" to the correct domain. 
   ##
-  #RewriteCond %{HTTP_HOST} ^domain\.com [NC]
-  #RewriteRule (.*) http://www.domain.com/$1 [R=301,L]
+  #	RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+  #	RewriteRule ^ http://%1%{REQUEST_URI} [R=301,L]
 
   ##
   # If you cannot use mod_deflate, uncomment the following lines to load a


### PR DESCRIPTION
Replaced:

```
  #RewriteCond %{HTTP_HOST} ^www.domain\.com [NC]
  #RewriteRule (.*) http://domain.com/$1 [R=301,L]
```

width:

```
  #RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
  #RewriteRule ^ http://%1%{REQUEST_URI} [R=301,L]
```

After uncommenting, this works for all domains in a multi-domain installation, so that not every domain has to be placed in the .htaccess file. I think this is a better default for the .htaccess. And I also think, that the correct domain should be without "www", shorter, better, less unneeded letters.
