### PR TITLE
Fix usage of wrong variable in repository manager.

### DIFF
--- a/system/modules/repository/classes/RepositoryManager.php
+++ b/system/modules/repository/classes/RepositoryManager.php
@@ -1161,9 +1161,9 @@ class RepositoryManager extends RepositoryBackendModule
 					foreach ($ext->dependencies as &$dep) {
 						$found = false;
 						foreach ($exts as $e)
-							if ($e->extension == $dep->extension) {
+							if ($ext->extension == $dep->extension) {
 								$found = true;
-								$extver = $e->version;
+								$extver = $ext->version;
 								$minver = $dep->minversion>0 ? $dep->minversion : $extver;
 								$maxver = $dep->maxversion>0 ? $dep->maxversion : $extver;
 								if ($extver<$minver || $extver>$maxver) {
@@ -1171,9 +1171,9 @@ class RepositoryManager extends RepositoryBackendModule
 									$minver = intval($minver / 10000);
 									$maxver = intval($maxver / 10000);
 									if ($extver<$minver || $extver>$maxver)
-										$ext->dep_incompatible[] = array('extension'=>$e->extension, 'version'=>$e->version);
+										$ext->dep_incompatible[] = array('extension'=>$ext->extension, 'version'=>$ext->version);
 									else
-										$ext->dep_shouldwork[] = array('extension'=>$e->extension, 'version'=>$e->version);
+										$ext->dep_shouldwork[] = array('extension'=>$ext->extension, 'version'=>$ext->version);
 								} // if
 								break;
 							} // if
@@ -1234,8 +1234,8 @@ class RepositoryManager extends RepositoryBackendModule
 				if (property_exists($rec, 'dependencies')) {
 					foreach ($rec->dependencies as &$dep) {
 						foreach ($exts as $e)
-							if ($e->extension == $dep->extension) {
-								$extver = intval($e->version/10000);
+							if ($ext->extension == $dep->extension) {
+								$extver = intval($ext->version/10000);
 								$minver = $dep->minversion>0 ? intval($dep->minversion/10000) : $extver;
 								$maxver = $dep->maxversion>0 ? intval($dep->maxversion/10000) : $extver;
 								if ($extver<$minver || $extver>$maxver) $compatible = false;
@@ -1259,7 +1259,7 @@ class RepositoryManager extends RepositoryBackendModule
 			$ext->status = array();
 
 			// code red
-			if ((int)$e->error>0)
+			if ((int)$ext->error>0)
 				$ext->status[] = (object)array(
 					'color'	=> 'red',
 					'text'	=> 'errorinstall'


### PR DESCRIPTION
In some lines the variable `$e` instead of `$ext` is used in the repository manager.
At a result, status messages will not displayed correctly.
The extension will be displayed as "clean", even its marked as "broken".
