### PR TITLE
Escape ampersand characters to the corresponding HTML entity

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -1269,7 +1269,7 @@ abstract class Controller extends \System
 						break;
 					}
 
-					$strUrl = ampersand(\Environment::get('request'), true);
+					$strUrl = ampersand(\Environment::get('request'));
 					$strGlue = (strpos($strUrl, '?') === false) ? '?' : '&amp;';
 
 					if ($objPage->isMobile)

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -1269,7 +1269,7 @@ abstract class Controller extends \System
 						break;
 					}
 
-					$strUrl = \Environment::get('request');
+					$strUrl = ampersand(\Environment::get('request'), true);
 					$strGlue = (strpos($strUrl, '?') === false) ? '?' : '&amp;';
 
 					if ($objPage->isMobile)

--- a/system/modules/core/modules/ModuleLogin.php
+++ b/system/modules/core/modules/ModuleLogin.php
@@ -170,7 +170,7 @@ class ModuleLogin extends \Module
 
 			$this->Template->slabel = specialchars($GLOBALS['TL_LANG']['MSC']['logout']);
 			$this->Template->loggedInAs = sprintf($GLOBALS['TL_LANG']['MSC']['loggedInAs'], $this->User->username);
-			$this->Template->action = \Environment::get('indexFreeRequest');
+			$this->Template->action = ampersand(\Environment::get('indexFreeRequest'), true);
 
 			if ($this->User->lastLogin > 0)
 			{
@@ -205,7 +205,7 @@ class ModuleLogin extends \Module
 		$this->Template->hasError = $blnHasError;
 		$this->Template->username = $GLOBALS['TL_LANG']['MSC']['username'];
 		$this->Template->password = $GLOBALS['TL_LANG']['MSC']['password'][0];
-		$this->Template->action = \Environment::get('indexFreeRequest');
+		$this->Template->action = ampersand(\Environment::get('indexFreeRequest'), true);
 		$this->Template->slabel = specialchars($GLOBALS['TL_LANG']['MSC']['login']);
 		$this->Template->value = specialchars(\Input::post('username'));
 		$this->Template->autologin = ($this->autologin && $GLOBALS['TL_CONFIG']['autologin'] > 0);

--- a/system/modules/core/modules/ModuleLogin.php
+++ b/system/modules/core/modules/ModuleLogin.php
@@ -170,7 +170,7 @@ class ModuleLogin extends \Module
 
 			$this->Template->slabel = specialchars($GLOBALS['TL_LANG']['MSC']['logout']);
 			$this->Template->loggedInAs = sprintf($GLOBALS['TL_LANG']['MSC']['loggedInAs'], $this->User->username);
-			$this->Template->action = ampersand(\Environment::get('indexFreeRequest'), true);
+			$this->Template->action = ampersand(\Environment::get('indexFreeRequest'));
 
 			if ($this->User->lastLogin > 0)
 			{
@@ -205,7 +205,7 @@ class ModuleLogin extends \Module
 		$this->Template->hasError = $blnHasError;
 		$this->Template->username = $GLOBALS['TL_LANG']['MSC']['username'];
 		$this->Template->password = $GLOBALS['TL_LANG']['MSC']['password'][0];
-		$this->Template->action = ampersand(\Environment::get('indexFreeRequest'), true);
+		$this->Template->action = ampersand(\Environment::get('indexFreeRequest'));
 		$this->Template->slabel = specialchars($GLOBALS['TL_LANG']['MSC']['login']);
 		$this->Template->value = specialchars(\Input::post('username'));
 		$this->Template->autologin = ($this->autologin && $GLOBALS['TL_CONFIG']['autologin'] > 0);

--- a/system/modules/core/modules/ModuleNavigation.php
+++ b/system/modules/core/modules/ModuleNavigation.php
@@ -99,7 +99,7 @@ class ModuleNavigation extends \Module
 			}
 		}
 
-		$this->Template->request = \Environment::get('indexFreeRequest');
+		$this->Template->request = ampersand(\Environment::get('indexFreeRequest'), true);
 		$this->Template->skipId = 'skipNavigation' . $this->id;
 		$this->Template->skipNavigation = specialchars($GLOBALS['TL_LANG']['MSC']['skipNavigation']);
 		$this->Template->items = $this->renderNavigation($trail[$level], 1, $host, $lang);

--- a/system/modules/core/modules/ModuleNavigation.php
+++ b/system/modules/core/modules/ModuleNavigation.php
@@ -99,7 +99,7 @@ class ModuleNavigation extends \Module
 			}
 		}
 
-		$this->Template->request = ampersand(\Environment::get('indexFreeRequest'), true);
+		$this->Template->request = ampersand(\Environment::get('indexFreeRequest'));
 		$this->Template->skipId = 'skipNavigation' . $this->id;
 		$this->Template->skipNavigation = specialchars($GLOBALS['TL_LANG']['MSC']['skipNavigation']);
 		$this->Template->items = $this->renderNavigation($trail[$level], 1, $host, $lang);

--- a/system/modules/core/modules/ModuleSearch.php
+++ b/system/modules/core/modules/ModuleSearch.php
@@ -99,7 +99,7 @@ class ModuleSearch extends \Module
 		$objFormTemplate->matchAll = specialchars($GLOBALS['TL_LANG']['MSC']['matchAll']);
 		$objFormTemplate->matchAny = specialchars($GLOBALS['TL_LANG']['MSC']['matchAny']);
 		$objFormTemplate->id = ($GLOBALS['TL_CONFIG']['disableAlias'] && \Input::get('id')) ? \Input::get('id') : false;
-		$objFormTemplate->action = \Environment::get('indexFreeRequest');
+		$objFormTemplate->action = ampersand(\Environment::get('indexFreeRequest'), true);
 
 		// Redirect page
 		if ($this->jumpTo && ($objTarget = $this->objModel->getRelated('jumpTo')) !== null)

--- a/system/modules/core/modules/ModuleSearch.php
+++ b/system/modules/core/modules/ModuleSearch.php
@@ -99,7 +99,7 @@ class ModuleSearch extends \Module
 		$objFormTemplate->matchAll = specialchars($GLOBALS['TL_LANG']['MSC']['matchAll']);
 		$objFormTemplate->matchAny = specialchars($GLOBALS['TL_LANG']['MSC']['matchAny']);
 		$objFormTemplate->id = ($GLOBALS['TL_CONFIG']['disableAlias'] && \Input::get('id')) ? \Input::get('id') : false;
-		$objFormTemplate->action = ampersand(\Environment::get('indexFreeRequest'), true);
+		$objFormTemplate->action = ampersand(\Environment::get('indexFreeRequest'));
 
 		// Redirect page
 		if ($this->jumpTo && ($objTarget = $this->objModel->getRelated('jumpTo')) !== null)


### PR DESCRIPTION
There were some unescaped ampersand characters when it comes to URL parameters.

Fix applied to
- various module classes
- Controller library

---

To reproduce the issue:
- Open the [search page](http://demo2.contao.org/en/search.html) from the Contao online demo
- Enter e.g. the keywords "james wilson" and search for it
- Check the source code view and/or validate the page with a HTML validator
