### PR TITLE
Fix an issue with the `class` attribute in the tree view and replace an ampersand by the corresponding character entity

### DIFF
--- a/system/modules/core/classes/DataContainer.php
+++ b/system/modules/core/classes/DataContainer.php
@@ -535,11 +535,11 @@ class DataContainer extends \Backend
 			// Add the key as CSS class
 			if (strpos($attributes, 'class="') !== false)
 			{
-				$attributes = str_replace('class="', 'class="' . $k . ' ', $attributes);
+				$attributes = str_replace('class="', ' class="' . $k . ' ', $attributes);
 			}
 			else
 			{
-				$attributes = 'class="' . $k . '"' . $attributes;
+				$attributes = ' class="' . $k . '"' . $attributes;
 			}
 
 			// Call a custom function instead of using the default button

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -3349,7 +3349,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 
 		$label = vsprintf(((strlen($GLOBALS['TL_DCA'][$table]['list']['label']['format'])) ? $GLOBALS['TL_DCA'][$table]['list']['label']['format'] : '%s'), $args);
 
-		// Shorten the label it if it is too long
+		// Shorten the label if it is too long
 		if ($GLOBALS['TL_DCA'][$table]['list']['label']['maxCharacters'] > 0 && $GLOBALS['TL_DCA'][$table]['list']['label']['maxCharacters'] < utf8_strlen(strip_tags($label)))
 		{
 			$label = trim(\String::substrHtml($label, $GLOBALS['TL_DCA'][$table]['list']['label']['maxCharacters'])) . ' …';

--- a/system/modules/core/widgets/PageTree.php
+++ b/system/modules/core/widgets/PageTree.php
@@ -185,7 +185,7 @@ class PageTree extends \Widget
 		}
 
 		$return .= '</ul>
-    <p><a href="contao/page.php?do='.\Input::get('do').'&amp;table='.$this->strTable.'&amp;field='.$this->strField.'&amp;act=show&amp;id='.\Input::get('id').'&amp;value='.implode(',', $arrSet).'&rt='.REQUEST_TOKEN.'" class="tl_submit" onclick="Backend.getScrollOffset();Backend.openModalSelector({\'width\':765,\'title\':\''.specialchars($GLOBALS['TL_LANG']['MSC']['pagepicker']).'\',\'url\':this.href,\'id\':\''.$this->strId.'\'});return false">'.$GLOBALS['TL_LANG']['MSC']['changeSelection'].'</a></p>' . (($this->strOrderField != '') ? '
+    <p><a href="contao/page.php?do='.\Input::get('do').'&amp;table='.$this->strTable.'&amp;field='.$this->strField.'&amp;act=show&amp;id='.\Input::get('id').'&amp;value='.implode(',', $arrSet).'&amp;rt='.REQUEST_TOKEN.'" class="tl_submit" onclick="Backend.getScrollOffset();Backend.openModalSelector({\'width\':765,\'title\':\''.specialchars($GLOBALS['TL_LANG']['MSC']['pagepicker']).'\',\'url\':this.href,\'id\':\''.$this->strId.'\'});return false">'.$GLOBALS['TL_LANG']['MSC']['changeSelection'].'</a></p>' . (($this->strOrderField != '') ? '
     <script>Backend.makeMultiSrcSortable("sort_'.$this->strId.'", "ctrl_'.$this->strOrderId.'")</script>' : '') . '
   </div>';
 


### PR DESCRIPTION
- Commit 79e1033549b922089ccd75bc3922f6c8500267a4: Fix the anchor `class` attribute in the tree view
- Commit 4b26ae26a0eb8390c19a4d045993f0c540e78643: Fix an unescaped ampersand in the `PageTree` widget
