### PR TITLE
Beim Login wird die Letzte Anmeldung nicht geupdatet

### DIFF
--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -338,8 +338,8 @@ abstract class User extends \System
 		$this->setUserFromDb();
 
 		// Update the record
-		$this->lastLogin = $this->currentLogin;
 		$this->currentLogin = $time;
+		$this->lastLogin = $this->currentLogin;
 		$this->loginCount = $GLOBALS['TL_CONFIG']['loginCount'];
 		$this->save();
 


### PR DESCRIPTION
Hallo miteinander, 

mir ist gerade aufgefallen, dass - obwohl ich mich als FrontendUser eingeloggt habe - der Zeitstempel der letzten Anmeldung nicht mehr geändert wird. 

Getestet habe ich dies auch in der Online-Demo mit Erfolg.
Ich habe mich als FrontendUser angemeldet, und im Backend danach eingeloggt. Es erscheint auch unter System-Log die Info, dass sich der Benutzer angemeldet hat, jedoch stimmt die Uhrzeit und das Datum bei dem entsprechenden User nicht mit dem letzten Loginvorgang überein.

Fehler konnte ich mit der Codeänderung beheben.

Viele Grüße
Fabian
