### PR TITLE
Importing a template without user data ruins the tl_files table

### DIFF
--- a/contao/install.php
+++ b/contao/install.php
@@ -733,9 +733,14 @@ class InstallTool extends Backend
 
 					$this->Config->update("\$GLOBALS['TL_CONFIG']['adminEmail']", Input::post('email', true));
 
+					$objRow = $this->Database->query("SELECT COUNT(*) AS count FROM tl_files");
+
 					// Scan the upload folder
-					$this->import('Database\\Updater', 'Updater');
-					$this->Updater->scanUploadFolder();
+					if ($objRow->count < 1)
+					{
+						$this->import('Database\\Updater', 'Updater');
+						$this->Updater->scanUploadFolder();
+					}
 
 					$this->reload();
 				}


### PR DESCRIPTION
To reproduce:
1. Install Contao 3.1.2
2. Remove all _tl_user_ and _tl_user_group_ data from the file _templates/music_academy.sql_
3. Go to the install tool and import the template _music_academy.sql_
4. Create the admin account

After these steps the database table _tl_files_ is wrong. All files and directories appear twice.
