### PR TITLE
Extend fileTree Widget to configure gallery and download type by eval

### DIFF
--- a/system/modules/core/widgets/FileTree.php
+++ b/system/modules/core/widgets/FileTree.php
@@ -86,8 +86,10 @@ class FileTree extends \Widget
 		$this->import('Database');
 		parent::__construct($arrAttributes);
 
-		$this->strOrderField = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['orderField'];
-		$this->blnIsMultiple = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval']['multiple'];
+		$arrFieldEval = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval'];
+
+		$this->strOrderField = $arrFieldEval['orderField'];
+		$this->blnIsMultiple = $arrFieldEval['multiple'];
 
 		// Prepare the order field
 		if ($this->strOrderField != '')
@@ -103,8 +105,9 @@ class FileTree extends \Widget
 			$this->{$this->strOrderField} = array_filter(explode(',', $objRow->{$this->strOrderField}));
 		}
 
-		$this->blnIsGallery = (isset($GLOBALS['TL_DCA'][$this->strTable]['fields']['type']['eval']['gallery_types']) && in_array($this->activeRecord->type, $GLOBALS['TL_DCA'][$this->strTable]['fields']['type']['eval']['gallery_types']));
-		$this->blnIsDownloads = (isset($GLOBALS['TL_DCA'][$this->strTable]['fields']['type']['eval']['downloads_types']) && in_array($this->activeRecord->type, $GLOBALS['TL_DCA'][$this->strTable]['fields']['type']['eval']['downloads_types']));
+		$arrTypeEval = $GLOBALS['TL_DCA'][$this->strTable]['fields']['type']['eval'];
+		$this->blnIsGallery = ((isset($arrTypeEval['gallery_types']) && in_array($this->activeRecord->type, $arrTypeEval['gallery_types'])) || (isset($arrFieldEval['gallery']) && $arrFieldEval['gallery']));
+		$this->blnIsDownloads = (isset($arrTypeEval['downloads_types']) && in_array($this->activeRecord->type, $arrTypeEval['downloads_types'])  || (isset($arrFieldEval['download']) && $arrFieldEval['download']));
 	}
 
 


### PR DESCRIPTION
To reproduce:
1. create a custom Module
2. Create a DCA
3. Add more than one `fileTree` Widget to one Module Form
4. It is not possible to define for each `fileTree` Widget `gallery` or `download`. It is always for the whole Form / Type

This pull request allows developers to have some fileTree widgets in one Backend Form and define one as `download` the other one as `gallery` and so on.

Example:

``` php
// gallery
'eval'  => array('gallery'=>true),
// download
'eval'  => array('download'=>true),
```

``` php
'multiSRC' => array
(
    'label'                   => &$GLOBALS['TL_LANG']['tl_content']['multiSRC'],
    'exclude'                 => true,
    'inputType'               => 'fileTree',
    'eval'                    => array('multiple'=>true, 'fieldType'=>'checkbox', 'orderField'=>'orderSRC', 'files'=>true, 'mandatory'=>true, 'gallery'=>true),
    'sql'                     => "blob NULL"
),
```
