### PR TITLE
Callables in template

### DIFF
--- a/system/modules/core/library/Contao/Template.php
+++ b/system/modules/core/library/Contao/Template.php
@@ -116,6 +116,20 @@ abstract class Template extends \Controller
 
 
 	/**
+	 * Add support for callable variables (usually closures)
+	 *
+	 * @param string
+	 * @param array
+	 *
+	 * @return mixed
+	 */
+	public function __call($strName, $arrArguments)
+	{
+		return call_user_func_array($this->$strName, $arrArguments);
+	}
+
+
+	/**
 	 * Check whether a property is set
 	 *
 	 * @param string $strKey The property name


### PR DESCRIPTION
Hey people,

We needed to add closures to the templates in Isotope and as this is quite a cool feature we thought we might also add this to the Contao 3.2 core.

You can then do things like this:

``` php
$objTemplate->sum = function($a, $b) {
    return $a + $b;
}
```

So your users can use that function in the template:

``` html
<p>The sum is: <?php echo $this->sum(3, 7); ?></p>
```
