### PR TITLE
Show or Hide Hidden Files

### DIFF
--- a/system/config/default.php
+++ b/system/config/default.php
@@ -327,6 +327,7 @@ $GLOBALS['TL_CONFIG']['liveUpdateId']         = '';
 $GLOBALS['TL_CONFIG']['disableInsertTags']    = false;
 $GLOBALS['TL_CONFIG']['rootFiles']            = array();
 $GLOBALS['TL_CONFIG']['fileSyncExclude']      = '';
+$GLOBALS['TL_CONFIG']['hiddenFiles']	      = array('/^\./');
 $GLOBALS['TL_CONFIG']['doNotCollapse']        = false;
 $GLOBALS['TL_CONFIG']['urlSuffix']            = '.html';
 $GLOBALS['TL_CONFIG']['exampleWebsite']       = '';

--- a/system/modules/core/dca/tl_files.php
+++ b/system/modules/core/dca/tl_files.php
@@ -45,6 +45,14 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 	(
 		'global_operations' => array
 		(
+			'showHidden' => array
+			(
+				'label'				  => &$GLOBALS['TL_LANG']['tl_files']['hiddenFiles'],
+				'href'                => 'do=files',
+				'class'               => 'header_show_hidden',
+				'attributes'          => 'onclick="Backend.getScrollOffset()"',
+				'button_callback'     => array('tl_files', 'showHidden')
+			),
 			'sync' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_files']['sync'],
@@ -399,6 +407,27 @@ class tl_files extends Backend
 
 
 	/**
+	 * Return the showHidden files button
+	 * @param array
+	 * @param string
+	 * @param string
+	 * @param string
+	 * @param string
+	 * @param string
+	 * @return string
+	 */
+	public function showHidden($href, $label, $title, $class, $attributes)
+	{
+		$showHidden = 'showHidden=0';
+		if (\Input::get('showHidden', true)==0)
+		{
+			$showHidden = 'showHidden=1';
+		}
+		return $this->User->isAdmin ? '<a href="'.$this->addToUrl($href.'&'.$showHidden).'" title="'.specialchars($title).'" class="'.$class.'"'.$attributes.'>'.$label.'</a> ' : '';
+	}
+
+
+	/**
 	 * Return the edit file button
 	 * @param array
 	 * @param string
@@ -462,8 +491,10 @@ class tl_files extends Backend
 		{
 			return ($this->User->isAdmin || $this->User->hasAccess('f4', 'fop')) ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.specialchars($title).'"'.$attributes.'>'.Image::getHtml($icon, $label).'</a> ' : Image::getHtml(preg_replace('/\.gif$/i', '_.gif', $icon)).' ';
 		}
-
-		return ($this->User->isAdmin || $this->User->hasAccess('f3', 'fop') || $this->User->hasAccess('f4', 'fop')) ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.specialchars($title).'"'.$attributes.'>'.Image::getHtml($icon, $label).'</a> ' : Image::getHtml(preg_replace('/\.gif$/i', '_.gif', $icon)).' ';
+		else
+		{
+			return ($this->User->isAdmin || $this->User->hasAccess('f3', 'fop') || $this->User->hasAccess('f4', 'fop')) ? '<a href="'.$this->addToUrl($href.'&amp;id='.$row['id']).'" title="'.specialchars($title).'"'.$attributes.'>'.Image::getHtml($icon, $label).'</a> ' : Image::getHtml(preg_replace('/\.gif$/i', '_.gif', $icon)).' ';
+		}
 	}
 
 

--- a/system/modules/core/drivers/DC_Folder.php
+++ b/system/modules/core/drivers/DC_Folder.php
@@ -1939,7 +1939,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 		{
 			foreach (scan($path) as $v)
 			{
-				if ($v == '.svn' || $v == '.DS_Store')
+				if ($v == '.svn' || $v == '.DS_Store' || $this->isHiddenFile($v))
 				{
 					continue;
 				}
@@ -2235,5 +2235,24 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 		}
 
 		return $arrFiles;
+	}
+
+	/**
+	 * Check if the File is hidden
+	 * @param string
+	 * @return boolean
+	 */
+	protected function isHiddenFile($file, $forceIgnore=false)
+	{
+		$showHiddenFiles = (\Input::get('showHidden', true)==1)? true : false;
+
+		if ($showHiddenFiles && !$forceIgnore) return false;
+
+		foreach($GLOBALS['TL_CONFIG']['hiddenFiles'] as $pattern)
+		{
+			if (preg_match($pattern,$file)) return true;
+		}
+
+		return false;
 	}
 }

--- a/system/modules/core/languages/de/tl_files.xlf
+++ b/system/modules/core/languages/de/tl_files.xlf
@@ -197,6 +197,14 @@
         <source>Synchronize the file system and the database</source>
         <target>Dateisystem und Datenbank synchronisieren</target>
       </trans-unit>
+	  <trans-unit id="tl_files.hiddenFiles.0">
+        <source>Hidden Elements</source>
+        <target>Ausgeblendete Elemente</target>
+      </trans-unit>
+      <trans-unit id="tl_files.hiddenFiles.1">
+        <source>Show or hide the Hidden Elements</source>
+        <target>Alle ausgeblendeten Elemente Anzeigen oder Ausblenden</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
I attached a commit to enabled possibility to switch show or hide 'hidden' files.

It is configure able by using patterns. I have added a default as example. We can remove this.

``` php
$GLOBALS['TL_CONFIG']['hiddenFiles']          = array('/^\./');
```

The Hidden files are not excluded from sync. You can show them and edit them.
Also it is not possible to select them in the File Picker in an Article -> Do we need that?

You are able to show or Hide hidden Files by clicking on the `showHidden` link in the filemanager.

I know, that patterns are not for the best performance, but IMO it is the best solution.

This Pull Request refers to: #5699 and #5700

So there were discussions about adding a custom file in the Folder similar to the `.gitignore`. @LeoUnglaub and @s-nunez-gosub think that this is a good solution.

So wich way do you think is the best?
