### PR TITLE
Bugfix: ModuleNewsList liefert falsche Ergebnisse ab Seite 2

### DIFF
--- a/system/modules/news/modules/ModuleNewsList.php
+++ b/system/modules/news/modules/ModuleNewsList.php
@@ -137,7 +137,7 @@ class ModuleNewsList extends \ModuleNews
 			$offset += (max($page, 1) - 1) * $this->perPage;
 
 			// Overall limit
-			if ($offset + $limit > $total)
+			if (($offset + $limit) > ($total + $offset))
 			{
 				$limit = $total - $offset;
 			}


### PR DESCRIPTION
Setzt man im Frontend-Modul der Nachrichten-liste sowohl skipFirst auf 3 und begrenzt die Elemente pro Seite auf 3 (ohne eine Begrenzung der Gesamtanzahl der Beiträge), so wird ab der zweiten Seite und Folgeseiten (Paginierung), nur noch ein Beitrag angezeigt.
