### PR TITLE
Fix File::truncate() for already opened streams.

### DIFF
--- a/system/libraries/File.php
+++ b/system/libraries/File.php
@@ -232,7 +232,16 @@ class File extends System
 	 */
 	public function truncate()
 	{
-		return $this->write('');
+		if (!is_resource($this->resFile))
+		{
+			if (($this->resFile = $this->Files->fopen($this->strFile, $strMode)) == false)
+			{
+				return false;
+			}
+		}
+
+		ftruncate($this->resFile, 0);
+		return true;
 	}
 
 


### PR DESCRIPTION
``` php
$file = new File('example.txt');

$file->truncate();   // -> fopen('example.txt', 'wb') will truncate the file
$file->write('foo'); // -> fputs($handle, 'foo')

$file->truncate();   // -> fputs($handle, '') => will not truncated because handle is already opened!
$file->write('bar'); // -> fputs($handle, 'bar')
```

The file `example.txt` will contain `foobar` and **not** `bar` as expected.
