### PR TITLE
Fix redirecting to index.php in BackendUser class

### DIFF
--- a/system/modules/core/classes/BackendUser.php
+++ b/system/modules/core/classes/BackendUser.php
@@ -2,9 +2,9 @@
 
 /**
  * Contao Open Source CMS
- * 
+ *
  * Copyright (C) 2005-2012 Leo Feyer
- * 
+ *
  * @package Core
  * @link    http://contao.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL
@@ -161,7 +161,7 @@ class BackendUser extends \User
 		// Redirect to the last page visited upon login
 		if (\Environment::get('script') == 'contao/main.php' || \Environment::get('script') == 'contao/preview.php')
 		{
-			$strRedirect .= '?referer=' . base64_encode(\Environment::get('request'));
+			$strRedirect .= 'index.php?referer=' . base64_encode(\Environment::get('request'));
 		}
 
 		// Force JavaScript redirect on Ajax requests (IE requires an absolute link)


### PR DESCRIPTION
This PR fix a bug with wrong redirecting in backend when systen generates url like: `contao/?redirect=...`. And in case when `URL suffix` equals `/` in `Settings` section and activated `.htaccess` file with code like:

```
  RewriteCond %{REQUEST_FILENAME} !-f
  RewriteRule .*\/$ index.php [L]
```

In this case system shows message `Page not found` because of trying to open page `http://domain/contao/?redirect=...`

So, redirecting url should be as `contao/index.php?redirect=...` and not `contao/?redirect=...`
