### PR TITLE
Correctly search for namespace declaration.

### DIFF
--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -118,17 +118,19 @@ class ModuleAutoload extends \BackendModule
 					// Scan for classes
 					foreach ($arrFiles as $strFile)
 					{
+						$strClInRegexp = '#(class|interface) ' . preg_quote(basename($strFile, '.php')) . '#S';
+
 						// Read as long as needed to get namespace and class declaration
 						$strBuffer = '';
 						$fh = fopen(TL_ROOT . '/system/modules/' . $strModule . '/' . $strFile, 'rb');
-						while (!feof($fh) && (strpos($strBuffer, 'class ' . basename($strFile, '.php')) === false))
+						while (!feof($fh) && !preg_match($strClInRegexp, $strBuffer))
 						{
 							$strBuffer .= fread($fh, 1200);
 						}
 						fclose($fh);
 
 						// The file does not contains a class
-						if (strpos($strBuffer, 'class ' . basename($strFile, '.php')) === false) {
+						if (!preg_match($strClInRegexp, $strBuffer)) {
 							continue;
 						}
 

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -123,7 +123,7 @@ class ModuleAutoload extends \BackendModule
 						$strBuffer = fread($fh, 1200);
 						fclose($fh);
 
-						if (strpos($strBuffer, 'namespace') === false)
+						if (!preg_match('/namespace ([^; ]+);/s', $strBuffer))
 						{
 							$strNamespace = '';
 						}

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -127,6 +127,11 @@ class ModuleAutoload extends \BackendModule
 						}
 						fclose($fh);
 
+						// The file does not contains a class
+						if (strpos($strBuffer, 'class ' . basename($strFile, '.php')) === false) {
+							continue;
+						}
+
 						// By default use global config
 						$arrCurrentConfig = $arrConfig;
 

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -118,6 +118,15 @@ class ModuleAutoload extends \BackendModule
 					// Scan for classes
 					foreach ($arrFiles as $strFile)
 					{
+						// Read as long as needed to get namespace and class declaration
+						$strBuffer = '';
+						$fh = fopen(TL_ROOT . '/system/modules/' . $strModule . '/' . $strFile, 'rb');
+						while (!feof($fh) && (strpos($strBuffer, 'class ' . basename($strFile, '.php')) === false))
+						{
+							$strBuffer .= fread($fh, 1200);
+						}
+						fclose($fh);
+
 						// By default use global config
 						$arrCurrentConfig = $arrConfig;
 
@@ -131,11 +140,6 @@ class ModuleAutoload extends \BackendModule
 								break;
 							}
 						}
-
-						// Read the first 1200 characters of the file (should include the namespace tag)
-						$fh = fopen(TL_ROOT . '/system/modules/' . $strModule . '/' . $strFile, 'rb');
-						$strBuffer = fread($fh, 1200);
-						fclose($fh);
 
 						if (!preg_match('/namespace ([^; ]+);/s', $strBuffer))
 						{
@@ -179,6 +183,9 @@ class ModuleAutoload extends \BackendModule
 							$arrClassLoader[$strKey] = 'system/modules/' . $strModule . '/' . $strFile;
 							$intClassWidth = max(strlen($strKey), $intClassWidth);
 						}
+
+						// Memory cleanup
+						unset($strBuffer);
 					}
 
 					$intTplWidth = 0;

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -130,9 +130,12 @@ class ModuleAutoload extends \BackendModule
 						fclose($fh);
 
 						// The file does not contains a class
-						if (!preg_match($strClInRegexp, $strBuffer)) {
+						if (!preg_match($strClInRegexp, $strBuffer, $arrMatch)) {
 							continue;
 						}
+
+						// class or interface
+						$strType = $arrMatch[1];
 
 						// By default use global config
 						$arrCurrentConfig = $arrConfig;
@@ -176,7 +179,7 @@ class ModuleAutoload extends \BackendModule
 								$arrCompat[$strModule][$strRest][] = array
 								(
 									'namespace' => $strFirst,
-									'class'	 => basename($strFile, '.php'),
+									$strType    => basename($strFile, '.php'),
 									'abstract'  => preg_match('/^.*abstract class [^;]+.*$/s', $strBuffer)
 								);
 							}
@@ -376,7 +379,12 @@ EOT
 
 						foreach ($arrClasses as $arrClass)
 						{
-							$objFile->append("\t" . ($arrClass['abstract'] ? 'abstract ' : '') . 'class ' . $arrClass['class'] . ' extends \\' . $arrClass['namespace'] . '\\' . ($strNamespace ? $strNamespace . '\\' : '') . $arrClass['class'] . ' {}');
+							if (isset($arrClass['class'])) {
+								$objFile->append("\t" . ($arrClass['abstract'] ? 'abstract ' : '') . 'class ' . $arrClass['class'] . ' extends \\' . $arrClass['namespace'] . '\\' . ($strNamespace ? $strNamespace . '\\' : '') . $arrClass['class'] . ' {}');
+							}
+							else if (isset($arrClass['interface'])) {
+								$objFile->append("\t" . 'interface ' . $arrClass['interface'] . ' extends \\' . $arrClass['namespace'] . '\\' . ($strNamespace ? $strNamespace . '\\' : '') . $arrClass['interface'] . ' {}');
+							}
 						}
 
 						$objFile->append('}');

--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -376,7 +376,7 @@ EOT
 
 						foreach ($arrClasses as $arrClass)
 						{
-							$objFile->append("\t" . ($arrClass['abstract'] ? 'abstract ' : '') . 'class ' . $arrClass['class'] . ' extends ' . $arrClass['namespace'] . '\\' . ($strNamespace ? $strNamespace . '\\' : '') . $arrClass['class'] . ' {}');
+							$objFile->append("\t" . ($arrClass['abstract'] ? 'abstract ' : '') . 'class ' . $arrClass['class'] . ' extends \\' . $arrClass['namespace'] . '\\' . ($strNamespace ? $strNamespace . '\\' : '') . $arrClass['class'] . ' {}');
 						}
 
 						$objFile->append('}');


### PR DESCRIPTION
The autoload creator will fail, if there is no namespace in the PHP file, but the string _namespace_ in the first 1024 bytes.

A working live example:

**_MyClass.php**_

``` php
<?php

/**
 * Some package documentation
 */

/**
 * Class MyClass
 */
class MyClass {
    /**
     * The xml namespace.
     */
    const NS = 'foobar';

    // more code ...
}
```

The documentation contains the keyword _namespace_ but there is no php namespace.
In this case, the complete 1024 bytes will be added into the autoload.php like this (I expect the 1024 bytes ends after the "NS ="):

**_autoload.php**_

``` php
/**
 * Register the classes
 */
ClassLoader::addClasses(array
(
    '<?php

/**
 * Some package documentation
 */

/**
 * Class MyClass
 */
class MyClass {
    /**
     * The xml namespace.
     */
    const NS =' => 'system/modules/my/MyClass.php'
);
```

I change the test if there is a namespace declaration in the buffer into an regexp to solve this problem.
