### PR TITLE
New feed implementation in \PageRegular

### DIFF
--- a/system/modules/calendar/classes/Calendar.php
+++ b/system/modules/calendar/classes/Calendar.php
@@ -90,6 +90,40 @@ class Calendar extends \Frontend
 
 
 	/**
+	 * Add calendar feeds to the header scripts
+	 * @param object
+	 * @param object
+	 * @param object
+	 * @return string
+	 */
+	public function getPageStyleSheets($objPage, $objLayout, $objPageRegular)
+	{
+		$strStyleSheets = '';
+		$blnXhtml = ($objPage->outputFormat == 'xhtml');
+		$strTagEnding = $blnXhtml ? ' />' : '>';
+
+		$calendarfeeds = deserialize($objLayout->calendarfeeds);
+
+		// Add calendarfeeds
+		if (is_array($calendarfeeds) && !empty($calendarfeeds))
+		{
+			$objFeeds = \CalendarFeedModel::findByIds($calendarfeeds);
+
+			if ($objFeeds !== null)
+			{
+				while($objFeeds->next())
+				{
+					$base = $objFeeds->feedBase ?: \Environment::get('base');
+					$strStyleSheets .= '<link rel="alternate" href="' . $base . 'share/' . $objFeeds->alias . '.xml" type="application/' . $objFeeds->format . '+xml" title="' . $objFeeds->title . '"' . $strTagEnding . "\n";
+				}
+			}
+		}
+		
+		return $strStyleSheets;
+	}
+
+
+	/**
 	 * Generate an XML file and save it to the root directory
 	 * @param array
 	 */

--- a/system/modules/calendar/config/config.php
+++ b/system/modules/calendar/config/config.php
@@ -51,6 +51,7 @@ $GLOBALS['TL_CRON']['daily'][] = array('Calendar', 'generateFeeds');
 $GLOBALS['TL_HOOKS']['removeOldFeeds'][] = array('Calendar', 'purgeOldFeeds');
 $GLOBALS['TL_HOOKS']['getSearchablePages'][] = array('Calendar', 'getSearchablePages');
 $GLOBALS['TL_HOOKS']['generateXmlFiles'][] = array('Calendar', 'generateFeeds');
+$GLOBALS['TL_HOOKS']['getPageStyleSheets'][] = array('Calendar', 'getPageStyleSheets');
 
 
 /**

--- a/system/modules/core/pages/PageRegular.php
+++ b/system/modules/core/pages/PageRegular.php
@@ -576,39 +576,6 @@ class PageRegular extends \Frontend
 		// Always add conditional style sheets at the end
 		$strStyleSheets .= $strCcStyleSheets;
 
-		$newsfeeds = deserialize($objLayout->newsfeeds);
-		$calendarfeeds = deserialize($objLayout->calendarfeeds);
-
-		// Add newsfeeds
-		if (is_array($newsfeeds) && !empty($newsfeeds))
-		{
-			$objFeeds = \NewsFeedModel::findByIds($newsfeeds);
-
-			if ($objFeeds !== null)
-			{
-				while($objFeeds->next())
-				{
-					$base = $objFeeds->feedBase ?: \Environment::get('base');
-					$strStyleSheets .= '<link rel="alternate" href="' . $base . 'share/' . $objFeeds->alias . '.xml" type="application/' . $objFeeds->format . '+xml" title="' . $objFeeds->title . '"' . $strTagEnding . "\n";
-				}
-			}
-		}
-
-		// Add calendarfeeds
-		if (is_array($calendarfeeds) && !empty($calendarfeeds))
-		{
-			$objFeeds = \CalendarFeedModel::findByIds($calendarfeeds);
-
-			if ($objFeeds !== null)
-			{
-				while($objFeeds->next())
-				{
-					$base = $objFeeds->feedBase ?: \Environment::get('base');
-					$strStyleSheets .= '<link rel="alternate" href="' . $base . 'share/' . $objFeeds->alias . '.xml" type="application/' . $objFeeds->format . '+xml" title="' . $objFeeds->title . '"' . $strTagEnding . "\n";
-				}
-			}
-		}
-
 		// Add a placeholder for dynamic <head> tags (see #4203)
 		$strHeadTags = '[[TL_HEAD]]';
 

--- a/system/modules/core/pages/PageRegular.php
+++ b/system/modules/core/pages/PageRegular.php
@@ -573,6 +573,15 @@ class PageRegular extends \Frontend
 			$strStyleSheets .= '<link rel="stylesheet" href="' . $this->addStaticUrlTo('assets/contao/css/debug.css') . '"' . $strTagEnding . "\n";
 		}
 
+		if (isset($GLOBALS['TL_HOOKS']['getPageStyleSheets']) && is_array($GLOBALS['TL_HOOKS']['getPageStyleSheets']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['getPageStyleSheets'] as $callback)
+			{
+				$this->import($callback[0]);
+				$strStyleSheets .= $this->$callback[0]->$callback[1]($objPage, $objLayout, $this);
+			}
+		}
+
 		// Always add conditional style sheets at the end
 		$strStyleSheets .= $strCcStyleSheets;
 

--- a/system/modules/news/classes/News.php
+++ b/system/modules/news/classes/News.php
@@ -83,6 +83,40 @@ class News extends \Frontend
 
 
 	/**
+	 * Add news feeds to the header scripts
+	 * @param object
+	 * @param object
+	 * @param object
+	 * @return string
+	 */
+	public function getPageStyleSheets($objPage, $objLayout, $objPageRegular)
+	{
+		$strStyleSheets = '';
+		$blnXhtml = ($objPage->outputFormat == 'xhtml');
+		$strTagEnding = $blnXhtml ? ' />' : '>';
+
+		$newsfeeds = deserialize($objLayout->newsfeeds);
+
+		// Add newsfeeds
+		if (is_array($newsfeeds) && !empty($newsfeeds))
+		{
+			$objFeeds = \NewsFeedModel::findByIds($newsfeeds);
+
+			if ($objFeeds !== null)
+			{
+				while($objFeeds->next())
+				{
+					$base = $objFeeds->feedBase ?: \Environment::get('base');
+					$strStyleSheets .= '<link rel="alternate" href="' . $base . 'share/' . $objFeeds->alias . '.xml" type="application/' . $objFeeds->format . '+xml" title="' . $objFeeds->title . '"' . $strTagEnding . "\n";
+				}
+			}
+		}
+		
+		return $strStyleSheets;
+	}
+
+
+	/**
 	 * Generate an XML files and save them to the root directory
 	 * @param array
 	 */

--- a/system/modules/news/config/config.php
+++ b/system/modules/news/config/config.php
@@ -50,6 +50,7 @@ $GLOBALS['TL_CRON']['daily'][] = array('News', 'generateFeeds');
 $GLOBALS['TL_HOOKS']['removeOldFeeds'][] = array('News', 'purgeOldFeeds');
 $GLOBALS['TL_HOOKS']['getSearchablePages'][] = array('News', 'getSearchablePages');
 $GLOBALS['TL_HOOKS']['generateXmlFiles'][] = array('News', 'generateFeeds');
+$GLOBALS['TL_HOOKS']['getPageStyleSheets'][] = array('News', 'getPageStyleSheets');
 
 
 /**


### PR DESCRIPTION
Adds a new Hook `getPageStyleSheets` to extend the default header style output.
It is not possbile to register **custom module feeds** (or custom link-rel-types) on the fly.

This **additional hook** aims to the Frontend output of a regular Page and cleans up the `\PageRegular` class. 

The default feeds (`newsfeeds` & `calendarfeeds`) are **hardcoded** in `\PageRegular`. The functions have been moved to their module configuration files and classes by using the new hook.

Changes:
1. **Module News**
   - Registered a new hook `getPageStyleSheets` 
   - Added a new function to `\News` to add the news feeds (`getPageStyleSheets` )
2. **Module Calendar**
   - Registered a new hook `getPageStyleSheets` (config)
   - Added a new function to `\Calendar` to add the calendar feeds (`getPageStyleSheets`)
