### PR TITLE
Set TMP, TEMP and TMPDIR environment variable

### DIFF
--- a/system/initialize.php
+++ b/system/initialize.php
@@ -34,6 +34,14 @@ if (TL_MODE == 'BE')
 
 
 /**
+ * Set temporary directory
+ */
+putenv('TMP=' . TL_ROOT . '/system/tmp');
+putenv('TEMP=' . TL_ROOT . '/system/tmp');
+putenv('TMPDIR=' . TL_ROOT . '/system/tmp');
+
+
+/**
  * Include the helpers
  */
 require TL_ROOT . '/system/helper/functions.php';


### PR DESCRIPTION
Last time, I have a lot of problems with shared hosters.
A lot of hosters block access to `/tmp`, but they not change the `TMP`, `TEMP` and `TMPDIR` environment variables.
As result the `sys_get_temp_dir()` still return `/tmp`.
Contao itself does not use `sys_get_temp_dir()`, but framework independent scripts like Swift use this function to get a temporary directory path.

Settings the three environment variables (see comments in http://de.php.net/sys_get_temp_dir) to `/path/to/contao/system/tmp` or similar would fix this problem.

As side effect, this also secures session data, because PHP internally also use the system temp dir as default session path.

I know this is not a Contao problem, but more and more hosters make this bad setup and we should work around this behavior.
