### PR TITLE
Make possible to configure the model class for a dc table.

### DIFF
--- a/system/modules/core/library/Contao/System.php
+++ b/system/modules/core/library/Contao/System.php
@@ -758,6 +758,11 @@ abstract class System
 	 */
 	public static function getModelClassFromTable($strTable)
 	{
+		if (isset($GLOBALS['TL_DCA'][$strTable]['config']['model']))
+		{
+			return $GLOBALS['TL_DCA'][$strTable]['config']['model'];
+		}
+
 		$arrChunks = explode('_', $strTable);
 
 		if ($arrChunks[0] == 'tl')


### PR DESCRIPTION
You try to gues the model class name from the table name in the `System::getModelClassFromTable` method. But in my case, the Model is inside of a namespace, like `InfinitySoft\Foo\Model\BarModel`.
With this little patch I can configure my own model in the DCA:

``` php
$GLOBALS['TL_DCA']['tl_bar'] = array(
    'config' => array(
        ...
        'model' => 'Foo\Model\BarModel'
    ),
    ...
);
```
