### PR TITLE
Install tool: add a missing language variable

### DIFF
--- a/system/modules/core/languages/en/tl_install.xlf
+++ b/system/modules/core/languages/en/tl_install.xlf
@@ -254,6 +254,9 @@
       <trans-unit id="tl_install.DROP">
         <source>Drop existing tables</source>
       </trans-unit>
+      <trans-unit id="tl_install.selectAll">
+        <source>Select all</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/system/modules/core/library/Contao/Database/Installer.php
+++ b/system/modules/core/library/Contao/Database/Installer.php
@@ -67,7 +67,7 @@ class Installer extends \Controller
 				$return .= '
     <tr>
       <td class="tl_col_1"><input type="checkbox" id="check_all_' . $count . '" class="tl_checkbox" onclick="Backend.toggleCheckboxElements(this, \'' . strtolower($command) . '\')"></td>
-      <td class="tl_col_2"><label for="check_all_' . $count . '" style="color:#a6a6a6"><em>Select all</em></label></td>
+      <td class="tl_col_2"><label for="check_all_' . $count . '" style="color:#a6a6a6"><em>' . $GLOBALS['TL_LANG']['tl_install']['selectAll'] . '</em></label></td>
     </tr>';
 
 				// Fields


### PR DESCRIPTION
Add a missing language variable to the install tool in order to make it translatable on our translation and localization management platform.
