### PR TITLE
Fixed a wrong URL ampersand escaping

### DIFF
--- a/contao/main.php
+++ b/contao/main.php
@@ -178,7 +178,8 @@ class Main extends Backend
 
 			if ($arrRow['editUrl'] != '')
 			{
-				$arrRow['editUrl'] = preg_replace('/&(amp;)?rt=[a-f0-9]+/', '&amp;rt=' . REQUEST_TOKEN, $arrRow['editUrl']);
+				$arrRow['editUrl'] = preg_replace('/rt=[a-f0-9]+/', 'rt=' . REQUEST_TOKEN, $arrRow['editUrl']);
+				$arrRow['editUrl'] = preg_replace('/&(amp;)?/', '&amp;', $arrRow['editUrl']);
 			}
 
 			$arrVersions[] = $arrRow;

--- a/system/modules/core/templates/be_welcome.html5
+++ b/system/modules/core/templates/be_welcome.html5
@@ -21,13 +21,13 @@
 <table class="tl_listing">
 <thead>
 <tr>
-  <th><?php echo $GLOBALS['TL_LANG']['MSC']['date']; ?></th>
-  <th><?php echo $GLOBALS['TL_LANG']['MSC']['user']; ?></th>
-  <th><?php echo $GLOBALS['TL_LANG']['MSC']['table']; ?></th>
-  <th>ID</th>
-  <th><?php echo $GLOBALS['TL_LANG']['MSC']['description']; ?></th>
-  <th><?php echo $GLOBALS['TL_LANG']['MSC']['version']; ?></th>
-  <th>&nbsp;</th>
+  <th scope="col"><?php echo $GLOBALS['TL_LANG']['MSC']['date']; ?></th>
+  <th scope="col"><?php echo $GLOBALS['TL_LANG']['MSC']['user']; ?></th>
+  <th scope="col"><?php echo $GLOBALS['TL_LANG']['MSC']['table']; ?></th>
+  <th scope="col">ID</th>
+  <th scope="col"><?php echo $GLOBALS['TL_LANG']['MSC']['description']; ?></th>
+  <th scope="col"><?php echo $GLOBALS['TL_LANG']['MSC']['version']; ?></th>
+  <th scope="col">&nbsp;</th>
 </tr>
 </thead>
 <tbody>


### PR DESCRIPTION
The URL ampersand escaping in the `contao/main.php` did not work properly. I've fixed this issue and added &ndash; on this occasion &ndash; also the `scope` attribute for the table header cells (versions overview table)

[Contao 3.0.RC1 Commit: f796f96b7d01b54a48efe624abc8c4446733711c]
