### PR TITLE
Get root id from url always fails.

### DIFF
--- a/system/modules/core/classes/Frontend.php
+++ b/system/modules/core/classes/Frontend.php
@@ -285,7 +285,7 @@ abstract class Frontend extends \Controller
 	public static function getRootIdFromUrl()
 	{
 		$objRootPage = static::getRootPageFromUrl();
-		return $objRootPage->numRows ? $objRootPage->id : 0;
+		return $objRootPage->id;
 	}
 
 


### PR DESCRIPTION
There is a rather big bug in the Method: `Frontend::getRootIdFromUrl()` which prevents it from working entirely.

The method consists of:

``` php
$objRootPage = static::getRootPageFromUrl();
return $objRootPage->numRows ? $objRootPage->id : 0;
```

There is one bug and one quirk as `Frontend::getRootPageFromUrl()`:
1. does only return a Model instance and no collection or Database result (the bug).
2. does a redirect or 404 effectively always killing the script when no root page has been found and therefore the check if there was a root page returned is entirely obsolete (the quirk).
