### PR TITLE
Security: TinyMCE spellchecker security fix for CVE-2012-6112 / 2.11.9

### DIFF
--- a/plugins/tinyMCE/plugins/spellchecker/classes/GoogleSpell.php
+++ b/plugins/tinyMCE/plugins/spellchecker/classes/GoogleSpell.php
@@ -53,6 +53,8 @@ class GoogleSpell extends SpellChecker {
 	}
 
 	function &_getMatches($lang, $str) {
+		$lang = preg_replace('/[^a-z\-]/i', '', $lang); // Sanitize, remove everything but a-z or -
+		$str = preg_replace('/[\x00-\x1F\x7F]/', '', $str); // Sanitize, remove all control characters
 		$server = "www.google.com";
 		$port = 443;
 		$path = "/tbproxy/spell?lang=" . $lang . "&hl=en";


### PR DESCRIPTION
This is TinyMCE spellchecker security fix for CVE-2012-6112 from
https://github.com/tinymce/tinymce_spellchecker_php/commit/22910187bfb9edae90c26e10100d8145b505b974.
