### PR TITLE
Feature: completely change headerfields in mode4

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -3645,31 +3645,42 @@ window.addEvent(\'domready\', function() {
 				$strMethod = $GLOBALS['TL_DCA'][$table]['list']['sorting']['header_callback'][1];
 
 				$this->import($strClass);
+				// the callback can eighter return a string or an array
 				$add = $this->$strClass->$strMethod($add, $this);
 			}
 
-			// Output the header data
-			$return .= '
+			if(is_string($add))
+			{
+				// if it is a string display it
+				$return .= $add;
+			}
+			else
+			{
+				// Output the header data from an array as table
+				$return .= '
 
 <table class="tl_header_table">';
 
-			foreach ($add as $k=>$v)
-			{
-				if (is_array($v))
+				foreach ($add as $k=>$v)
 				{
-					$v = $v[0];
-				}
+					if (is_array($v))
+					{
+						$v = $v[0];
+					}
 
-				$return .= '
+					$return .= '
   <tr>
     <td><span class="tl_label">'.$k.':</span> </td>
     <td>'.$v.'</td>
   </tr>';
+				}
+
+				$return .= '
+</table>';
 			}
 
-			$return .= '
-</table>
-</div>';
+			// output the header data
+			$return .= '</div>';
 
 			$orderBy = array();
 			$firstOrderBy = array();


### PR DESCRIPTION
In my case i have many variables i'd like to display in the headerfields (mode 4) in a very specific way.
I'd like to add the array of headerfields to a template instead of dumping it as table.

So i'd suggest the following, backwards compatible change. This way it's possible to change the header to any string including rendered template data. 

It can be used with the header_callback like this

``` php
/**
* Edit the Headerfields in mode 4
* @param  Array $arrHeaderFields the headerfields given via header_callback
* @param  Datacontainer $dc a Datacontainer Object
* @return Array|String The manipulated headerfields
*/
public function showTask($arrHeaderFields, Datacontainer $dc)
{
    // We can eighter dump the header data as table
    // return $arrHeaderFields;
    // But now i want to replace the complete header with a string (or a template)
    return 'Foobar';
}
```
