### PR TITLE
Escape ampersand characters to the corresponding entity in the `Versions` class

### DIFF
--- a/system/modules/core/classes/Versions.php
+++ b/system/modules/core/classes/Versions.php
@@ -396,7 +396,7 @@ class Versions extends \Backend
 <select name="version" class="tl_select">'.$versions.'
 </select>
 <input type="submit" name="showVersion" id="showVersion" class="tl_submit" value="'.specialchars($GLOBALS['TL_LANG']['MSC']['restore']).'">
-<a href="'.$this->addToUrl('versions=1&popup=1').'" title="'.specialchars($GLOBALS['TL_LANG']['MSC']['showDifferences']).'" onclick="Backend.openModalIframe({\'width\':765,\'title\':\''.specialchars(str_replace("'", "\\'", $GLOBALS['TL_LANG']['MSC']['showDifferences'])).'\',\'url\':this.href});return false">'.\Image::getHtml('diff.gif').'</a>
+<a href="'.$this->addToUrl('versions=1&amp;popup=1').'" title="'.specialchars($GLOBALS['TL_LANG']['MSC']['showDifferences']).'" onclick="Backend.openModalIframe({\'width\':765,\'title\':\''.specialchars(str_replace("'", "\\'", $GLOBALS['TL_LANG']['MSC']['showDifferences'])).'\',\'url\':this.href});return false">'.\Image::getHtml('diff.gif').'</a>
 </div>
 </form>
 


### PR DESCRIPTION
In the `Versions` class, one ampersand character in the generated URL ("ShowDifferences") has not been escaped to the corresponding HTML entity `&amp;`. This PR fixes the issue thus making the generated HTML markup valid again.
