### PR TITLE
Handle base64 encoded images in TCPDF

### DIFF
--- a/system/libraries/Controller.php
+++ b/system/libraries/Controller.php
@@ -1326,6 +1326,21 @@ abstract class Controller extends System
 		// Handle line breaks in preformatted text
 		$strArticle = preg_replace_callback('@(<pre.*</pre>)@Us', 'nl2br_callback', $strArticle);
 
+		// Handle base64 encoded images
+		preg_match_all('@src="data:image/(.*);base64,([^"]*)"@', $strArticle, $arrMatches);
+
+		if ($arrMatches)
+		{
+			foreach ($arrMatches[0] as $k => $match)
+			{
+				$strSrcPath = 'system/html/' . md5($arrMatches[2][$k]) . '.' . $arrMatches[1][$k];
+				$objFile = new File($strSrcPath);
+				$objFile->write(base64_decode($arrMatches[2][$k]));
+				$objFile->close();
+				$strArticle = str_replace($match, sprintf('src="%s"', $this->Environment->base . $strSrcPath), $strArticle);
+			}
+		}
+
 		// Default PDF export using TCPDF
 		$arrSearch = array
 		(


### PR DESCRIPTION
Hi everyone

@alekszmusic had an issue printing an article as PDF on one of her customer's pages.

I found that it's an issue with base64 encoded images in tinyMCE. Apparently there are cases where images are stored base64 encoded in the html source code. In this case it was Microsoft's Lync that automatically transforms phone numbers and adds an icon next to it which was then transformed to base64 by tinyMCE.

It eventually all looks perfectly fine on the website (I won't discuss the issue whether the icon belongs to the website or not).

The issue is that TCPDF can't handle base64-encoded images as it needs an URI for the image to call.

Basically we had two options:
1. Tell the customer to always edit the html code in tinyMCE and to remove the icon. Problem: they don't know html and they don't want to care about things like that.
2. We provide a workaround that turns base64 encoded images into real, temporary files which is what this pull request does.

It's a TCPDF specific problem which is why I put the code in `Controller::printArticleAsPdf()`. Please don't discuss whether it is correct or not to have base64 encoded images in tinyMCE. It's apparently something that may happen and that causes a fatal error in the front end.

What do you think?
