### PR TITLE
Auto detect TL_PATH not work with aliases.

### DIFF
--- a/system/initialize.php
+++ b/system/initialize.php
@@ -89,7 +89,7 @@ require_once TL_ROOT . '/system/vendor/simplepie/autoloader.php';
 /**
  * Define the relative path to the installation (see #5339)
  */
-define('TL_PATH', str_replace(Environment::get('documentRoot'), '', str_replace('\\', '/',  dirname(__DIR__))));
+define('TL_PATH', Environment::get('websitePath'));
 
 
 /**

--- a/system/initialize.php
+++ b/system/initialize.php
@@ -34,6 +34,14 @@ if (TL_MODE == 'BE')
 
 
 /**
+ * Set temporary directory
+ */
+putenv('TMP=' . TL_ROOT . '/system/tmp');
+putenv('TEMP=' . TL_ROOT . '/system/tmp');
+putenv('TMPDIR=' . TL_ROOT . '/system/tmp');
+
+
+/**
  * Include the helpers
  */
 require TL_ROOT . '/system/helper/functions.php';

--- a/system/modules/core/library/Contao/Environment.php
+++ b/system/modules/core/library/Contao/Environment.php
@@ -86,6 +86,50 @@ class Environment
 
 
 	/**
+	 * Return the relative website path (e.g. /website)
+	 *
+	 * @return string The relative path to the website
+	 */
+	protected static function websitePath()
+	{
+		$documentRoot = static::get('documentRoot');
+		$scriptName = static::get('scriptName');
+		$websitePath = str_replace(Environment::get('documentRoot'), '', str_replace('\\', '/',  TL_ROOT));
+
+		$position = strpos($scriptName, $websitePath);
+
+		// there must be an alias, because $scriptName does not start with $websitePath
+		if ($position > 0)
+		{
+			$websitePath = substr($scriptName, 0, $position) . $websitePath;
+		}
+
+		// the determinated $websitePath is not in $scriptName, the full contao installation may be aliased
+		else if ($position === false)
+		{
+			if (TL_MODE == 'BE' && preg_match('#/contao/\w+\.php#', $scriptName))
+			{
+				$websitePath = dirname($scriptName);
+			}
+			if (TL_MODE == 'FE')
+			{
+				if (
+					($position = strpos($scriptName, '/system/modules/')) !== false ||
+					($position = strpos($scriptName, '/share/index.php')) !== false
+				) {
+					$websitePath = substr($scriptName, 0, $position);
+				}
+				else
+				{
+					$websitePath = dirname($scriptName);
+				}
+			}
+		}
+
+		return $websitePath;
+	}
+
+	/**
 	 * Return the absolute path to the script (e.g. /home/www/html/website/index.php)
 	 * 
 	 * @return string The absolute path to the script


### PR DESCRIPTION
The auto detection of `TL_PATH` not work, when using apache aliases.

I use userdir that provide all `~/public_html/` under `http://localhost/~user/`.
In my case, I have a `documentRoot=/home/tristan/public_html/contao-core` and `REQUEST_URI=/~tristan/contao-core/contao/install.php`.
As result, the determinated `TL_PATH` is **only** `/contao-core`, but it has to be `/~tristan/contao-core`.

Solving this problem seams not to be that easy, but I give it a try.
The attachet code is primary for discussion, but solved the problem for me.
