### PR TITLE
Combiner: added support for URLs with single quotes in CSS

### DIFF
--- a/system/modules/core/library/Contao/Combiner.php
+++ b/system/modules/core/library/Contao/Combiner.php
@@ -221,7 +221,7 @@ class Combiner extends \System
 				$strGlue = ($strDirname != '.') ? $strDirname . '/' : '';
 
 				$strBuffer = '';
-				$chunks = preg_split('/url\("([^"]+)"\)/', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+				$chunks = preg_split('/url\(["\']([^"\']+)["\']\)/', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
 
 				// Check the URLs
 				for ($i=0; $i<count($chunks); $i=$i+2)


### PR DESCRIPTION
See #4096 and #2741

Compass (http://compass-style.org/) always generates single quotes around URLs, so supporting single quotes would be great for all people using SASS/Compass with Contao.
