### PR TITLE
Fix bug with getting hook object in User class

### DIFF
--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -74,30 +74,6 @@ abstract class User extends \System
 	protected $strCookie;
 
 	/**
-	 * Authentication object
-	 * @var object
-	 */
-	protected $objAuth;
-
-	/**
-	 * Import object
-	 * @var object
-	 */
-	protected $objImport;
-
-	/**
-	 * Login object
-	 * @var object
-	 */
-	protected $objLogin;
-
-	/**
-	 * Logout object
-	 * @var object
-	 */
-	protected $objLogout;
-
-	/**
 	 * Data
 	 * @var array
 	 */


### PR DESCRIPTION
Since Contao stores all imported classes in `arrObjects` array there is a problem with getting hooks objects in `User` class. It tries to load `User` property object instead of getting it from parent `System` class.

This pull request fixes this bug.
