### PR TITLE
Frontend Preview Hook

### DIFF
--- a/contao/main.php
+++ b/contao/main.php
@@ -260,6 +260,16 @@ class Main extends Backend
 				}
 			}
 		}
+		
+		// HOOK: change the front end file preview
+		if (isset($GLOBALS['TL_HOOKS']['frontendPreview']) && is_array($GLOBALS['TL_HOOKS']['frontendPreview']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['frontendPreview'] as $callback)
+			{
+				$this->import($callback[0]);
+				$this->Template->frontendFile = $this->$callback[0]->$callback[1]($this->Template->frontendFile, Input::get('do'), CURRENT_ID);
+			}
+		}
 
 		$this->Template->output();
 	}


### PR DESCRIPTION
Add a Hook to manipulate the front end Preview query string.

Usage Example:

``` php
public function SetFrontendPreview($strFrontendFile, $strDo, $intCurrentID)
{
    if ($do === "module1")
    {
        strFrontendFile = "?page=123";
    }
    if ($do === "module2")
    {
        strFrontendFile = "?page=234";
    }
    return $strFrontendFile;
}
```

This feature is a good improvement for all Modules, if they need to manipulate the front end preview.
