### PR TITLE
Fix [C3]: cacheMode == 'browser' always prohibits caching ($intCache is always null)

### DIFF
--- a/system/modules/core/classes/FrontendTemplate.php
+++ b/system/modules/core/classes/FrontendTemplate.php
@@ -172,10 +172,10 @@ class FrontendTemplate extends \Template
 		// Send cache headers
 		if (!headers_sent())
 		{
-			if ($intCache !== null && ($GLOBALS['TL_CONFIG']['cacheMode'] == 'both' || $GLOBALS['TL_CONFIG']['cacheMode'] == 'browser'))
+			if (intval($objPage->cache) > 0 && ($GLOBALS['TL_CONFIG']['cacheMode'] == 'both' || $GLOBALS['TL_CONFIG']['cacheMode'] == 'browser'))
 			{
-				header('Cache-Control: public, max-age=' . ($intCache -  time()));
-				header('Expires: ' . gmdate('D, d M Y H:i:s', $intCache) . ' GMT');
+				header('Cache-Control: public, max-age=' . intval($objPage->cache));
+				header('Expires: ' . gmdate('D, d M Y H:i:s', (intval($objPage->cache) + time())) . ' GMT');
 				header('Last-Modified: ' . gmdate('D, d M Y H:i:s', time()) . ' GMT');
 				header('Pragma: public');
 			}


### PR DESCRIPTION
In Contao 3.x, [FrontendTemplate.php, Ll. 127](https://github.com/contao/core/blob/850b2ed9d0d78a7f515fc02ee201dae76d5c206b/system/modules/core/classes/FrontendTemplate.php#L127), `$intCache` is initialized to `null`. The `if` block starting in line 130 fails with `$GLOBALS['TL_CONFIG']['cacheMode'] = 'browser'`. 

The check in [FrontendTemplate.php, Ll. 175](https://github.com/contao/core/blob/850b2ed9d0d78a7f515fc02ee201dae76d5c206b/system/modules/core/classes/FrontendTemplate.php#L175) then always fails because `$intCache == null;`. Thus, Contao always prohibits client side caching in said conditions. 

This commit fixes the bug by replacing the checked for variable and also where this variable was used for setting the cache time. The fix is the same as in #5358 (the FrontendTemplate.php in Contao 3.x is essentially equal to the one in Contao 2.11.10). However, I did not test this fix. 
