### PR TITLE
Set max width to images wich are linked in the href

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -1525,7 +1525,16 @@ abstract class Controller extends \System
 								$attribute = ' data-lightbox="' . substr($rel, 8) . '"';
 							}
 
-							$arrCache[$strTag] = '<a href="' . TL_FILES_URL . $strFile . '"' . (($alt != '') ? ' title="' . $alt . '"' : '') . $attribute . '><img src="' . TL_FILES_URL . $src . '" ' . $dimensions . ' alt="' . $alt . '"' . (($class != '') ? ' class="' . $class . '"' : '') . (($objPage->outputFormat == 'xhtml') ? ' />' : '>') . '</a>';
+							$href = $strFile;
+							if ($GLOBALS['TL_CONFIG']['maxImageWidth'] > 0)
+							{
+								$size = @getimagesize(TL_ROOT .'/'. rawurldecode($href));
+								$size[0] = $GLOBALS['TL_CONFIG']['maxImageWidth'];
+								$ratio = $size[1] / $size[0];
+								$size[1] = floor($size[0] * $ratio);
+								$href = \Image::get($strFile, $size[0], $size[1], '');
+							}
+							$arrCache[$strTag] = '<a href="' . TL_FILES_URL . $href . '"' . (($alt != '') ? ' title="' . $alt . '"' : '') . $attribute . '><img src="' . TL_FILES_URL . $src . '" ' . $dimensions . ' alt="' . $alt . '"' . (($class != '') ? ' class="' . $class . '"' : '') . (($objPage->outputFormat == 'xhtml') ? ' />' : '>') . '</a>';
 						}
 						else
 						{

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -2533,8 +2533,7 @@ abstract class Controller extends \System
 			{
 				$ratio = floor($objTemplate->height / $objTemplate->width);
 				$size[0] = $GLOBALS['TL_CONFIG']['maxImageWidth'];
-				$ratio = $imgSize[1] / $imgSize[0];
-				$size[1] = floor($GLOBALS['TL_CONFIG']['maxImageWidth'] * $ratio);
+				$size[1] = floor($size[0] * $ratio);
 				$href = \Image::get($arrItem['singleSRC'], $size[0], $size[1], '');
 			}
 			$objTemplate->href = TL_FILES_URL . \System::urlEncode($href);

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -2528,7 +2528,16 @@ abstract class Controller extends \System
 		// Fullsize view
 		elseif ($arrItem['fullsize'] && TL_MODE == 'FE')
 		{
-			$objTemplate->href = TL_FILES_URL . \System::urlEncode($arrItem['singleSRC']);
+			$href = $arrItem['singleSRC'];
+			if ($GLOBALS['TL_CONFIG']['maxImageWidth'] > 0)
+			{
+				$ratio = floor($objTemplate->height / $objTemplate->width);
+				$size[0] = $GLOBALS['TL_CONFIG']['maxImageWidth'];
+				$ratio = $imgSize[1] / $imgSize[0];
+				$size[1] = floor($GLOBALS['TL_CONFIG']['maxImageWidth'] * $ratio);
+				$href = \Image::get($arrItem['singleSRC'], $size[0], $size[1], '');
+			}
+			$objTemplate->href = TL_FILES_URL . \System::urlEncode($href);
 			$objTemplate->attributes = ($objPage->outputFormat == 'xhtml') ? ' rel="' . $strLightboxId . '"' : ' data-lightbox="' . substr($strLightboxId, 9, -1) . '"';
 		}
 


### PR DESCRIPTION
This Pullrequest improved the possibility to resize the Images wich are shown in a Lightbox or in a new window.

The Reason why I need this is, that I am working on an extension, wich resize the Images for mobile devices. With these changes it would be much more easier to resize those images.

I use the `$GLOBALS['TL_CONFIG']['maxImageWidth']` beacause it overrides all other Image width as well.

One Thing I am not sure if we should resize this as well. -> the original `$objTemplate->singleSRC`.

What do you think?
