### PR TITLE
Contao 3: Issues with the Combiner

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -2017,7 +2017,7 @@ abstract class Controller extends \System
 		// Create the aggregated style sheet
 		if ($objCombiner->hasEntries())
 		{
-			$strScripts .= '<link' . ($blnXhtml ? ' type="text/css"' : '') . ' rel="stylesheet" href="' . $objCombiner->getCombinedFile() . '"' . $strTagEnding . "\n";
+			$strScripts = '<link' . ($blnXhtml ? ' type="text/css"' : '') . ' rel="stylesheet" href="' . $objCombiner->getCombinedFile() . '"' . $strTagEnding . "\n" . $strScripts;
 		}
 
 		$arrReplace['[[TL_CSS]]'] = $strScripts;
@@ -2045,7 +2045,7 @@ abstract class Controller extends \System
 			// Create the aggregated script
 			if ($objCombiner->hasEntries())
 			{
-				$strScripts .= '<script' . ($blnXhtml ? ' type="text/javascript"' : '') . ' src="' . $objCombiner->getCombinedFile() . '"></script>' . "\n";
+				$strScripts = '<script' . ($blnXhtml ? ' type="text/javascript"' : '') . ' src="' . $objCombiner->getCombinedFile() . '"></script>' . "\n" . $strScripts;
 			}
 		}
 


### PR DESCRIPTION
The Combiner scripts are currently loaded after all other script. This will cause a lot of issues because then the Mootools Core is loaded after non-static files.
