### PR TITLE
Defect ClassLoader::register using self

### DIFF
--- a/system/library/Contao/ClassLoader.php
+++ b/system/library/Contao/ClassLoader.php
@@ -248,7 +248,7 @@ class ClassLoader
 	 */
 	public static function register()
 	{
-		spl_autoload_register('self::load');
+		spl_autoload_register('ClassLoader::load');
 	}
 
 


### PR DESCRIPTION
The `ClassLoader::register` use `self::load`, but if there are more class loaders register this does not work!
Changing to the class name instead of `self` solve this problem.
