### PR TITLE
Make the file picker work for non database data containers

### DIFF
--- a/system/modules/core/classes/Ajax.php
+++ b/system/modules/core/classes/Ajax.php
@@ -270,7 +270,7 @@ class Ajax extends \Backend
 						die('Bad Request');
 					}
 				}
-				elseif ($dc instanceof \DC_Table)
+				elseif (!empty($dc->table) && $this->Database->tableExists($dc->table))
 				{
 					// The field does not exist
 					if (!$this->Database->fieldExists($strField, $dc->table))
@@ -318,7 +318,7 @@ class Ajax extends \Backend
 					$GLOBALS['TL_CONFIG'][$strField] = $varValue;
 					$arrAttribs['activeRecord'] = null;
 				}
-				elseif ($dc instanceof \DC_Table)
+				elseif (!empty($dc->table) && $this->Database->tableExists($dc->table))
 				{
 					$objRow->$strField = $varValue;
 					$arrAttribs['activeRecord'] = $objRow;

--- a/system/modules/core/classes/Ajax.php
+++ b/system/modules/core/classes/Ajax.php
@@ -270,7 +270,7 @@ class Ajax extends \Backend
 						die('Bad Request');
 					}
 				}
-				else
+				elseif ($dc instanceof \DC_Table)
 				{
 					// The field does not exist
 					if (!$this->Database->fieldExists($strField, $dc->table))
@@ -318,10 +318,14 @@ class Ajax extends \Backend
 					$GLOBALS['TL_CONFIG'][$strField] = $varValue;
 					$arrAttribs['activeRecord'] = null;
 				}
-				else
+				elseif ($dc instanceof \DC_Table)
 				{
 					$objRow->$strField = $varValue;
 					$arrAttribs['activeRecord'] = $objRow;
+				}
+				else
+				{
+					$arrAttribs['activeRecord'] = null;
 				}
 
 				$arrAttribs['id'] = $strFieldName;


### PR DESCRIPTION
Fixes an error similar to the one pointed out in #5565 for all data containers that don't extend `DC_Table` and therefore have no database connection.
