### PR TITLE
Allow for-Attribute for Select-Menu

### DIFF
--- a/system/modules/core/forms/FormSelectMenu.php
+++ b/system/modules/core/forms/FormSelectMenu.php
@@ -35,6 +35,12 @@ class FormSelectMenu extends \Widget
 	protected $blnSubmitInput = true;
 
 	/**
+	 * Add a for attribute
+	 * @var boolean
+	 */
+	protected $blnForAttribute = true;
+
+	/**
 	 * Template
 	 * @var string
 	 */


### PR DESCRIPTION
The label for Select-Menus in forms didn't have a for-attribute.
