### PR TITLE
File manager: show an error message on empty upload field

### DIFF
--- a/system/modules/core/drivers/DC_Folder.php
+++ b/system/modules/core/drivers/DC_Folder.php
@@ -784,6 +784,12 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 				// Upload the files
 				$arrUploaded = $objUploader->uploadTo($strFolder);
 
+				if (empty($arrUploaded))
+				{
+					\Message::addError($GLOBALS['TL_LANG']['ERR']['all_fields']);
+					$this->reload();
+				}
+
 				foreach ($arrUploaded as $strFile)
 				{
 					$objFile = \FilesModel::findByPath($strFile);


### PR DESCRIPTION
Show a warning message when the upload field is empty.
