### PR TITLE
Escape the single quotation mark in the simple modal title strings

### DIFF
--- a/system/modules/core/classes/DataContainer.php
+++ b/system/modules/core/classes/DataContainer.php
@@ -555,7 +555,7 @@ class DataContainer extends \Backend
 			{
 				if ($k == 'show')
 				{
-					$return .= '<a href="'.$this->addToUrl($v['href'].'&amp;id='.$arrRow['id'].'&amp;popup=1').'" title="'.specialchars($title).'" onclick="Backend.openModalIframe({\'width\':765,\'title\':\'' . sprintf($GLOBALS['TL_LANG'][$strTable]['show'][1], $arrRow['id']) . '\',\'url\':this.href});return false"'.$attributes.'>'.\Image::getHtml($v['icon'], $label).'</a> ';
+					$return .= '<a href="'.$this->addToUrl($v['href'].'&amp;id='.$arrRow['id'].'&amp;popup=1').'" title="'.specialchars($title).'" onclick="Backend.openModalIframe({\'width\':765,\'title\':\''.specialchars(str_replace("'", "\\'", sprintf($GLOBALS['TL_LANG'][$strTable]['show'][1], $arrRow['id']))).'\',\'url\':this.href});return false"'.$attributes.'>'.\Image::getHtml($v['icon'], $label).'</a> ';
 				}
 				else
 				{


### PR DESCRIPTION
Simple modal window: escape the single quotation mark in the iframe's title/heading string

Fixes issue #5645
