### PR TITLE
New insert tag '{{br}}' and '{{break}}'

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -689,6 +689,12 @@ abstract class Controller extends \System
 			// Replace the tag
 			switch (strtolower($elements[0]))
 			{
+				// Line breaks
+				case 'br':
+				case 'break':
+					$arrCache[$strTag] = '<br' . ($objPage->outputFormat == 'xhtml' ? ' />' : '>');
+					break;
+
 				// Date
 				case 'date':
 					$arrCache[$strTag] = \Date::parse($elements[1] ?: $GLOBALS['TL_CONFIG']['dateFormat']);

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -691,7 +691,6 @@ abstract class Controller extends \System
 			{
 				// Line breaks
 				case 'br':
-				case 'break':
 					$arrCache[$strTag] = '<br' . ($objPage->outputFormat == 'xhtml' ? ' />' : '>');
 					break;
 


### PR DESCRIPTION
I use a custom insert tag with a hook very often, for creating line breaks in the FE from single line text inputs in the BE. Maybe it is useful by default?
