### PR TITLE
Fix [C2.11]: cacheMode == 'browser' always prohibits caching ($intCache is always null)

### DIFF
--- a/system/modules/frontend/FrontendTemplate.php
+++ b/system/modules/frontend/FrontendTemplate.php
@@ -168,10 +168,10 @@ class FrontendTemplate extends Template
 		// Send cache headers
 		if (!headers_sent())
 		{
-			if ($intCache !== null && ($GLOBALS['TL_CONFIG']['cacheMode'] == 'both' || $GLOBALS['TL_CONFIG']['cacheMode'] == 'browser'))
+			if (intval($objPage->cache) > 0 && ($GLOBALS['TL_CONFIG']['cacheMode'] == 'both' || $GLOBALS['TL_CONFIG']['cacheMode'] == 'browser'))
 			{
-				header('Cache-Control: public, max-age=' . ($intCache -  time()));
-				header('Expires: ' . gmdate('D, d M Y H:i:s', $intCache) . ' GMT');
+				header('Cache-Control: public, max-age=' . intval($objPage->cache));
+				header('Expires: ' . gmdate('D, d M Y H:i:s', (intval($objPage->cache) + time())) . ' GMT');
 				header('Last-Modified: ' . gmdate('D, d M Y H:i:s', time()) . ' GMT');
 				header('Pragma: public');
 			}


### PR DESCRIPTION
In Contao 2.11.9, [FrontendTemplate.php, Ll. 132](https://github.com/contao/core/blob/2.11.9/system/modules/frontend/FrontendTemplate.php#L132), `$intCache` is initialized to `null`. The `if` block starting in line 135 fails with `$GLOBALS['TL_CONFIG']['cacheMode'] = 'browser'`. 

The check in [FrontendTemplate.php, Ll. 171](https://github.com/contao/core/blob/2.11.9/system/modules/frontend/FrontendTemplate.php#L171) then always fails because `$intCache == null;`. Thus, Contao always prohibits client side caching in said conditions. 

This commit fixes the bug by replacing the checked for variable and also where this variable was used for setting the cache time. I tested the fix on a live system, all looking good. Pull Request for Contao 3.x coming up. 
