### PR TITLE
During SMH Installation the Installer issues a call to Files::getInstance before $GLOBALS['TL_CONFIG']['useFTP'] can be set

### DIFF
--- a/system/modules/core/library/Contao/Files.php
+++ b/system/modules/core/library/Contao/Files.php
@@ -66,28 +66,53 @@ abstract class Files
 	 */
 	public static function getInstance()
 	{
-		if (self::$objInstance === null)
+		/*
+		 * Hmn, okay. Due to problems when getInstance() is called
+		 * self::$objInstance might be of the wrong type, ie:
+		 * a php file handler when an ftp file handler would be 
+		 * required.
+		 */
+		
+		$handlerType = "PHP";
+		if ($GLOBALS['TL_CONFIG']['useFTP']) {
+			$handlerType = "FTP";
+		} elseif ($GLOBALS['TL_CONFIG']['useSmhExtended'] && in_array('smhextended', \Config::getInstance()->getActiveModules())) {
+			$handlerType = "SMH";
+		}
+
+		if (self::$objInstance === null) {
+			self::$objInstance = array(
+				'PHP'	=>	null,
+				'FTP'	=>	null,
+				'SMH'	=>	null,
+			);
+		}
+		
+
+
+		if (self::$objInstance[$handlerType] === null)
 		{
+
 			// Use FTP to modify files
 			if ($GLOBALS['TL_CONFIG']['useFTP'])
 			{
-				self::$objInstance = new \Files\Ftp();
+				self::$objInstance[$handlerType] = new \Files\Ftp();
 			}
 
 			// HOOK: use the smhextended module
 			elseif ($GLOBALS['TL_CONFIG']['useSmhExtended'] && in_array('smhextended', \Config::getInstance()->getActiveModules()))
 			{
-				self::$objInstance = new \SMHExtended();
+				self::$objInstance[$handlerType] = new \SMHExtended();
 			}
 
 			// Use PHP to modify files
 			else
 			{
-				self::$objInstance = new \Files\Php();
+				self::$objInstance[$handlerType] = new \Files\Php();
 			}
 		}
 
-		return self::$objInstance;
+		return self::$objInstance[$handlerType];
 	}
 
 


### PR DESCRIPTION
Because we're doing a safe-mode installation, we want that the Installer instantiates the Files\Ftp-Implementation by setting before $GLOBALS['TL_CONFIG']['useFTP'] to true prior to the call to Files::getInstance() being made.

Only this doesn't work because InstallTool->loadLanguageFile() is called by InstallTool's constructor, and it in turn again will result in a call to Files::getInstance and an instantiation of Files\Php; this all happens before $GLOBALS['TL_CONFIG']['useFTP'] is set. The user-facing consequences of this is that entering the correct FTP-credentials will lead to no error message and the FTP Credentials Input mask being displayed again. And again. And again ... 

The correct fix would be to fix the call-flow, but I don't have the time nor the inclination to for this, so instead of this you get a quick hack. ;)
It somewhat relaxes the singleton-semantics of Files; it now differentiates between three different handler types and treats each of those handlers as a singleton.
Objects that have called Files::getInstance before the change to $GLOBALS['TL_CONFIG']['useFTP']  was made retain their old implementation, but can "update" it by another call to $this->import('Files')
