### PR TITLE
Restore User::getData() method.

### DIFF
--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -156,6 +156,16 @@ abstract class User extends \System
 
 
 	/**
+	 * Return the current record as associative array
+	 * @return array
+	 */
+	public function getData()
+	{
+		return $this->arrData;
+	}
+
+
+	/**
 	 * Authenticate a user
 	 *
 	 * @return boolean True if the user could be authenticated


### PR DESCRIPTION
In C 2.11 the class `User` extends `Model` which contains a `getData()` method.
`getData()` is really handy because you not need to select the `BackendUserModel` twice.
