### PR TITLE
Only show files in the `tl_content.posterSRC` file picker

### DIFF
--- a/system/modules/core/dca/tl_content.php
+++ b/system/modules/core/dca/tl_content.php
@@ -611,7 +611,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_content']['posterSRC'],
 			'exclude'                 => true,
 			'inputType'               => 'fileTree',
-			'eval'                    => array('fieldType'=>'radio', 'files'=>true),
+			'eval'                    => array('filesOnly'=>true, 'fieldType'=>'radio'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'playerSize' => array


### PR DESCRIPTION
Limits the selection options to show only files in the preview image file picker.

Of course, affects version 3.1 as well.
