### PR TITLE
Fixed: load core autoload.php files first

### DIFF
--- a/system/modules/core/library/Contao/ClassLoader.php
+++ b/system/modules/core/library/Contao/ClassLoader.php
@@ -204,28 +204,17 @@ class ClassLoader
 	 */
 	public static function scanAndRegister()
 	{
-		// Load core modules first
-		$arrCoreModules = array('core', 'calendar', 'comments', 'devtools', 'faq', 'listing', 'news', 'newsletter', 'repository');
-		foreach($arrCoreModules as $strModule)
+		$arrModules = array_unique
+		(
+			array_merge
+			(
+				array('core', 'calendar', 'comments', 'devtools', 'faq', 'listing', 'news', 'newsletter', 'repository'),
+				scan(TL_ROOT . '/system/modules')
+			)
+		);
+
+		foreach ($arrModules as $file)
 		{
-			$path = TL_ROOT . '/system/modules/' . $strModule;
-
-			if (file_exists($path . '/.skip') || !file_exists($path . '/config/autoload.php'))
-			{
-				continue;
-			}
-
-			include $path . '/config/autoload.php';
-		}
-
-		// Than load the extension modules
-		foreach (scan(TL_ROOT . '/system/modules') as $file)
-		{
-			if(in_array($file,$arrCoreModules))
-			{
-				continue;
-			}
-
 			$path = TL_ROOT . '/system/modules/' . $file;
 
 			if (strncmp($file, '.', 1) === 0 || !is_dir($path))

--- a/system/modules/core/library/Contao/ClassLoader.php
+++ b/system/modules/core/library/Contao/ClassLoader.php
@@ -204,8 +204,28 @@ class ClassLoader
 	 */
 	public static function scanAndRegister()
 	{
+		// Load core modules first
+		$arrCoreModules = array('core', 'calendar', 'comments', 'devtools', 'faq', 'listing', 'news', 'newsletter', 'repository');
+		foreach($arrCoreModules as $strModule)
+		{
+			$path = TL_ROOT . '/system/modules/' . $strModule;
+
+			if (file_exists($path . '/.skip') || !file_exists($path . '/config/autoload.php'))
+			{
+				continue;
+			}
+
+			include $path . '/config/autoload.php';
+		}
+
+		// Than load the extension modules
 		foreach (scan(TL_ROOT . '/system/modules') as $file)
 		{
+			if(in_array($file,$arrCoreModules))
+			{
+				continue;
+			}
+
 			$path = TL_ROOT . '/system/modules/' . $file;
 
 			if (strncmp($file, '.', 1) === 0 || !is_dir($path))


### PR DESCRIPTION
Die autoload.php Dateien sollten in der selben Riehenfolge wie auch die config.php Dateien geladen werden. Ist dies nicht der Fall, kann eine Erweiterung (die durch die Sortierung von `scan()` **vor** einer core-Erweiterunge geladen wird) keine core-Templates überschreiben.
