### PR TITLE
Reset cache postHtmlEncoded and postHtmlDecoded in setPost.

### DIFF
--- a/system/modules/core/library/Contao/Input.php
+++ b/system/modules/core/library/Contao/Input.php
@@ -287,6 +287,8 @@ class Input
 
 		unset(static::$arrCache['postEncoded'][$strKey]);
 		unset(static::$arrCache['postDecoded'][$strKey]);
+		unset(static::$arrCache['postHtmlEncoded'][$strKey]);
+		unset(static::$arrCache['postHtmlDecoded'][$strKey]);
 		unset(static::$arrCache['postRaw'][$strKey]);
 
 		if ($varValue === null)


### PR DESCRIPTION
The Input::setPost method does not reset postHtmlEncoded and postHtmlDecoded cache entries.
Because of this, only the first `Input::setPost(..) .. Input::postHtml(..)` will work, but any other `Input::setPost(..) .. Input::postHtml(..)` will only return the cached value from the first call.

``` php
Input::setPost('foo', 'bar');
Input::postHtml('foo');
// will return 'bar'

Input::setPost('foo', 'zap');
Input::postHtml('foo')
// will also return 'bar', not 'zap'
```
