### PR TITLE
Bugfix: use the fallback for the root page also when language is supplied on the URL.

### DIFF
--- a/system/modules/frontend/Frontend.php
+++ b/system/modules/frontend/Frontend.php
@@ -193,7 +193,7 @@ abstract class Frontend extends Controller
 		// The language is set in the URL
 		if ($GLOBALS['TL_CONFIG']['addLanguageToUrl'] && !empty($_GET['language']))
 		{
-			$objRootPage = $this->Database->prepare("SELECT id, dns, language, fallback FROM tl_page WHERE type='root' AND (dns=? OR dns='') AND language=?" . (!BE_USER_LOGGED_IN ? " AND (start='' OR start<$time) AND (stop='' OR stop>$time) AND published=1" : "") . " ORDER BY dns DESC, fallback")
+			$objRootPage = $this->Database->prepare("SELECT id, dns, language, fallback FROM tl_page WHERE type='root' AND (dns=? OR dns='') AND (language=? OR fallback=1)" . (!BE_USER_LOGGED_IN ? " AND (start='' OR start<$time) AND (stop='' OR stop>$time) AND published=1" : "") . " ORDER BY dns DESC, fallback")
 										  ->limit(1)
 										  ->execute($host, $this->Input->get('language'));
 


### PR DESCRIPTION
Bugfix: use the fallback for the root page also when there has been a language supplied on the URL.

Otherwise the result is always an internal "no root page found" for ANY 2char suffix on the URL, causing the defined 404 page never being used.

test via: http://contao.org/yy
