### PR TITLE
Fixed a HTML5 deprecated element attribute

### DIFF
--- a/system/modules/core/widgets/ChmodTable.php
+++ b/system/modules/core/widgets/ChmodTable.php
@@ -65,7 +65,7 @@ class ChmodTable extends \Widget
 		{
 			$return .= '
     <tr>
-      <td scope="row" class="th">'.$GLOBALS['TL_LANG']['CHMOD'][$v].'</td>';
+      <th scope="row" class="th">'.$GLOBALS['TL_LANG']['CHMOD'][$v].'</th>';
 
 			// Add checkboxes
 			for ($j=1; $j<=6; $j++)


### PR DESCRIPTION
In HTML5, the `scope` attribute on the [table `<td>` element](http://www.w3.org/TR/html-markup/td.html) is obsolete and thus no longer supported. Therefore, I have replaced the `<td>` tag by an [`<th>` table header element](http://www.pdprogrammeur.com/tables-and-html5-table/) (according [WCAG 2.0](http://www.w3.org/TR/WCAG20-TECHS/H63)) in the `ChmodTable` widget class.

[Contao 3.0.RC1 Commit: f796f96b7d01b54a48efe624abc8c4446733711c]
