### PR TITLE
Prevent really long words in search index

### DIFF
--- a/system/libraries/Search.php
+++ b/system/libraries/Search.php
@@ -163,8 +163,8 @@ class Search extends System
 			$arrData['keywords'] .= ' ' . implode(', ', array_unique($tags[2]));
 		}
 
-		// Make sure <br /> tags are always followed by a line break
-		$strBody = str_ireplace(array('<br>', '<br />'), "<br>\n", $strBody);
+		// Add a whitespace character before line-breaks and between consecutive tags (see #5363)
+		$strBody = str_ireplace(array('<br', '><'), array(' <br', '> <'), $strBody);
 		$strBody = strip_tags($strBody);
 
 		// Put everything together


### PR DESCRIPTION
Hey Leo

This is really such a lucky hit I found this issue. Imagine a table on a page like this:

``` html
<table><tr><td>word</td><td>otherword</td></tr><tr><td>anotherword</td>.....</table>
```

If this is output in a template like this with no line breaks and always one word only, it can lead to really long words in the search index.

It will do something like this then: "wordotherwordanotherword..."

In my case it was even worse!
I had German words with umlauts and because the field tl_search_index.word is VARBINARY(64) and my word was too long, it cut off the rest of the data.
It cut it off **EXACTLY** in between of the two byte utf-8 character which obviously resulted in an invalid utf-8 string and caused an error in the front end, as ModuleSearch.php does a preg_match_all call on the word to display the context:

``` php
preg_match_all('/\b.{0,'.$this->contextLength.'}\PL' . $strWord . '\PL.{0,'.$this->contextLength.'}\b/ui', $arrResult[$i]['text'], $arrChunks);
```

So I solved this by simply enforce having at least a space between two tags :-)

The probability to discover this was like 1 in a million :D
