### PR TITLE
allow trailing slashes with empty URL suffix

### DIFF
--- a/system/modules/core/classes/Frontend.php
+++ b/system/modules/core/classes/Frontend.php
@@ -104,6 +104,11 @@ abstract class Frontend extends \Controller
 
 				$strRequest = substr($strRequest, 0, -$intSuffixLength);
 			}
+			else
+			{
+				// Tolerate trailing slashes when URL suffix is empty
+				$strRequest = rtrim($strRequest, '/');
+			}
 		}
 
 		// Extract the language


### PR DESCRIPTION
When the configured URL suffix for a site is empty, the generated URLs look like folder paths. Thus, trailing slashes should be ignored to meet user expectations of how folder paths work.
