### PR TITLE
Switch deprecated jquery accordion option `autoHeight:true` to `heightStyle:'content'`

### DIFF
--- a/system/modules/core/templates/jquery/j_accordion.html5
+++ b/system/modules/core/templates/jquery/j_accordion.html5
@@ -5,7 +5,7 @@
     $(document).ready(function() {
       $(document).accordion({
         // Put custom options here
-        autoHeight: false,
+        heightStyle: 'content',
         header:'div.toggler',
         collapsible: true
       });

--- a/system/modules/core/templates/jquery/j_accordion.xhtml
+++ b/system/modules/core/templates/jquery/j_accordion.xhtml
@@ -6,7 +6,7 @@
     $(document).ready(function() {
       $(document).accordion({
         // Put custom options here
-        autoHeight: false,
+        heightStyle: 'content',
         header:'div.toggler',
         collapsible: true
       });


### PR DESCRIPTION
I have my own customized jquery-ui 1.10.2 installed.
Maybe you must look for the version the new option belongs to.

See http://api.jqueryui.com/accordion/#option-heightStyle
