### PR TITLE
A field must not exist in the database, but it must exist in the DCA

### DIFF
--- a/system/modules/core/classes/Ajax.php
+++ b/system/modules/core/classes/Ajax.php
@@ -259,27 +259,17 @@ class Ajax extends \Backend
 					$strField = preg_replace('/(.*)_[0-9a-zA-Z]+$/', '$1', $strField);
 				}
 
-				// Validate the request data
-				if ($GLOBALS['TL_DCA'][$dc->table]['config']['dataContainer'] == 'File')
+				// The field does not exist
+				if (!isset($GLOBALS['TL_DCA'][$dc->table]['fields'][$strField]))
 				{
-					// The field does not exist
-					if (!array_key_exists($strField, $GLOBALS['TL_CONFIG']))
-					{
-						$this->log('Field "' . $strField . '" does not exist in the global configuration', 'Ajax executePostActions()', TL_ERROR);
-						header('HTTP/1.1 400 Bad Request');
-						die('Bad Request');
-					}
+					$this->log('Field "' . $strField . '" does not exist in DCA "' . $dc->table . '"', 'Ajax executePostActions()', TL_ERROR);
+					header('HTTP/1.1 400 Bad Request');
+					die('Bad Request');
 				}
-				elseif ($this->Database->tableExists($dc->table))
-				{
-					// The field does not exist
-					if (!$this->Database->fieldExists($strField, $dc->table))
-					{
-						$this->log('Field "' . $strField . '" does not exist in table "' . $dc->table . '"', 'Ajax executePostActions()', TL_ERROR);
-						header('HTTP/1.1 400 Bad Request');
-						die('Bad Request');
-					}
 
+				// Validate the request data
+				if ($GLOBALS['TL_DCA'][$dc->table]['config']['dataContainer'] != 'File' && $this->Database->tableExists($dc->table))
+				{
 					$objRow = $this->Database->prepare("SELECT * FROM " . $dc->table . " WHERE id=?")
 											 ->execute($intId);
 

--- a/system/modules/core/classes/Ajax.php
+++ b/system/modules/core/classes/Ajax.php
@@ -268,7 +268,7 @@ class Ajax extends \Backend
 				}
 
 				// Validate the request data
-				if ($GLOBALS['TL_DCA'][$dc->table]['config']['dataContainer'] != 'File' && $this->Database->tableExists($dc->table))
+				if ($GLOBALS['TL_DCA'][$dc->table]['config']['dataContainer'] != 'File' && $intId > 0 && $this->Database->tableExists($dc->table))
 				{
 					$objRow = $this->Database->prepare("SELECT * FROM " . $dc->table . " WHERE id=?")
 											 ->execute($intId);
@@ -308,7 +308,7 @@ class Ajax extends \Backend
 					$GLOBALS['TL_CONFIG'][$strField] = $varValue;
 					$arrAttribs['activeRecord'] = null;
 				}
-				elseif ($this->Database->tableExists($dc->table))
+				elseif ($intId > 0 && $this->Database->tableExists($dc->table))
 				{
 					$objRow->$strField = $varValue;
 					$arrAttribs['activeRecord'] = $objRow;


### PR DESCRIPTION
I remember we have added security checks for the file and page widgets so that a user cannot access fields that do not exist. However, the check for if a database field exists is inappropriate, we must check the DCA.

Background/Reason: I have a pageTree widget in Isotope where I store the values in a subtable (using `load_callback` and `save_callback`). I have also set the DCA to `doNotSaveEmpty=true` so I do not need a real database field in the table.
