### PR TITLE
Use ForeignKey DCA field property in listView

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -4124,7 +4124,27 @@ Backend.makeParentViewSortable("ul_' . CURRENT_ID . '");
 					{
 						$row_v = deserialize($row[$v]);
 
-						if (is_array($row_v))
+						// Get the field value
+						if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['foreignKey']))
+						{
+							$temp = array();
+							$chunks = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$v]['foreignKey'], 2);
+
+							foreach ((array) $row_v as $v)
+							{
+								$objKey = $this->Database->prepare("SELECT " . $chunks[1] . " AS value FROM " . $chunks[0] . " WHERE id=?")
+														 ->limit(1)
+														 ->execute($v);
+
+								if ($objKey->numRows)
+								{
+									$temp[] = $objKey->value;
+								}
+							}
+
+							$args[$k] = implode(', ', $temp);
+						}
+						elseif (is_array($row_v))
 						{
 							$args_k = array();
 


### PR DESCRIPTION
For now `foreignKey` DCA property doesn't use in listView.

How to reproduce this bug in demo.

1 Edit `core/dca/tl_member.php` file and add `groups` column to `[label][fields]` as:

``` php
'label' => array
(
    'fields' => array('icon', 'firstname', 'lastname', 'username', 'groups', 'dateAdded'),
...
```

2 Go to Backend _Members_ page and you will see added field `groups` as _Member groups_ column but with values like `2`. But if you will look into _Show the details of member ID 1_ you will see that _Member groups_ field has value `Piano Students`. This value came from `tl_member_group` because field `groups` has DCA property `'foreignKey' => 'tl_member_group.name'`. 

The same value `Piano Students` expected to see in _Member groups_ column, but it shows only it's id values.

So, this pull request will use that `foreignKey` property for showing wright values in listView.
