### PR TITLE
Use fwrite instead of fputs and taking into account of the function result

### DIFF
--- a/system/modules/core/library/Contao/File.php
+++ b/system/modules/core/library/Contao/File.php
@@ -414,8 +414,7 @@ class File extends \System
 			}
 		}
 
-		fputs($this->resFile, $varData);
-		return true;
+		return (fwrite($this->resFile, $varData) !== false);
 	}
 
 

--- a/system/modules/core/library/Contao/Files/Ftp.php
+++ b/system/modules/core/library/Contao/Files/Ftp.php
@@ -172,10 +172,12 @@ class Ftp extends \Files
 	 * 
 	 * @param resource $resFile    The file handle
 	 * @param string   $strContent The content to store in the file
+	 * 
+	 * @return boolean True if the operation was successful
 	 */
 	public function fputs($resFile, $strContent)
 	{
-		@fputs($resFile, $strContent);
+		return (@fwrite($resFile, $strContent) !== false);
 	}
 
 

--- a/system/modules/core/library/Contao/Files/Php.php
+++ b/system/modules/core/library/Contao/Files/Php.php
@@ -71,10 +71,12 @@ class Php extends \Files
 	 * 
 	 * @param resource $resFile    The file handle
 	 * @param string   $strContent The content to store in the file
+	 * 
+	 * @return boolean True if the operation was successful
 	 */
 	public function fputs($resFile, $strContent)
 	{
-		@fputs($resFile, $strContent);
+		return (@fwrite($resFile, $strContent) !== false);
 	}
 
 


### PR DESCRIPTION
According to PHP manual function `fputs` is an alias of `fwrite` ([link](http://www.php.net/manual/en/function.fputs.php)) and also `fwrite` return `false` in case of error ([link](http://www.php.net/manual/en/function.fwrite.php))
