### PR TITLE
Fixed: comments have been displayed all the time

### DIFF
--- a/system/modules/comments/classes/Comments.php
+++ b/system/modules/comments/classes/Comments.php
@@ -88,8 +88,6 @@ class Comments extends \Frontend
 			$objTemplate->pagination = $objPagination->generate("\n  ");
 		}
 
-		$objTemplate->allowComments = true;
-
 		// Get all published comments
 		if ($limit)
 		{


### PR DESCRIPTION
Don't know whether this is the correct fix but after the update to Contao 3.0 RC1 my event module displayed the comment form although I disabled it in the settings :-)
