### PR TITLE
Feature RuntimeClassLoader

### DIFF
--- a/system/helper/ide_compat.php
+++ b/system/helper/ide_compat.php
@@ -55,6 +55,7 @@ class Model_QueryBuilder extends Contao\Model_QueryBuilder {}
 abstract class Model extends Contao\Model {}
 class Request extends Contao\Request {}
 class RequestToken extends Contao\RequestToken {}
+class RuntimeClassLoader extends Contao\RuntimeClassLoader {}
 class Search extends Contao\Search {}
 class Session extends Contao\Session {}
 class String extends Contao\String {}

--- a/system/initialize.php
+++ b/system/initialize.php
@@ -60,12 +60,16 @@ require TL_ROOT . '/system/helper/interface.php';
 /**
  * Register the class and template loader
  */
+require TL_ROOT . '/system/library/Contao/RuntimeClassLoader.php';
+class_alias('Contao\\RuntimeClassLoader', 'RuntimeClassLoader');
+
 require TL_ROOT . '/system/library/Contao/ClassLoader.php';
 class_alias('Contao\\ClassLoader', 'ClassLoader');
 
 require TL_ROOT . '/system/library/Contao/TemplateLoader.php';
 class_alias('Contao\\TemplateLoader', 'TemplateLoader');
 
+RuntimeClassLoader::register();
 ClassLoader::scanAndRegister(); // config/autoload.php
 
 

--- a/system/library/Contao/RuntimeClassLoader.php
+++ b/system/library/Contao/RuntimeClassLoader.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ * 
+ * Copyright (C) 2005-2012 Leo Feyer
+ * 
+ * @package Library
+ * @link    http://www.contao.org
+ * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL
+ */
+
+namespace Contao;
+
+
+/**
+ * Automatically loads class files based on a mapper array
+ * 
+ * The class stores namespaces and classes and automatically loads the class
+ * files upon their first usage. It uses a mapper array to support complex
+ * nesting and arbitrary subfolders to store the class files in.
+ * 
+ * Usage:
+ * 
+ *     ClassLoader::addNamespace('Custom');
+ *     ClassLoader::addClass('Custom\\Calendar', 'calendar/Calendar.php');
+ * 
+ * @package   Library
+ * @author    Leo Feyer <https://github.com/leofeyer>
+ * @copyright Leo Feyer 2011-2012
+ */
+class RuntimeClassLoader
+{
+	/**
+	 * Marker when loading the non-runtime class
+	 *
+	 * @var bool
+	 */
+	protected static $triggerWarning = false;
+
+	/**
+	 * Known class mappings
+	 *
+	 * @var array
+	 */
+	protected static $classMapping = array();
+
+
+	/**
+	 * Add a new namespace
+	 * 
+	 * @param string $name The namespace name
+	 */
+	public static function addClassMapping($runtimeClass, $targetClass)
+	{
+		self::$classMapping[$runtimeClass] = $targetClass;
+	}
+
+
+	/**
+	 * Return the class mapping as array
+	 * 
+	 * @return array An array of all namespaces
+	 */
+	public static function getClassMapping()
+	{
+		return self::$classMapping;
+	}
+
+
+	/**
+	 * Autoload a runtime class and create an alias
+	 * 
+	 * @param string $runtimeClass The class name
+	 */
+	public static function load($runtimeClass)
+	{
+		if (class_exists($runtimeClass, false) || interface_exists($runtimeClass, false))
+		{
+			return;
+		}
+
+		// The class is a runtime class
+		if (strncmp($runtimeClass, 'Runtime\\', 8) === 0)
+		{
+			// The class file is mapped
+			if (isset(self::$classMapping[$runtimeClass]))
+			{
+				$targetClass = self::$classMapping[$runtimeClass];
+			}
+
+			// remove the Runtime\ prefix
+			else
+			{
+				$targetClass = substr($runtimeClass, 8);
+			}
+
+			// do not trigger warnings while loading the target class
+			self::$triggerWarning = false;
+
+			// create the class alias
+			class_alias($targetClass, $runtimeClass);
+
+			// now trigger warnings for future class loads
+			self::$triggerWarning = true;
+		}
+
+		// Trigger a warning for non global namespace classes
+		else if (self::$triggerWarning && strpos($runtimeClass, '\\') !== false)
+		{
+			trigger_error('You should use Runtime\\' . $runtimeClass . ' when using your class ' . $runtimeClass . '.', E_USER_WARNING);
+		}
+	}
+
+
+	/**
+	 * Register the autoloader
+	 */
+	public static function register()
+	{
+		spl_autoload_register('RuntimeClassLoader::load');
+	}
+}

--- a/system/library/Contao/RuntimeClassLoader.php
+++ b/system/library/Contao/RuntimeClassLoader.php
@@ -47,13 +47,27 @@ class RuntimeClassLoader
 
 
 	/**
-	 * Add a new namespace
+	 * Add a class mapping
 	 * 
 	 * @param string $name The namespace name
 	 */
 	public static function addClassMapping($runtimeClass, $targetClass)
 	{
 		self::$classMapping[$runtimeClass] = $targetClass;
+	}
+
+
+	/**
+	 * Add multiple class mappings
+	 *
+	 * @param string $name The namespace name
+	 */
+	public static function addClassMappings($classMappings)
+	{
+		foreach ($classMappings as $runtimeClass => $targetClass)
+		{
+			self::addClassMapping($runtimeClass, $targetClass);
+		}
 	}
 
 

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -78,7 +78,11 @@ class ModuleAutoload extends \BackendModule
 					$arrFiles = array();
 					$arrClassLoader = array();
 					$arrNamespaces = array();
-					$arrConfig = array();
+					$arrConfig = array(
+						'autoload' => array(
+							'register_namespaces' => true,
+						),
+					);
 
 					// load the config.ini
 					if (file_exists(TL_ROOT . '/system/modules/' . $strModule . '/config/config.ini'))
@@ -202,11 +206,13 @@ EOT
 					);
 
 					// Namespaces
-					$arrNamespaces = array_unique($arrNamespaces);
-
-					if (!empty($arrNamespaces))
+					if ($arrConfig['autoload']['register_namespaces'])
 					{
-						$objFile->append(
+						$arrNamespaces = array_unique($arrNamespaces);
+
+						if (!empty($arrNamespaces))
+						{
+							$objFile->append(
 <<<EOT
 
 
@@ -216,14 +222,15 @@ EOT
 ClassLoader::addNamespaces(array
 (
 EOT
-						);
+							);
 
-						foreach ($arrNamespaces as $strNamespace)
-						{
-							$objFile->append("\t'" . $strNamespace . "',");
+							foreach ($arrNamespaces as $strNamespace)
+							{
+								$objFile->append("\t'" . $strNamespace . "',");
+							}
+
+							$objFile->append('));');
 						}
-
-						$objFile->append('));');
 					}
 
 					// Classes

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -84,6 +84,7 @@ class ModuleAutoload extends \BackendModule
 							'register_classes'    => true,
 							'register_templates'  => true,
 						),
+						'autoload/map' => array(),
 					);
 
 					// load the config.ini
@@ -206,6 +207,34 @@ class ModuleAutoload extends \BackendModule
 
 EOT
 					);
+
+					// Class mapping
+					if (!empty($arrConfig['autoload/map']))
+					{
+						$objFile->append(
+<<<EOT
+
+
+/**
+ * Register class mappings
+ */
+RuntimeClassLoader::addClassMappings(array
+(
+EOT
+						);
+
+						foreach ($arrConfig['autoload/map'] as $strRuntimeClass => $strTargetClass)
+						{
+							if (strncmp($strRuntimeClass, 'Runtime\\', 8) !== 0)
+							{
+								$strRuntimeClass = 'Runtime\\' . $strRuntimeClass;
+							}
+
+							$objFile->append("\t'" . $strRuntimeClass . "' => '" . $strTargetClass . "',");
+						}
+
+						$objFile->append('));');
+					}
 
 					// Namespaces
 					if ($arrConfig['autoload']['register_namespaces'])

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -81,6 +81,7 @@ class ModuleAutoload extends \BackendModule
 					$arrConfig = array(
 						'autoload' => array(
 							'register_namespaces' => true,
+							'register_classes'    => true,
 						),
 					);
 
@@ -234,7 +235,7 @@ EOT
 					}
 
 					// Classes
-					if (!empty($arrClassLoader))
+					if ($arrConfig['autoload']['register_classes'] && !empty($arrClassLoader))
 					{
 						$objFile->append(
 <<<EOT

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -82,6 +82,7 @@ class ModuleAutoload extends \BackendModule
 						'autoload' => array(
 							'register_namespaces' => true,
 							'register_classes'    => true,
+							'register_templates'  => true,
 						),
 					);
 
@@ -275,7 +276,7 @@ EOT
 					}
 
 					// Templates
-					if (!empty($arrTplLoader))
+					if ($arrConfig['autoload']['register_templates'] && !empty($arrTplLoader))
 					{
 						$objFile->append(
 <<<EOT

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -78,6 +78,21 @@ class ModuleAutoload extends \BackendModule
 					$arrFiles = array();
 					$arrClassLoader = array();
 					$arrNamespaces = array();
+					$arrConfig = array();
+
+					// load the config.ini
+					if (file_exists(TL_ROOT . '/system/modules/' . $strModule . '/config/config.ini'))
+					{
+						$arrTemp = parse_ini_file(TL_ROOT . '/system/modules/' . $strModule . '/config/config.ini', true);
+
+						foreach (array_keys($arrConfig) as $strSection)
+						{
+							if (isset($arrTemp[$strSection]))
+							{
+								$arrConfig[$strSection] = array_merge($arrConfig[$strSection], $arrTemp[$strSection]);
+							}
+						}
+					}
 
 					// Recursively scan all subfolders
 					$objFiles = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(TL_ROOT . '/system/modules/' . $strModule));


### PR DESCRIPTION
Das hier ist die Fortsetzung des letzten Pull Requests #4526 für echte Namespaces in Contao 3.

Zuerst einmal vorne weg, Leo hat ein paar Commits eingebaut, unter anderem den c496e0d61ff28dbc063ee1719f6472ebd97b9dde. Der Autoloader Registriert nun alle Klassen, egal in welcher Tiefe. Damit ist das DevTool grundsätzlich PSR-0 kompatibel, weil man seine Klassenhierarchie nach PSR-0 aufbauen kann. Das DevTool wird zwar zum registrieren weiterhin benötigt, ich hatte Leo aber bereits gesagt das ich persönlich damit kein Problem habe.
(Für die Entwicklung werde ich vermutlich einen PSR-0 ClassLoader in das ER stellen, ausliefern sollte jeder Entwickler seine Extension allerdings mit einer vollständigen autoload.php).

---

Des weiteren hat Leo den Commit dd4d17f529e4f06b2dba110c7b7260382f7a8162 eingeführt, womit nur noch der 1. Teil des Namespaces registriert wird.

Das größte Problem was wir haben ist die Fähigkeit, Klassen verlustfrei zu überschreiben. Mein Vorschlag aus dem Vorangegangenen Pull Request #4526 ist, den Namespace `Runtime\` als Präfix hinzu zu nehmen. Anstelle der Klasse `Avisota\Mail\Transport` würde man die Klasse `Runtime\Avisota\Mail\Transport` verwenden.
Nach Leos Änderung wäre es aber auch möglich anstelle von `Avisota\Mail\Transport` die Klasse `Mail\Transport` zu verwenden. Das ist quasi das gleiche Prinzip wie mit den Klassen im globalen Namespace. Hier gilt also, wenn eine andere Erweiterung die Klasse `Kunde\Mail\Transport` später definiert, wird diese als Implementierung für `Mail\Transport` verwendet.

2 gültige Lösungen:
- Runtime\ Präfix kommt hinzu
- 1. Namespace Teil fällt weg

Leos Lösung hat meiner Meinung nach allerdings überwiegende Nachteile, gegenüber meiner `Runtime\` Präfix Lösung.

---

Zuerst will ich die Performance der ClassLoaders betrachten, genauer die Prüfungen die durchgeführt werden müssen um eine Klasse zu finden.

Contao ClassLoader

```
1x prüfe ob Klasse in self::$classes existiert
(N+1)x prüfe ob NS+Klasse in self::$classes existiert // N=Anzahl der registrierten Namespaces +1 wegen dem Contao\ Namespace
= (N+2) prüfe Existenz in self::$classes
```

Gehen wir mal davon aus, dass jemand 20 Extensions installiert hat (bei mir ist das zumindest eine übliche Menge, meistens habe ich mehr).

```
= 22x prüfe Existenz in self::$classes für jede Klasse. // Worst-Case
```

Um das ganze nach zu vollziehen muss man sich mit der Arbeitsweise des ClassLoader's auseinander setzen.
https://github.com/contao/core/blob/develop/system/library/Contao/ClassLoader.php#L198
Der Faktor N ensteht durch eine foreach Schleife, mit der alle registrierten Namespaces durchlaufen werden:
https://github.com/contao/core/blob/develop/system/library/Contao/ClassLoader.php#L234

---

Meine Lösung mit dem `Runtime\` Präfix und einem Mapping zum überschreiben von Klassen, hat deutlich weniger überprüfungen.

```
1x prüfe ob Klasse in RuntimeClassLoader::$classMapping existiert
1x prüfe ob Klasse in ClassLoader::$classes existiert
```

Zum prüfen ob die Originalklasse existiert, verwende ich einfach den vorhandenen ClassLoader Stack, dadurch bleibt der `RuntimeClassLoader` schlank und bedient sich bereits vorhandener Logik.

Bei dieser Lösung gäbe es allerdings maximal 2 Prüfungen um die Klasse zu finden (abgesehen vom Fall-Back wo dann der ganze Stack durchlaufen wird), egal wie viele Extensions installiert sind.
Meine Lösung skaliert also besser.

---

Ein weiteres Problem von Leos Lösung sind Kollisionen.
Ein akutes Beispiel ist das Mailer Framework, dort gibt es auch eine Transport-Klasse.
Dann gäbe es plötzlich `Avisota\Mail\Transport`
und es gäbe `Mailer\Mail\Transport`
Beiden würden sich überschreiben obwohl sie nichts mit einander zu tun haben.
Dies ließe sich nur verhindern, in dem man einen Doppel-Vendor (oder wie man das auch immer nennen mag) verwendet.
Die Klassen müssten dann `InfinitySoft\Avisota\Mail\Transport` und `InfinitySoft\Mailer\Mail\Transport` heißen und verwendet werden würden `Avisota\Mail\Transport` und `Mailer\Mail\Transport`.

---

Dem Grunde nach verfolgen beide Lösungen eigentlich das gleiche, Leo nimmst den 1. Namespace-Part weg, ich dichte `Runtime\` hinzu. **Beide** Lösungen sind gewöhnungsbedürftig und nicht Standard-konform.

Alles in allem würde ich allerdings persönlich doch eher zu der `Runtime\` Lösung tendieren, aus folgenden Gründen:
- es geht nichts verloren (bei Leos Lösung geht ein Teil vom Namespace verloren, was zu Verwirrung führen kann)
- die Prüfung im Class Loader skaliert besser.
- die `Runtime\` Variante ist nicht Kollisionsgefährdet (wie ich bereits oben beschrieben habe, besteht durch den Wegfall eines Teils des NS ein Konfliktpotential)

Ansonsten haben beide Lösungen die gleichen Probleme:
- der Entwickler kann das ganze umgehen und direkt `Avisota\Mail\Transport` anstelle von `Mail\Transport` bzw. `Runtime\Avisota\Mail\Transport` verwenden. (hier ließe sich in beiden Fällen eine Warning in den Class Loader einbauen)
- überschreiben lässt sich nur durch automatisches (Leos Variante) oder manuelles (meine Variante) Mapping realisieren

Alles in allem ist immer der Entwickler gefragt, er muss sich an den Core halten oder eben nicht.

---

Für das manuelle Mapping kommt in meinem Fall eine `config/config.ini` zum Einsatz. Dazu baue ich auf den Pull Request #4591 auf, mit dem man als Entwickler das DevTool konfigurieren kann. Z.B. kann man das Registrieren der Namespaces dadurch unterbinden. Diese Idee hatte Leo bei unserem Tel-Gspr. am Freitag, ich habe es jetzt nur mal umgesetzt.

Ich erweitere diese Funktionalität um das Klassen-Mapping, wie das aussieht kann man in meiner Demo Extension anschauen. https://github.com/InfinitySoft/contao3-poc-namespaces-extension/blob/master/system/modules/NamespacesExtension/config/config.ini
