### PR TITLE
standardize HTML5 element formatting

### DIFF
--- a/assets/contao/css/reset-uncompressed.css
+++ b/assets/contao/css/reset-uncompressed.css
@@ -19,6 +19,9 @@ body,div,h1,h2,h3,h4,h5,h6,p,blockquote,pre,code,ol,ul,li,dl,dt,dd,figure,table,
 /**
  * Basic element formatting
  */
+header,footer,nav,section,aside,article,figure,figcaption {
+	display:block;
+}
 table {
 	border-spacing:0;
 	border-collapse:collapse;


### PR DESCRIPTION
I am not sure about this change, but wanted to suggest it anyway. I made a page where I did not use Contao’s standard CSS framework from layout.css. So I skimmed through layout.css to check for any goodies I would be missing. I came across [these lines](https://github.com/contao/core/blob/master/assets/contao/css/layout-uncompressed.css#L21-L23) and thought they should actually be included in reset.css as well. A lot of the other normalizations performed by layout.css are already part of reset.css, but this one is not.
