### PR TITLE
Add missing TL_ROOT path in System::readPhpFileWithoutTags while reading...

### DIFF
--- a/system/modules/core/library/Contao/System.php
+++ b/system/modules/core/library/Contao/System.php
@@ -786,7 +786,7 @@ abstract class System
 	 */
 	protected static function readPhpFileWithoutTags($strName)
 	{
-		$strCode = rtrim(file_get_contents($strName));
+		$strCode = rtrim(file_get_contents(TL_ROOT . '/' . $strName));
 
 		// Opening tag
 		if (strncmp($strCode, '<?php', 5) === 0)


### PR DESCRIPTION
... the file content.

Without `TL_ROOT` the `file_get_contents` return `false` on my system.
