### PR TITLE
CRITICAL protect tl_content from deletion

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -1467,7 +1467,14 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			// Consider the dynamic parent table (see #4867)
 			if ($GLOBALS['TL_DCA'][$v]['config']['dynamicPtable'])
 			{
-				$cond = ($v == 'tl_content') ? "(ptable=? OR ptable='')" : "ptable=?"; // backwards compatibility
+				if ($v == 'tl_content' && $GLOBALS['TL_DCA'][$v]['config']['ptable'] == 'tl_article')
+				{
+					$cond = "(ptable=? OR ptable='')"; // backwards compatibility
+				}
+				else
+				{
+					$cond = "ptable=?";
+				}
 
 				$objDelete = $this->Database->prepare("SELECT id FROM $v WHERE pid=? AND $cond")
 											->execute($id, $GLOBALS['TL_DCA'][$v]['config']['ptable']);


### PR DESCRIPTION
The backwards compatibility delete `tl_content` records where `tl_content.ptable == ''`, even if I delete a parent record from another table than `tl_article`.

To clarify the situation, a short example:

The table `tl_article`:

```
id  | title   ...
1   | I'm an article ...
```

The table `tl_news`:

```
id  | title   ...
1   | I'm an awesome news ...
```

The table `tl_content`:

```
id  | pid  | ptable  | type ...
1   | 1    | <empty> | text ... // belongs to tl_article !!!
1   | 1    | tl_news | text ... // belongs to tl_news !!!
```

If I now delete the `tl_news` record `id=1`, the backwards compatibility will select:
`SELECT id FROM tl_content WHERE pid=? AND (ptable='tl_news' OR ptable='')`.
This will also select the `tl_content` records, that belongs to `tl_article`!
The backwards compatibility should only be used for `tl_content` records which belongs to `tl_article`! 
