### PR TITLE
Double domain in url when open fe page from page tree

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -2306,7 +2306,11 @@ abstract class Controller extends \System
 			$varArticle = '/articles/' . $varArticle;
 		}
 
-		$strUrl = $strDomain . $this->generateFrontendUrl($objPage->row(), $varArticle, $objPage->language);
+		// remove domain to force generateFrontendUrl to not add the domain twice
+		$arrRow = $objPage->row();
+		$arrRow['domain'] = '';
+
+		$strUrl = $strDomain . $this->generateFrontendUrl($arrRow, $varArticle, $objPage->language);
 
 		if (!$blnReturn)
 		{


### PR DESCRIPTION
When opening a fe page from the page tree, that has a different domain than the current be call, the domain was added twice.
