### PR TITLE
Add the sysinit hook.

### DIFF
--- a/system/initialize.php
+++ b/system/initialize.php
@@ -237,6 +237,19 @@ if (file_exists(TL_ROOT . '/system/config/initconfig.php'))
 
 
 /**
+ * HOOK: Call module initializations
+ */
+if (isset($GLOBALS['TL_HOOKS']['sysinit']) && is_array($GLOBALS['TL_HOOKS']['sysinit']))
+{
+	foreach ($GLOBALS['TL_HOOKS']['sysinit'] as $callback)
+	{
+		$objCallback = System::importStatic($callback[0]);
+		$objCallback->$callback[1]($objConfig);
+	}
+}
+
+
+/**
  * Check the request token upon POST requests
  */
 if ($_POST && !RequestToken::validate(Input::post('REQUEST_TOKEN')))


### PR DESCRIPTION
In a current customer project I have the problem that I need to manipulate the system environment, right before the request processing started. I tried a lot other hooks from `generateFrontendUrl` till `loadLanguageFile` but they all too late.

I need to manipulate the session data, right before request processing started, because it have also have to affect the `index.php` processing. The really last point to do this is the `initconfig.php`

When adding my code to the `initconfig.php` it works fine, but my customer says it have to be installable without custom modifications on the installation settings. So I request the `sysinit` hook. I called it `sysinit` in souvenir to the sysinit system initialization program for Linux. :-)

I also write the documentation for the hook https://github.com/tristanlins/docs/blob/3.0/hooks/hooks/sysinit.md

I'm hopeful it will be added to 3.1 :-)
