### PR TITLE
Add missing \ at the beginning of the extending class in the ide_compat file

### DIFF
--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -345,7 +345,7 @@ EOT
 
 						foreach ($arrClasses as $arrClass)
 						{
-							$objFile->append("\t" . ($arrClass['abstract'] ? 'abstract ' : '') . 'class ' . $arrClass['class'] . ' extends ' . $arrClass['namespace'] . '\\' . ($strNamespace ? $strNamespace . '\\' : '') . $arrClass['class'] . ' {}');
+							$objFile->append("\t" . ($arrClass['abstract'] ? 'abstract ' : '') . 'class ' . $arrClass['class'] . ' extends \\' . $arrClass['namespace'] . '\\' . ($strNamespace ? $strNamespace . '\\' : '') . $arrClass['class'] . ' {}');
 						}
 
 						$objFile->append('}');


### PR DESCRIPTION
For namespaced classes, the `ide_compat.php` looks like this:

``` php
namespace Foo {
    class Bar extends Dev\Foo\Bar {}
}
```

But this means, the class `Bar` extends the class `Foo\Dev\Foo\Bar` because the leading `\` is missing ;-)

Correct is:

``` php
namespace Foo {
    class Bar extends \Dev\Foo\Bar {}
}
```
