### PR TITLE
Use constant E_RECOVERABLE_ERROR, E_DEPRECATED and E_USER_DEPRECATED instead of int code.

### DIFF
--- a/system/helper/functions.php
+++ b/system/helper/functions.php
@@ -39,7 +39,7 @@ function __error($intType, $strMessage, $strFile, $intLine)
 		E_STRICT            => 'Runtime notice',
 		4096                => 'Recoverable error',
 		8192                => 'Deprecated notice',
-		16384               => 'Deprecated notice'
+		E_USER_DEPRECATED   => 'Deprecated notice'
 	);
 
 	// Ignore functions with an error control operator (@function_name)

--- a/system/helper/functions.php
+++ b/system/helper/functions.php
@@ -37,7 +37,7 @@ function __error($intType, $strMessage, $strFile, $intLine)
 		E_USER_WARNING      => 'Warning',
 		E_USER_NOTICE       => 'Notice',
 		E_STRICT            => 'Runtime notice',
-		4096                => 'Recoverable error',
+		E_RECOVERABLE_ERROR => 'Recoverable error',
 		8192                => 'Deprecated notice',
 		E_USER_DEPRECATED   => 'Deprecated notice'
 	);

--- a/system/helper/functions.php
+++ b/system/helper/functions.php
@@ -38,7 +38,7 @@ function __error($intType, $strMessage, $strFile, $intLine)
 		E_USER_NOTICE       => 'Notice',
 		E_STRICT            => 'Runtime notice',
 		E_RECOVERABLE_ERROR => 'Recoverable error',
-		8192                => 'Deprecated notice',
+		E_DEPRECATED        => 'Deprecated notice',
 		E_USER_DEPRECATED   => 'Deprecated notice'
 	);
 


### PR DESCRIPTION
The constant `E_RECOVERABLE_ERROR`, `E_DEPRECATED` and `E_USER_DEPRECATED` are part of PHP since 5.2.0 (recoverable error) respectively 5.3.0 and should be used instead of the int code.
See http://php.net/manual/de/errorfunc.constants.php
