### PR TITLE
Integrate a Hook to customize Widgets

### DIFF
--- a/system/modules/core/library/Contao/Widget.php
+++ b/system/modules/core/library/Contao/Widget.php
@@ -516,6 +516,16 @@ abstract class Widget extends \Controller
 		$strBuffer = ob_get_contents();
 		ob_end_clean();
 
+		// HOOK: add custom parse filters
+		if (isset($GLOBALS['TL_HOOKS']['parseWidget']) && is_array($GLOBALS['TL_HOOKS']['parseWidget']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['parseWidget'] as $callback)
+			{
+				$this->import($callback[0]);
+				$strBuffer = $this->$callback[0]->$callback[1]($strBuffer, $this->strTemplate);
+			}
+		}
+	
 		return $strBuffer;
 	}
 


### PR DESCRIPTION
Adds a new Hook `parseWidget` to customize/extend the \Widget Controller output ($strBuffer).

This **additional hook** aims to the Frontend output of Form Generator (or others).
Since many modules have been moved to \Hybrid, it's not possible to manipulate single \Widget outputs in general atm.

Please note, that it's not possible to realize this feature with monkeypatching (overwriting the \Widget->parse() function).
