### PR TITLE
Problem with video formats (mp4, webm, ogv)

### DIFF
--- a/.htaccess.default
+++ b/.htaccess.default
@@ -243,7 +243,7 @@ FileETag None
   #
   # For more information see: https://github.com/contao/core/issues/4364
   ##
-  <FilesMatch "\.(htm|php|js|css|htc|png|gif|jpe?g|ico|xml|csv|txt|swf|flv|eot|woff|svg|ttf|pdf|gz)$">
+  <FilesMatch "\.(htm|php|js|css|htc|png|gif|jpe?g|ico|xml|csv|txt|swf|flv|mp4|webm|ogv|eot|woff|svg|ttf|pdf|gz)$">
     RewriteEngine Off
   </FilesMatch>
 

--- a/.htaccess.default
+++ b/.htaccess.default
@@ -243,7 +243,7 @@ FileETag None
   #
   # For more information see: https://github.com/contao/core/issues/4364
   ##
-  <FilesMatch "\.(htm|php|js|css|htc|png|gif|jpe?g|ico|xml|csv|txt|swf|flv|mp4|webm|ogv|eot|woff|svg|ttf|pdf|gz)$">
+  <FilesMatch "\.(htm|php|js|css|htc|png|gif|jpe?g|ico|xml|csv|txt|swf|flv|eot|woff|svg|ttf|pdf|gz)$">
     RewriteEngine Off
   </FilesMatch>
 


### PR DESCRIPTION
If you have **no url suffix** and want to use the **video CE**, the video doesn't work.
This commit fixes the problem with the video formats (mp4, webm, ogv).
