### PR TITLE
Allow to set createNewVersion (e.g. from save_callback)

### DIFF
--- a/system/modules/core/classes/DataContainer.php
+++ b/system/modules/core/classes/DataContainer.php
@@ -304,7 +304,6 @@ class DataContainer extends \Backend
 					{
 						$this->noReload = true;
 						$objWidget->addError($e->getMessage());
-						$this->blnCreateNewRecord = false;
 					}
 				}
 			}

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -285,6 +285,26 @@ class DC_Table extends \DataContainer implements \listable, \editable
 
 
 	/**
+	 * Set an object property
+	 * @param string
+	 * @return mixed
+	 */
+	public function __set($strKey, $varValue)
+	{
+		switch ($strKey)
+		{
+			case 'createNewVersion':
+				$this->blnCreateNewVersion = (bool) $varValue;
+				break;
+
+			default:
+				throw new \Exception(sprintf('Invalid argument "%s"', $strKey));
+				break;
+		}
+	}
+
+
+	/**
 	 * List all records of a particular table
 	 * @return string
 	 */


### PR DESCRIPTION
My `save_callback` stores the result in a new subtable. I want to be able to enable versioning (through `onversion_callback` and `onrestore_callback`), but then I need to be able to tell the DC_Table to create a new version because my field value has changed.

PS: can you include this in the next 3.1.x?
