### PR TITLE
Check whether skipFramework exists in install tool

### DIFF
--- a/system/modules/core/library/Contao/Database/Updater.php
+++ b/system/modules/core/library/Contao/Database/Updater.php
@@ -282,7 +282,12 @@ class Updater extends \Controller
 		$this->Database->query("ALTER TABLE `tl_layout` ADD `framework` varchar(255) NOT NULL default ''");
 		$this->Database->query("UPDATE `tl_layout` SET `framework`='a:2:{i:0;s:10:\"layout.css\";i:1;s:11:\"tinymce.css\";}'");
 		$this->Database->query("UPDATE `tl_layout` SET `framework`='a:1:{i:0;s:10:\"layout.css\";}' WHERE skipTinymce=1");
-		$this->Database->query("UPDATE `tl_layout` SET `framework`='' WHERE skipFramework=1");
+		
+		// make sure skipFramework exists (updating from versions < 2.11)
+		if ($this->Database->fieldExists('skipFramework', 'tl_layout'))
+		{
+			$this->Database->query("UPDATE `tl_layout` SET `framework`='' WHERE skipFramework=1");
+		}
 
 		// Add the "ptable" field
 		$this->Database->query("ALTER TABLE `tl_content` ADD ptable varchar(64) NOT NULL default ''");


### PR DESCRIPTION
I've tried to update a 2.9 installation to version 3 RC1 but the install tool fails. I am able to reproduce it as follows (using the old localconfig.php):
1. Use the Contao 3 files and import a 2.9 database
2. Call the install.php
3. Enter the install tool password
4. It tells me that the database is not up-to-date --> execute 2.10 update
5. It tells me that the database is not up-to-date again --> execute step 1 of the Contao 3 update

> Fatal error: Uncaught exception Exception with message Query error: Unknown column 'skipFramework' in 'where clause' (UPDATE `tl_layout` SET `framework`='' WHERE skipFramework=1) thrown in /system/modules/core/library/Contao/Database/Statement.php on line 317

I think `skipFramework` has been added in Contao 2.11 and so updating from < 2.11 fails.
The proposed change fixes this issue :-)
