### PR TITLE
Feature Devtool Configurable

### DIFF
--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -78,7 +78,11 @@ class ModuleAutoload extends \BackendModule
 					$arrFiles = array();
 					$arrClassLoader = array();
 					$arrNamespaces = array();
-					$arrConfig = array();
+					$arrConfig = array(
+						'autoload' => array(
+							'register_namespaces' => true,
+						),
+					);
 
 					// load the config.ini
 					if (file_exists(TL_ROOT . '/system/modules/' . $strModule . '/config/config.ini'))
@@ -202,11 +206,13 @@ EOT
 					);
 
 					// Namespaces
-					$arrNamespaces = array_unique($arrNamespaces);
-
-					if (!empty($arrNamespaces))
+					if ($arrConfig['autoload']['register_namespaces'])
 					{
-						$objFile->append(
+						$arrNamespaces = array_unique($arrNamespaces);
+
+						if (!empty($arrNamespaces))
+						{
+							$objFile->append(
 <<<EOT
 
 
@@ -216,14 +222,15 @@ EOT
 ClassLoader::addNamespaces(array
 (
 EOT
-						);
+							);
 
-						foreach ($arrNamespaces as $strNamespace)
-						{
-							$objFile->append("\t'" . $strNamespace . "',");
+							foreach ($arrNamespaces as $strNamespace)
+							{
+								$objFile->append("\t'" . $strNamespace . "',");
+							}
+
+							$objFile->append('));');
 						}
-
-						$objFile->append('));');
 					}
 
 					// Classes

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -81,6 +81,7 @@ class ModuleAutoload extends \BackendModule
 					$arrConfig = array(
 						'autoload' => array(
 							'register_namespaces' => true,
+							'register_classes'    => true,
 						),
 					);
 
@@ -234,7 +235,7 @@ EOT
 					}
 
 					// Classes
-					if (!empty($arrClassLoader))
+					if ($arrConfig['autoload']['register_classes'] && !empty($arrClassLoader))
 					{
 						$objFile->append(
 <<<EOT

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -82,6 +82,7 @@ class ModuleAutoload extends \BackendModule
 						'autoload' => array(
 							'register_namespaces' => true,
 							'register_classes'    => true,
+							'register_templates'  => true,
 						),
 					);
 
@@ -275,7 +276,7 @@ EOT
 					}
 
 					// Templates
-					if (!empty($arrTplLoader))
+					if ($arrConfig['autoload']['register_templates'] && !empty($arrTplLoader))
 					{
 						$objFile->append(
 <<<EOT

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -78,6 +78,21 @@ class ModuleAutoload extends \BackendModule
 					$arrFiles = array();
 					$arrClassLoader = array();
 					$arrNamespaces = array();
+					$arrConfig = array();
+
+					// load the config.ini
+					if (file_exists(TL_ROOT . '/system/modules/' . $strModule . '/config/config.ini'))
+					{
+						$arrTemp = parse_ini_file(TL_ROOT . '/system/modules/' . $strModule . '/config/config.ini', true);
+
+						foreach (array_keys($arrConfig) as $strSection)
+						{
+							if (isset($arrTemp[$strSection]))
+							{
+								$arrConfig[$strSection] = array_merge($arrConfig[$strSection], $arrTemp[$strSection]);
+							}
+						}
+					}
 
 					// Recursively scan all subfolders
 					$objFiles = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(TL_ROOT . '/system/modules/' . $strModule));


### PR DESCRIPTION
The devtool is now configurable and can be configured with a config.ini.

There are 3 options, to disable registration of namespace. classes and templates.

Example config.ini:

```
[autoload]
register_namespaces = off
register_classes = off
register_templates = off
```
