### PR TITLE
Bugfix für verlorene Filemounts bei falschem Passwort

### DIFF
--- a/system/modules/core/classes/BackendUser.php
+++ b/system/modules/core/classes/BackendUser.php
@@ -288,7 +288,10 @@ class BackendUser extends \User
 	public function save()
 	{
 		$filemounts = $this->filemounts;
-		$this->arrData['filemounts'] = $this->arrFilemountIds;
+		if(!empty($this->arrFilemountIds)) 
+		{
+			$this->arrData['filemounts'] = $this->arrFilemountIds;
+		}			
 		parent::save();
 		$this->filemounts = $filemounts;
 	}


### PR DESCRIPTION
Bugfix für verlorene Filemounts.
Der Fehler tritt bei mir unter folgender Konstellation auf:
- 3.0.5
- BE Nutzer wurde einer Gruppe zugeordnet (obs auch ohne diese Zuordnung geht habe ich nicht probiert)
- Nutzer wurden Filemounts zugeordnet
- Man versucht sich mit dem Nutzer an anzumelden gibt aber das falsche Passwort an
- Filemounts werden in dem Fall zurück gesetzt

Bei der Authentifizierung wird durch das falsche Password aus der Methode "login" von BackendUser gespeichert und raus gesprungen ohne setUserFromDb aufzurufen - somit wird arrFilemountIds nicht gesetzt. Beim Speichern wird die Methode "save" von BackendUser aufgerufen und an der stelle $this->arrData['filemounts'] = $this->arrFilemountIds;  auf Null gesetzt wird ergo filemounts gehen verloren.
