### PR TITLE
fix issue #5152 - Autoload creator does not handle some files correctly.

### DIFF
--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -164,7 +164,7 @@ class ModuleAutoload extends \BackendModule
 				$fh = fopen(TL_ROOT . '/system/modules/' . $strModule . '/' . $strFile, 'rb');
 
 				// Read until a class or interface definition has been found
-				while ($size > 0 && !feof($fh) && !preg_match('/(class|interface) ' . preg_quote(basename($strFile, '.php'), '/') . '/', $strBuffer, $arrMatches))
+				while (!preg_match('/(class|interface) ' . preg_quote(basename($strFile, '.php'), '/') . '/', $strBuffer, $arrMatches) && $size > 0 && !feof($fh))
 				{
 					$length = min(512, $size);
 					$strBuffer .= fread($fh, $length);


### PR DESCRIPTION
Autoload creator does not handle files correctly that have the "class" or "interface" declaration within the last 512 bytes chunk of file.

When the

```
class Foo
{
}
```

is within the last 512 bytes of the file and those 512 bytes do not also appear to be the first 512 bytes, the autoload creator skips the preg_match() call due to early resolving of the "&&" conditions in the while loop.

Therefore I inverted the conditions to always perform the preg_match first, as this hurts less on an empty string than having no match at all. :)
