### PR TITLE
Update Controller.php

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -2461,16 +2461,16 @@ abstract class Controller extends \System
 		$objTemplate->height = $imgSize[1];
 
 		// Adjust the image size
+		$arrMargin = deserialize($arrItem['imagemargin']);
+
+		// Subtract margins
+		if (is_array($arrMargin) && $arrMargin['unit'] == 'px')
+		{
+			$intMaxWidth = $intMaxWidth - $arrMargin['left'] - $arrMargin['right'];
+		}
+
 		if ($intMaxWidth > 0 && ($size[0] > $intMaxWidth || (!$size[0] && !$size[1] && $imgSize[0] > $intMaxWidth)))
 		{
-			$arrMargin = deserialize($arrItem['imagemargin']);
-
-			// Subtract margins
-			if (is_array($arrMargin) && $arrMargin['unit'] == 'px')
-			{
-				$intMaxWidth = $intMaxWidth - $arrMargin['left'] - $arrMargin['right'];
-			}
-
 			// See #2268 (thanks to Thyon)
 			$ratio = ($size[0] && $size[1]) ? $size[1] / $size[0] : $imgSize[1] / $imgSize[0];
 


### PR DESCRIPTION
Function addImageToTemplate

Vor der Entscheidung, ob ein Bild verkleinert werden muss, muss das Margin schon mit berücksichtigt werden.

Beispiel ce_gallery:

Einstellungen:
Maximale Frontend-Breite = 800

ce_gallery:
margin: 0 20px;
Bildbreite = 400
2 Bilder nebeneinander

Die Bilder müssen jetzt auf 360px Breite verkleinert werden.

Momentanes Verhalten:
Die Verkleinerung wird nicht ausgelöst, da der Check fehl schlägt. Würde ich die Bildbreite mit 500 angeben, wäre der Check true und die Verkleinerung auf 360px würde korrekt ausgeführt.
