### PR TITLE
fixed forwarding if auto_item is set

### DIFF
--- a/system/modules/core/pages/PageForward.php
+++ b/system/modules/core/pages/PageForward.php
@@ -78,7 +78,14 @@ class PageForward extends \Frontend
 					continue;
 				}
 
-				$strGet .= '/' . $key . '/' . \Input::get($key);
+				if ($GLOBALS['TL_CONFIG']['useAutoItem'] && $key != "auto_item")
+				{
+					$strGet .= '/' . $key . '/' . \Input::get($key);
+				}
+				else
+				{
+					$strGet .= '/' . \Input::get($key);
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixed Page Forwarding if Auto Item is set to true.

You can reproduce the issue, by the following way (online demo):
1. copy the "news" page
2. set this page to visible
3. redirect the old "news" page to the copied one
4. change the jump to URL in the news archive to our New Page
5. call a news item with the old page alias
So `http://demo2.contao.org/en/news/open-days.html` will be redirected to `http://demo2.contao.org/en/news-copied/auto_items/open-days.html`

This Pull request fixes the `auto_item` issue if the `$GLOBALS['TL_CONFIG']['useAutoItem']` is set to true.
