### PR TITLE
Remove @ from include_once in autoloader function.

### DIFF
--- a/system/functions.php
+++ b/system/functions.php
@@ -143,6 +143,23 @@ function __error($intType, $strMessage, $strFile, $intLine)
 		8192                => 'Deprecated notice'
 	);
 
+	if (($intType == E_WARNING || $intType == E_USER_WARNING) &&
+		$strFile == __FILE__ &&
+		$intLine >= 50 && $intLine <= 68)
+	{
+		// Log the error
+		error_log(
+			sprintf(
+				'PHP %s: %s in %s on line %s',
+				$arrErrors[$intType],
+				$strMessage,
+				$strFile,
+				$intLine
+			)
+		);
+		return;
+	}
+
 	// Ignore functions with an error control operator (@function_name)
 	if (ini_get('error_reporting') > 0)
 	{

--- a/system/functions.php
+++ b/system/functions.php
@@ -49,7 +49,7 @@ function __autoload($strClassName)
 	// Try to load the class name from the session cache
 	if (!$GLOBALS['TL_CONFIG']['debugMode'] && isset($objCache->$strClassName))
 	{
-		if (@include_once(TL_ROOT . '/' . $objCache->$strClassName))
+		if (include_once(TL_ROOT . '/' . $objCache->$strClassName))
 		{
 			return; // The class could be loaded
 		}

--- a/system/functions.php
+++ b/system/functions.php
@@ -55,6 +55,14 @@ function __autoload($strClassName)
 		}
 		else
 		{
+			trigger_error(
+				sprintf(
+					'Class cache not up to date, class file %s for class %s does not exists anymore',
+					$objCache->$strClassName,
+					$strClassName
+				),
+				E_USER_WARNING
+			);
 			unset($objCache->$strClassName); // The class has been removed
 		}
 	}


### PR DESCRIPTION
The `@` before the `include_once` will not only hide catchable errors.
Also fatal errors are hidden silently.
The developer never see errors like this `Fatal error: Class X contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (ContentElement::compile)`, only a white side is shown.
