### PR TITLE
Add missing \ before extending class in ide_compat.

### DIFF
--- a/system/modules/devtools/modules/ModuleAutoload.php
+++ b/system/modules/devtools/modules/ModuleAutoload.php
@@ -572,7 +572,7 @@ EOT
 
 				foreach ($arrClasses as $arrClass)
 				{
-					$objFile->append("\t" . ($arrClass['abstract'] ? 'abstract ' : '') . $arrClass['type'] . ' ' . $arrClass['class'] . ' extends ' . $arrClass['namespace'] . '\\' . ($strNamespace ? $strNamespace . '\\' : '') . $arrClass['class'] . ' {}');
+					$objFile->append("\t" . ($arrClass['abstract'] ? 'abstract ' : '') . $arrClass['type'] . ' ' . $arrClass['class'] . ' extends \\' . $arrClass['namespace'] . '\\' . ($strNamespace ? $strNamespace . '\\' : '') . $arrClass['class'] . ' {}');
 				}
 
 				$objFile->append('}');


### PR DESCRIPTION
Im sure we already fixed this a long time ago, but it was gone :-(
