### PR TITLE
correct initialization of pagemounts array

### DIFF
--- a/system/modules/core/classes/BackendUser.php
+++ b/system/modules/core/classes/BackendUser.php
@@ -381,7 +381,7 @@ class BackendUser extends \User
 		}
 		else
 		{
-			$this->filemounts = array_filter($this->filemounts);
+			$this->pagemounts = array_filter($this->pagemounts);
 		}
 
 		if (!is_array($this->filemounts))


### PR DESCRIPTION
I believe the pagemounts array is not properly initialized. (Looks like a copy&paste bug to me.) Because of this, I get the following PHP error in the log:

```
[27-Feb-2013 16:27:48] 
PHP Warning: array_filter() expects parameter 1 to be array, boolean given in /mnt/webe/c0/27/5122327/htdocs/contao/system/modules/core/classes/BackendUser.php on line 384
#0 [internal function]: __error(2, 'array_filter() ...', '/mnt/webe/c0/27...', 384, Array)
#1 /mnt/webe/c0/27/5122327/htdocs/contao/system/modules/core/classes/BackendUser.php(384): array_filter(false)
#2 /mnt/webe/c0/27/5122327/htdocs/contao/system/modules/core/library/Contao/User.php(338): Contao\BackendUser->setUserFromDb()
#3 /mnt/webe/c0/27/5122327/htdocs/contao/contao/index.php(53): Contao\User->login()
#4 /mnt/webe/c0/27/5122327/htdocs/contao/contao/index.php(126): Index->__construct()
#5 {main}
```
