### PR TITLE
Fix class detection for realy small files.

### DIFF
--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -422,7 +422,7 @@ EOT
 				$fh = fopen(TL_ROOT . '/system/modules/' . $strModule . '/' . $strFile, 'rb');
 
 				// Read until a class or interface definition has been found
-				while (!feof($fh) && !preg_match('/(class|interface) ' . preg_quote(basename($strFile, '.php'), '/') . '/', $strBuffer, $arrMatches))
+				while (!preg_match('/(class|interface) ' . preg_quote(basename($strFile, '.php'), '/') . '/', $strBuffer, $arrMatches) && !feof($fh))
 				{
 					$strBuffer .= fread($fh, 512);
 				}


### PR DESCRIPTION
If I have a realy small class file (less then 512 bytes), the autoload creator will fail.
A real live example may look like this:

``` php
<?php

/**
 * My Extension
 * for Contao Open Source CMS
 *
 * @package MyExtension
 * @author  Tristan Lins <tristan.lins@bit3.de>
 * @link    http://bit3.de
 * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL
 */

namespace FooBarZap\Extension\DataContainer;

class Content
{
    public function updateMandatories()
    {
        $GLOBALS['TL_DCA']['tl_content']['fields']['headline']['eval']['mandatory'] = $GLOBALS['TL_CONFIG']['mysetting'];
    }
}
```

This file only contains 461 bytes!
Most files may be bigger than 512 bytes. But when I start development I often create simple prototypes, use the autoload create to register them and this will not work.
