### PR TITLE
New entity [br]

### DIFF
--- a/system/modules/core/library/Contao/String.php
+++ b/system/modules/core/library/Contao/String.php
@@ -252,7 +252,7 @@ class String
 	 */
 	public static function restoreBasicEntities($strBuffer)
 	{
-		return str_replace(array('[&]', '[&amp;]', '[lt]', '[gt]', '[nbsp]', '[-]'), array('&amp;', '&amp;', '&lt;', '&gt;', '&nbsp;', '&shy;'), $strBuffer);
+		return str_replace(array('[&]', '[&amp;]', '[lt]', '[gt]', '[nbsp]', '[-]', '[br]'), array('&amp;', '&amp;', '&lt;', '&gt;', '&nbsp;', '&shy;', '<br>'), $strBuffer);
 	}
 
 


### PR DESCRIPTION
From time to time i need the posibility to add a newline in certain fields that does not accept html.
I don't want to allow html on each field, because this make it open for _all_ html.
Alternative I often add a primitive entity `[br]` that can be used by the editor to add a newline.
#6040 is an alternative PR to this one.
