### PR TITLE
Fix endless recursion in loadDataContainer.

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -2246,6 +2246,9 @@ abstract class Controller extends \System
 			return;
 		}
 
+		// Use a global cache variable to support nested calls
+		$GLOBALS['loadDataContainer'][$strName] = true;
+
 		$strCacheFile = 'system/cache/dca/' . $strName . '.php';
 
 		// Try to load from cache
@@ -2281,9 +2284,6 @@ abstract class Controller extends \System
 		{
 			include TL_ROOT . '/system/config/dcaconfig.php';
 		}
-
-		// Use a global cache variable to support nested calls
-		$GLOBALS['loadDataContainer'][$strName] = true;
 	}
 
 


### PR DESCRIPTION
When `Controller::loadDataContainer('X')` is called, and somewhere in the `$GLOBALS['TL_HOOKS']['loadLanguageFile']` stack `Controller::loadDataContainer('X')` is called twice, it will result in an endless recursion.
