### PR TITLE
Do not add `Model` suffix to the generated model filename

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -4983,8 +4983,14 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				{
 					$value = $blnDate ? $kk : $vv;
 
+					// Options callback
+					if (!empty($options_callback) && is_array($options_callback))
+					{
+						$vv = $options_callback[$vv];
+					}
+
 					// Replace the ID with the foreign key
-					if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey']))
+					elseif (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey']))
 					{
 						$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey'], 2);
 
@@ -5002,12 +5008,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isBoolean'] || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple']))
 					{
 						$vv = ($vv != '') ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
-					}
-
-					// Options callback
-					elseif (!empty($options_callback) && is_array($options_callback))
-					{
-						$vv = $options_callback[$vv];
 					}
 
 					// Get the name of the parent record (see #2703)

--- a/system/modules/devtools/modules/ModuleExtension.php
+++ b/system/modules/devtools/modules/ModuleExtension.php
@@ -147,7 +147,7 @@ class ModuleExtension extends \BackendModule
 					$tplTable->table = $strTable;
 					$tplTable->class = $strModel;
 
-					\File::putContent('system/modules/' . $objModule->folder . '/models/' . $strModel . 'Model.php', $tplTable->parse());
+					\File::putContent('system/modules/' . $objModule->folder . '/models/' . $strModel . '.php', $tplTable->parse());
 				}
 
 				$arrTemplates = array_filter(trimsplit(',', $objModule->feTemplates));


### PR DESCRIPTION
Suffix `Model` is already added in `\Model::getClassFromTable()`. 
It generates model filename as `TableModelModel`, but should be `TableModel`.
