### PR TITLE
Automatically add isPermaLink=false to RSS feed

### DIFF
--- a/system/modules/core/library/Contao/Feed.php
+++ b/system/modules/core/library/Contao/Feed.php
@@ -150,7 +150,7 @@ class Feed extends \System
 			$xml .= '<description><![CDATA[' . preg_replace('/[\n\r]+/', ' ', $objItem->description) . ']]></description>';
 			$xml .= '<link>' . specialchars($objItem->link) . '</link>';
 			$xml .= '<pubDate>' . date('r', $objItem->published) . '</pubDate>';
-			$xml .= '<guid>' . ($objItem->guid ? $objItem->guid : specialchars($objItem->link)) . '</guid>';
+			$xml .= '<guid' . ($objItem->guid ? ((strpos($objItem->guid, 'http') !== 0 ? ' isPermaLink="false">' : '') . $objItem->guid) : ('>'.specialchars($objItem->link))) . '</guid>';
 
 			// Enclosures
 			if (is_array($objItem->enclosure))


### PR DESCRIPTION
According to W3C, an RSS item GUID should be an URL (permalink) by default, but not necessarily. If it's not an URL (and I assume it must be absolute), the attribute "isPermaLink" should be set to "false".
