### PR TITLE
fixed bug with empty headlines in faq page front end module

### DIFF
--- a/system/modules/faq/modules/ModuleFaqPage.php
+++ b/system/modules/faq/modules/ModuleFaqPage.php
@@ -130,7 +130,7 @@ class ModuleFaqPage extends \Module
 
 			// Order by PID
 			$arrFaq[$objFaq->pid]['items'][] = $objTemp;
-			$arrFaq[$objFaq->pid]['headline'] = $objFaq->category;
+			$arrFaq[$objFaq->pid]['headline'] = $objFaq->getRelated('pid')->headline;
 		}
 
 		$arrFaq = array_values(array_filter($arrFaq));


### PR DESCRIPTION
The faq category headlines didn't show up on the FAQ page.

Similar to 1d9ae2ce5a0e6944169aea5469105fe566c197ea but for the FAQ page module.
