### PR TITLE
Module dependencies

### DIFF
--- a/system/modules/calendar/config/depend.php
+++ b/system/modules/calendar/config/depend.php
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TL_DEPEND']['calendar'][] = 'core';

--- a/system/modules/comments/config/depend.php
+++ b/system/modules/comments/config/depend.php
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TL_DEPEND']['comments'][] = 'core';

--- a/system/modules/core/library/Contao/Config.php
+++ b/system/modules/core/library/Contao/Config.php
@@ -25,7 +25,11 @@ namespace Contao;
  */
 class Config
 {
+	
+	const LOCALCONFIG_FILE = 'system/config/localconfig.php';
 
+	const MODULES_CACHE_FILE = 'system/cache/modules.php';
+	
 	/**
 	 * Object instance (Singleton)
 	 * @var \Config
@@ -67,13 +71,8 @@ class Config
 	 * @var array
 	 */
 	protected $arrData = array();
-
-	/**
-	 * Cache
-	 * @var array
-	 */
-	protected $arrCache = array();
-
+	
+	protected $arrModules;
 
 	/**
 	 * Prevent direct instantiation (Singleton)
@@ -121,149 +120,32 @@ class Config
 	 */
 	protected function initialize()
 	{
+		$this->Files = \Files::getInstance();
+		
 		// Load the default files
 		include TL_ROOT . '/system/config/default.php';
 		include TL_ROOT . '/system/config/agents.php';
-
+		
+		$this->blnHasLcf = file_exists(TL_ROOT . '/system/config/localconfig.php');
+		
+		if($this->blnHasLcf) {
+			include TL_ROOT . '/' . static::LOCALCONFIG_FILE;
+		}
+		
 		// Get the module configuration files
-		foreach ($this->getActiveModules() as $strModule)
-		{
-			$strFile = TL_ROOT . '/system/modules/' . $strModule . '/config/config.php';
-
-			if (file_exists($strFile))
-			{
+		foreach($this->getActiveModules() as $strModule) {
+			$strFile = static::getModuleBasePath($strModule) . '/config/config.php';
+		
+			if(file_exists($strFile)) {
 				include $strFile;
 			}
 		}
-
-		// Return if there is no local configuration file yet
-		if (!file_exists(TL_ROOT . '/system/config/localconfig.php'))
-		{
-			return;
-		}
-
-		$this->blnHasLcf = true;
-		include TL_ROOT . '/system/config/localconfig.php';
-
-		// Read the local configuration file
-		$strMode = 'top';
-		$resFile = fopen(TL_ROOT . '/system/config/localconfig.php', 'rb');
-
-		while (!feof($resFile))
-		{
-			$strLine = fgets($resFile);
-			$strTrim = trim($strLine);
-
-			if ($strTrim == '?>')
-			{
-				continue;
-			}
-
-			if ($strTrim == '### INSTALL SCRIPT START ###')
-			{
-				$strMode = 'data';
-				continue;
-			}
-
-			if ($strTrim == '### INSTALL SCRIPT STOP ###')
-			{
-				$strMode = 'bottom';
-				continue;
-			}
-
-			if ($strMode == 'top')
-			{
-				$this->strTop .= $strLine;
-			}
-			elseif ($strMode == 'bottom')
-			{
-				$this->strBottom .= $strLine;
-			}
-			elseif ($strTrim != '')
-			{
-				$arrChunks = array_map('trim', explode('=', $strLine, 2));
-				$this->arrData[$arrChunks[0]] = $arrChunks[1];
-			}
-		}
-
-		fclose($resFile);
-	}
-
-
-	/**
-	 * Save the local configuration file
-	 */
-	public function save()
-	{
-		if ($this->strTop == '')
-		{
-			$this->strTop = '<?php';
-		}
-
-		$strFile  = trim($this->strTop) . "\n\n";
-		$strFile .= "### INSTALL SCRIPT START ###\n";
-
-		foreach ($this->arrData as $k=>$v)
-		{
-			$strFile .= "$k = $v\n";
-		}
-
-		$strFile .= "### INSTALL SCRIPT STOP ###\n";
-		$this->strBottom = trim($this->strBottom);
-
-		if ($this->strBottom != '')
-		{
-			$strFile .= $this->strBottom . "\n";
-		}
-
-		$strTemp = md5(uniqid(mt_rand(), true));
-
-		// Write to a temp file first
-		$objFile = fopen(TL_ROOT . '/system/tmp/' . $strTemp, 'wb');
-		fputs($objFile, $strFile);
-		fclose($objFile);
-
-		// Make sure the file has been written (see #4483)
-		if (!filesize(TL_ROOT . '/system/tmp/' . $strTemp))
-		{
-			$this->log('The local configuration file could not be written. Have your reached your quota limit?');
-			return;
-		}
-
-		// Then move the file to its final destination
-		$this->Files->rename('system/tmp/' . $strTemp, 'system/config/localconfig.php');
-
-		// Reset the Zend Optimizer+ cache (unfortunately no API to delete just a single file)
-		if (function_exists('accelerator_reset'))
-		{
-			accelerator_reset();
-		}
-
-		// Recompile the APC file (thanks to Trenker)
-		if (function_exists('apc_compile_file') && !ini_get('apc.stat'))
-		{
-			apc_compile_file('system/config/localconfig.php');
-		}
-
-		// Purge the eAccelerator cache (thanks to Trenker)
-		if (function_exists('eaccelerator_purge') && !ini_get('eaccelerator.check_mtime'))
-		{
-			@eaccelerator_purge();
-		}
-
-		// Purge the XCache cache (thanks to Trenker)
-		if (function_exists('xcache_count') && !ini_get('xcache.stat'))
-		{
-			if (($count = xcache_count(XC_TYPE_PHP)) > 0)
-			{
-				for ($id=0; $id<$count; $id++)
-				{
-					xcache_clear_cache(XC_TYPE_PHP, $id);
-				}
-			}
+		
+		if($this->blnHasLcf) {
+			include TL_ROOT . '/' . static::LOCALCONFIG_FILE;
+			list($this->strTop, $this->strBottom, $this->arrData) = $this->readLcf();
 		}
 	}
-
 
 	/**
 	 * Return true if the installation is completed
@@ -275,7 +157,6 @@ class Config
 		return $this->blnHasLcf;
 	}
 
-
 	/**
 	 * Return all active modules (starting with "core") as array
 	 * 
@@ -283,42 +164,50 @@ class Config
 	 * 
 	 * @return array An array of active modules
 	 */
-	public function getActiveModules($blnNoCache=false)
-	{
-		if (!$blnNoCache && isset($this->arrCache['activeModules']))
-		{
-			return (array) $this->arrCache['activeModules']; // (array) = PHP 5.1.2 fix
+	public function getActiveModules($blnNoCache = false, $blnWriteCache = true) {
+		if(!$blnNoCache && isset($this->arrModules)) {
+			return $this->arrModules;
 		}
-
-		$arrActiveModules = array();
-		$arrCoreModules = array('core', 'calendar', 'comments', 'devtools', 'faq', 'listing', 'news', 'newsletter', 'repository');
-		$arrExtensionModules = scan(TL_ROOT . '/system/modules');
-
-		// Load the core modules first
-		foreach ($arrCoreModules as $strModule)
-		{
-			if (!file_exists(TL_ROOT . '/system/modules/' . $strModule . '/.skip'))
-			{
-				$arrActiveModules[] = $strModule;
+		
+		if($GLOBALS['TL_CONFIG']['coreOnlyMode']) {
+			$arrModules = static::scanModules(true, true);
+			
+		} else {
+			$arrModules = static::scanModules(false);
+			$arrInactive = deserialize($GLOBALS['TL_CONFIG']['inactiveModules']);
+			$arrInactive && $arrModules = array_diff($arrModules, $arrInactive);
+			
+			if(!$blnNoCache && file_exists(TL_ROOT . '/' . static::MODULES_CACHE_FILE)) {
+				$arrCached = include TL_ROOT . '/' . static::MODULES_CACHE_FILE;
 			}
-		}
-
-		// Then load the extension modules
-		if (!$GLOBALS['TL_CONFIG']['coreOnlyMode'])
-		{
-			foreach ($arrExtensionModules as $strModule)
-			{
-				if (strncmp($strModule, '.', 1) !== 0 && !in_array($strModule, $arrCoreModules) && is_dir(TL_ROOT . '/system/modules/' . $strModule) && !file_exists(TL_ROOT . '/system/modules/' . $strModule . '/.skip'))
-				{
-					$arrActiveModules[] = $strModule;
+			
+			if($arrCached && count($arrCached) == count($arrModules) && !array_diff($arrCached, $arrModules)) {
+				$arrModules = $arrCached;
+				
+			} else {
+				$arrModules = array_filter($arrModules, 'static::isModuleActive');
+				
+				$arrDepend = static::loadDependencyMap($arrModules);
+				list($arrModules, $arrCycles, $arrUnresolvable) = static::resolveDependencies($arrModules, $arrDepend);
+				if($arrCycles || $arrUnresolvable) {
+					$this->log();
 				}
+				
+				$blnWriteCache && $this->writeModules($arrModules);
 			}
 		}
-
-		$this->arrCache['activeModules'] = $arrActiveModules;
-		return $arrActiveModules;
+		
+		$this->arrModules = $arrModules;
+		return $arrModules;
 	}
-
+	
+	/**
+	 * Save the local configuration file
+	 */
+	public function save()
+	{
+		$this->writeLcf();
+	}
 
 	/**
 	 * Add a configuration variable to the local configuration file
@@ -329,7 +218,6 @@ class Config
 	public function add($strKey, $varValue)
 	{
 		$this->blnIsModified = true;
-		$this->Files = \Files::getInstance(); // Required in the destructor
 		$this->arrData[$strKey] = $this->escape($varValue) . ';';
 	}
 
@@ -372,7 +260,6 @@ class Config
 	public function delete($strKey)
 	{
 		$this->blnIsModified = true;
-		$this->Files = \Files::getInstance(); // Required in the destructor
 		unset($this->arrData[$strKey]);
 	}
 
@@ -411,4 +298,281 @@ class Config
 
 		return $varValue;
 	}
+
+	protected function readLcf() {
+		if(!$this->blnHasLcf) {
+			return array('', '', array());
+		}
+		
+		// Read the local configuration file
+		$strTop = $strBottom = '';
+		$arrData = array();
+		$strMode = 'top';
+		$resFile = fopen(TL_ROOT . '/' . static::LOCALCONFIG_FILE, 'rb');
+		
+		while (!feof($resFile))
+		{
+			$strLine = fgets($resFile);
+			$strTrim = trim($strLine);
+		
+			if ($strTrim == '?>')
+			{
+				continue;
+			}
+		
+			if ($strTrim == '### INSTALL SCRIPT START ###')
+			{
+				$strMode = 'data';
+				continue;
+			}
+		
+			if ($strTrim == '### INSTALL SCRIPT STOP ###')
+			{
+				$strMode = 'bottom';
+				continue;
+			}
+		
+			if ($strMode == 'top')
+			{
+				$strTop .= $strLine;
+			}
+			elseif ($strMode == 'bottom')
+			{
+				$strBottom .= $strLine;
+			}
+			elseif ($strTrim != '')
+			{
+				$arrChunks = array_map('trim', explode('=', $strLine, 2));
+				$arrData[$arrChunks[0]] = $arrChunks[1];
+			}
+		}
+		
+		fclose($resFile);
+		
+		return array($strTop, $strBottom, $arrData);
+	}
+	
+	protected function writeLcf() {
+		$strTop = trim($this->strTop);
+		$strContent = ($strTop == '' ? '<?php' : $strTop) . "\n\n";
+		$strContent .= "### INSTALL SCRIPT START ###\n";
+		
+		foreach($this->arrData as $k=>$v) $strContent .= $k . ' = ' . $v . "\n";
+		
+		$strContent .= "### INSTALL SCRIPT STOP ###\n";
+		$strBottom = trim($this->strBottom);
+		$strBottom == '' && $strContent .= $strBottom . "\n";
+		
+		$strTemp = static::writeTempFile($strContent);
+		
+		if(!$strTemp) {
+			$this->log('The local configuration file could not be written. Have you reached your quota limit?');
+			return false;
+		}
+		
+		// Then move the file to its final destination
+		$this->Files->rename($strTemp, static::LOCALCONFIG_FILE);
+		static::clearCaches(static::LOCALCONFIG_FILE);
+		
+		return true;
+	}
+	
+	protected function writeModules($arrModules) {
+		$strModules = '<?php return ' . var_export($arrModules, true) . ';';
+		$strTemp = static::writeTempFile($strModules);
+		
+		if(!$strTemp) {
+			$this->log('Modules cache file could not be written. Have you reached your quota limit?');
+			return false;
+		}
+		
+		$this->Files->rename($strTemp, static::MODULES_CACHE_FILE);
+		static::clearCaches(static::MODULES_CACHE_FILE);
+		
+		return true;
+	}
+	
+	public static function isModuleActive($strModule) {
+		return $strModule[0] != '.' && !file_exists(static::getModuleBasePath($strModule) . '/.skip');
+	}
+	
+	public static function getModuleBasePath($strModule) {
+		return TL_ROOT . '/system/modules/' . $strModule;
+	}
+	
+	public static function writeTempFile($strContent) {
+		$strTemp = 'system/tmp/' . md5(uniqid(mt_rand(), true));
+		
+		// Write to a temp file first
+		$objFile = fopen(TL_ROOT . '/' . $strTemp, 'wb');
+		fwrite($objFile, $strContent);
+		fclose($objFile);
+		
+		// Make sure the file has been written (see #4483)
+		return filesize(TL_ROOT . '/' . $strTemp) == 0 ? null : $strTemp;
+	}
+
+	public static function clearCaches($strFile) {
+		// Reset the Zend Optimizer+ cache (unfortunately no API to delete just a single file)
+		if (function_exists('accelerator_reset'))
+		{
+			accelerator_reset();
+		}
+		
+		// Recompile the APC file (thanks to Trenker)
+		if (function_exists('apc_compile_file') && !ini_get('apc.stat'))
+		{
+			apc_compile_file($strFile);
+		}
+		
+		// Purge the eAccelerator cache (thanks to Trenker)
+		if (function_exists('eaccelerator_purge') && !ini_get('eaccelerator.check_mtime'))
+		{
+			@eaccelerator_purge();
+		}
+		
+		// Purge the XCache cache (thanks to Trenker)
+		if (function_exists('xcache_count') && !ini_get('xcache.stat'))
+		{
+			if (($count = xcache_count(XC_TYPE_PHP)) > 0)
+			{
+				for ($id=0; $id<$count; $id++)
+				{
+				xcache_clear_cache(XC_TYPE_PHP, $id);
+				}
+			}
+		}
+	}
+	
+	public static function scanModules($blnActiveOnly = true, $blnCoreOnlyMode = false) {
+		$arrModules = array(
+			'core', 'calendar', 'comments',
+			'devtools', 'faq', 'listing',
+			'news', 'newsletter', 'repository'
+		);
+		
+		if(!$blnCoreOnlyMode) {
+			$arrExtensions = scan(TL_ROOT . '/system/modules');
+			$arrModules = array_merge($arrModules, array_diff($arrExtensions, $arrModules));
+		}
+		
+		return $blnActiveOnly ? array_filter($arrModules, 'static::isModuleActive') : $arrModules;
+	}
+	
+	public static function loadDependencyMap($arrModules) {
+		unset($GLOBALS['TL_DEPEND']);
+		
+		foreach($arrModules as $strModule) {
+			$strDepend = static::getModuleBasePath($strModule) . '/config/depend.php';
+			
+			if(file_exists($strDepend)) {
+				include $strDepend;
+			}
+		}
+		
+		return $GLOBALS['TL_DEPEND'];
+	}
+	
+	public static function resolveDependencies($arrModules, $arrDepend) {
+		// prepare input and early out checks
+		if(!is_array($arrModules) || !$arrModules || !is_array($arrDepend) || !$arrDepend) {
+			return array($arrModules, array(), array());
+		}
+	
+		$arrModules = array_flip($arrModules);
+		$arrDepend = array_intersect_key($arrDepend, $arrModules);
+		foreach($arrDepend as &$arrDependencies) {
+			$arrDependencies = array_intersect_key(array_flip($arrDependencies), $arrModules);
+		}
+		unset($arrDependencies);
+	
+		$arrDepend = array_filter($arrDepend);
+		if(!$arrDepend) {
+			return array(array_keys($arrModules), array(), array());
+		}
+	
+		// calculate dependency closure
+		$intCount = 0;
+		do {
+			$intOldCount = $intCount;
+			foreach($arrDepend as $strDependant => &$arrDependencies) {
+				$arrStep = array_intersect_key($arrDepend, $arrDependencies);
+				if($arrStep) {
+					$arrStep[] = $arrDependencies;
+					$arrDependencies = call_user_func_array('array_merge', $arrStep);
+				}
+			}
+			$intCount = array_sum(array_map('count', $arrDepend));
+		} while($intOldCount != $intCount);
+		unset($arrDependencies);
+		
+		// check for cycles
+		$arrCycles = array();
+		foreach($arrDepend as $strDependant => $arrDependencies) {
+			if(isset($arrDependencies[$strDependant])) {
+				$arrCycles[$strDependant] = true;
+			}
+		}
+		
+		// special treatment for core modules
+		$arrCore = array(
+			'core', 'calendar', 'comments',
+			'devtools', 'faq', 'listing',
+			'news', 'newsletter', 'repository'
+		);
+		$arrCore = array_intersect_key(array_fill_keys($arrCore, array()), $arrModules);
+	
+		// core modules are involved in cycles, drop dependency calculation
+		if(array_intersect_key($arrCycles, $arrCore)) {
+			$arrModules = array_keys($arrModules);
+			return array($arrModules, array_keys($arrCycles), $arrModules);
+		}
+	
+		// remove cycles from dependency closure
+		$arrDepend = array_diff_key($arrDepend, $arrCycles);
+		// get core dependencies
+		$arrCore = array_merge($arrCore, array_intersect_key($arrDepend, $arrCore));
+	
+		// add core modules as dependencies for non-core modules,
+		// but respect injected core dependency
+		foreach($arrModules as $strModule => $_) {
+			if(!isset($arrCore[$strModule])) {
+				$arrStep = array();
+				foreach($arrCore as $strCore => $arrDependencies) {
+					if(!isset($arrDependencies[$strModule])) {
+						$arrStep[$strCore] = $arrDependencies;
+					}
+				}
+				if($arrStep) {
+					$arrStep[] = array_flip(array_keys($arrStep));
+					isset($arrDepend[$strModule]) && $arrStep[] = $arrDepend[$strModule];
+					$arrDepend[$strModule] = call_user_func_array(
+						'array_merge', $arrStep
+					);
+				}
+			}
+		}
+		
+		// add independant modules (either its just the core module or third party modules, which injected a core module dependency)
+		$arrResolved = array_diff_key($arrModules, $arrDepend, $arrCycles);
+	
+		// add dependant modules
+		$intCount = count($arrDepend);
+		do {
+			$intOldCount = $intCount;
+			foreach($arrDepend as $strDependant => $arrDependencies) {
+				if(!array_diff_key($arrDependencies, $arrResolved)) {
+					$arrResolved[$strDependant] = true;
+				}
+			}
+			$arrDepend = array_diff_key($arrDepend, $arrResolved);
+			$intCount = count($arrDepend);
+		} while($intCount != $intOldCount);
+	
+		// add cycles and unresolvable dependencies
+		$arrResolved = array_merge($arrResolved, $arrCycles, $arrDepend);
+	
+		return array(array_keys($arrResolved), array_keys($arrCycles), array_keys($arrDepend));
+	}
+	
 }

--- a/system/modules/core/library/Contao/Config.php
+++ b/system/modules/core/library/Contao/Config.php
@@ -283,18 +283,13 @@ class Config
 			return $varValue ? 'true' : 'false';
 		}
 
-		if ($varValue == 'true')
+		if ($varValue == 'true' || $varValue == 'false')
 		{
-			return 'true';
+			return strval($varValue);
 		}
 
-		if ($varValue == 'false')
-		{
-			return 'false';
-		}
-
-		$varValue = preg_replace('/[\n\r\t]+/', ' ', str_replace("'", "\\'", $varValue));
-		$varValue = "'" . preg_replace('/ {2,}/', ' ', $varValue) . "'";
+		$varValue = preg_replace('/[\n\r\t ]+/', ' ', str_replace("'", "\\'", $varValue));
+		$varValue = "'" . $varValue . "'";
 
 		return $varValue;
 	}

--- a/system/modules/core/library/Contao/Config.php
+++ b/system/modules/core/library/Contao/Config.php
@@ -190,7 +190,7 @@ class Config
 				$arrDepend = static::loadDependencyMap($arrModules);
 				list($arrModules, $arrCycles, $arrUnresolvable) = static::resolveDependencies($arrModules, $arrDepend);
 				if($arrCycles || $arrUnresolvable) {
-					$this->log();
+					$this->log('Errors in dependency definitions. Cycles: ' . implode(',', $arrCycles) . ' - Unresolvable: ' . implode(',', $arrUnresolvable));
 				}
 				
 				$blnWriteCache && $this->writeModules($arrModules);

--- a/system/modules/devtools/config/depend.php
+++ b/system/modules/devtools/config/depend.php
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TL_DEPEND']['devtools'][] = 'core';

--- a/system/modules/faq/config/depend.php
+++ b/system/modules/faq/config/depend.php
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TL_DEPEND']['faq'][] = 'core';

--- a/system/modules/listing/config/depend.php
+++ b/system/modules/listing/config/depend.php
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TL_DEPEND']['listing'][] = 'core';

--- a/system/modules/news/config/depend.php
+++ b/system/modules/news/config/depend.php
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TL_DEPEND']['news'][] = 'core';

--- a/system/modules/newsletter/config/depend.php
+++ b/system/modules/newsletter/config/depend.php
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TL_DEPEND']['newsletter'][] = 'core';

--- a/system/modules/repository/config/depend.php
+++ b/system/modules/repository/config/depend.php
@@ -1,0 +1,3 @@
+<?php
+
+$GLOBALS['TL_DEPEND']['repository'][] = 'core';


### PR DESCRIPTION
Extensive tests required.
Dependency calculation tested with synthetic use cases.

Behavior:
Cycles will be dropped from the dependency map.
If a core module is involved in a cycle, complete dependency calculation is canceled and legacy module order is used (core modules before alphabetical rest).
Each non-core module's dependency map is extended with each core module and their dependency map, that does not create a cycle.
Cycles and unresolvable modules will be added at the end of the module order.

How to define dependencies:
Create a depend.php within the config folder of your module and add entries to the dependency map.
Multiple own dependencies:
`$GLOBALS['TL_DEPEND']['myModule'][] = 'otherModule';`
`$GLOBALS['TL_DEPEND']['myModule'][] = 'otherModule2';`
Injected dependencies:
`$GLOBALS['TL_DEPEND']['anOtherModule'][] = 'myModule';`
Injected core dependencies:
`$GLOBALS['TL_DEPEND']['core'][] = 'myModule';`
