### PR TITLE
Check for `options_callback` first and then for `foreignKey` in `DC_Table::filterMenu()` method

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -4983,8 +4983,14 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				{
 					$value = $blnDate ? $kk : $vv;
 
+					// Options callback
+					if (!empty($options_callback) && is_array($options_callback))
+					{
+						$vv = $options_callback[$vv];
+					}
+
 					// Replace the ID with the foreign key
-					if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey']))
+					elseif (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey']))
 					{
 						$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey'], 2);
 
@@ -5002,12 +5008,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['isBoolean'] || ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['inputType'] == 'checkbox' && !$GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['eval']['multiple']))
 					{
 						$vv = ($vv != '') ? $GLOBALS['TL_LANG']['MSC']['yes'] : $GLOBALS['TL_LANG']['MSC']['no'];
-					}
-
-					// Options callback
-					elseif (!empty($options_callback) && is_array($options_callback))
-					{
-						$vv = $options_callback[$vv];
 					}
 
 					// Get the name of the parent record (see #2703)


### PR DESCRIPTION
In case when I need to customize filter menu output I have to use `options_callback`. But it doesn't work when `foreighKey` is set. Because while generating filter menu it first checks for `foreignKey` and then for `options_callback`.

As a little example. I have a table with field `pid`. Where `pid` is an id from `tl_member` table.

``` php
        'pid' => array
        (
...
            'exclude'                 => true,
            'inputType'               => 'input',
            'filter'                  => true,
            'options_callback'        => array('tl_mytable', 'getMembersList'),
            'eval'                    => array('mandatory'=>true, 'rgxp'=>'digit', 'nospace'=>true, 'readonly'=>true),
            'foreignKey'              => 'tl_member.username',
            'sql'                     => "int(10) unsigned NOT NULL default '0'",
            'relation'                => array('type'=>'belongsTo', 'load'=>'lazy')
        ),
```

If not to use `options_callback` it generates a filter menu for `pid` field as list of usernames:

```
j.smith
d.evans
...
```

But I need to output it as:

```
John Smith [j.smith]
Donna Evans [d.evans]
...
```

And for doing this I'm using `options_callback`.
