### PR TITLE
Fix domain property not being set in generateFrontendUrl

### DIFF
--- a/system/modules/core/modules/Module.php
+++ b/system/modules/core/modules/Module.php
@@ -269,10 +269,11 @@ abstract class Module extends \Frontend
 						{
 							$strForceLang = null;
 
+							$objNext->loadDetails(); // see #3983 and #3765
+
 							// Check the target page language (see #4706)
 							if ($GLOBALS['TL_CONFIG']['addLanguageToUrl'])
 							{
-								$objNext->loadDetails(); // see #3983
 								$strForceLang = $objNext->language;
 							}
 


### PR DESCRIPTION
The fix for #3765 relies on the domain property. Without the above fix that property may not be set when it should have been.
