### PR TITLE
Allow InsertTags for the "emails" validator 

### DIFF
--- a/system/modules/core/library/Contao/Widget.php
+++ b/system/modules/core/library/Contao/Widget.php
@@ -904,6 +904,11 @@ abstract class Widget extends \Controller
 
 					foreach ($arrEmails as $strEmail)
 					{
+						if (strpos($strEmail, '{{') !== false)
+						{
+							continue;
+						}
+
 						$strEmail = \Idna::encodeEmail($strEmail);
 
 						if (!\Validator::isEmail($strEmail))


### PR DESCRIPTION
This patch allows **InsertTags** for fields with a `eval => array('rgxp'=>'emails')` field validator.

It is not possible to append custom InsertTags to the `recipient` configuration (`tl_form`).

Example recipients:

``` html
user1@domain.tld,user2@domain.tld,{{custom::insert::tag}}
```

You can parse the insert tag with the `$GLOBALS['TL_HOOKS']['prepareFormData']` hook.
