### PR TITLE
Prevent oversizing of colorbox lightbox.

### DIFF
--- a/system/modules/core/templates/j_colorbox.html5
+++ b/system/modules/core/templates/j_colorbox.html5
@@ -13,7 +13,9 @@ $GLOBALS['TL_CSS'][] = 'assets/jquery/colorbox/'. COLORBOX .'/css/colorbox.min.c
       $(this).colorbox({
         // Put custom options here
         loop:false,
-        rel:$(this).attr('data-lightbox')
+        rel:$(this).attr('data-lightbox'),
+        maxWidth: '95%',
+        maxHeight: '95%'
       });
     });
   });

--- a/system/modules/core/templates/j_colorbox.xhtml
+++ b/system/modules/core/templates/j_colorbox.xhtml
@@ -12,7 +12,9 @@ $GLOBALS['TL_CSS'][] = 'assets/jquery/colorbox/'. COLORBOX .'/css/colorbox.min.c
   $(document).ready(function() {
     $('a[rel^=lightbox]').colorbox({
       // Put custom options here
-      loop:false
+      loop:false,
+      maxWidth: '95%',
+      maxHeight: '95%'
     });
   });
 })(jQuery);


### PR DESCRIPTION
If a source image is bigger than the viewport, colorbox will oversize the lightbox to fit the image size. You have to set a maximum width and height to prevent this. (Scaling is enabled by default, but no max width and height is set by default).
