### PR TITLE
InsertTag exception for "email" validation

### DIFF
--- a/system/modules/core/library/Contao/Widget.php
+++ b/system/modules/core/library/Contao/Widget.php
@@ -904,6 +904,11 @@ abstract class Widget extends \Controller
 
 					foreach ($arrEmails as $strEmail)
 					{
+                                                if (strpos($strEmail, '{{') !== false)
+                                                {
+                                                        continue;
+                                                }
+
 						$strEmail = \Idna::encodeEmail($strEmail);
 
 						if (!\Validator::isEmail($strEmail))


### PR DESCRIPTION
Allow InsertTags for fields with the `eval => array('rgxp'=>'emails')` widget validator.
