### PR TITLE
[LTS] Add missing user deprecated error code.

### DIFF
--- a/system/functions.php
+++ b/system/functions.php
@@ -133,7 +133,8 @@ function __error($intType, $strMessage, $strFile, $intLine)
 		E_USER_NOTICE       => 'Notice',
 		E_STRICT            => 'Runtime notice',
 		4096                => 'Recoverable error',
-		8192                => 'Deprecated notice'
+		8192                => 'Deprecated notice',
+		E_USER_DEPRECATED   => 'Deprecated notice'
 	);
 
 	// Ignore functions with an error control operator (@function_name)

--- a/system/functions.php
+++ b/system/functions.php
@@ -134,7 +134,7 @@ function __error($intType, $strMessage, $strFile, $intLine)
 		E_STRICT            => 'Runtime notice',
 		4096                => 'Recoverable error',
 		8192                => 'Deprecated notice',
-		E_USER_DEPRECATED   => 'Deprecated notice'
+		16384               => 'Deprecated notice'
 	);
 
 	// Ignore functions with an error control operator (@function_name)


### PR DESCRIPTION
The `E_USER_DEPRECATED` error code is not supported by the `__error` function and will throw an `undefined index` error on line `function.php:54`.
