### PR TITLE
Replace "domain.com" by "example.com"

### DIFF
--- a/.htaccess.default
+++ b/.htaccess.default
@@ -212,15 +212,15 @@ FileETag None
   ##
   # Uncomment the following lines to add "www." to the domain:
   #
-  #   RewriteCond %{HTTP_HOST} ^domain\.com$ [NC]
-  #   RewriteRule (.*) http://www.domain.com/$1 [R=301,L]
+  #   RewriteCond %{HTTP_HOST} ^example\.com$ [NC]
+  #   RewriteRule (.*) http://www.example.com/$1 [R=301,L]
   #
   # Uncomment the following lines to remove "www." from the domain:
   #
-  #   RewriteCond %{HTTP_HOST} ^www\.domain\.com$ [NC]
-  #   RewriteRule (.*) http://domain.com/$1 [R=301,L]
+  #   RewriteCond %{HTTP_HOST} ^www\.example\.com$ [NC]
+  #   RewriteRule (.*) http://example.com/$1 [R=301,L]
   #
-  # Make sure to replace "domain.com" with your domain name.
+  # Make sure to replace "example.com" with your domain name.
   ##
 
   ##

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ How to access the back end
 Open your web browser and add `/contao` to the URL of your website. Here are a
 few examples:
 
- * `http://www.yourdomain.com/contao`
- * `http://www.yourdomain.com/contao/contao`
- * `http://www.yourdomain.com/contao-3.1.0/contao`
+ * `http://www.example.com/contao`
+ * `http://www.example.com/contao/contao`
+ * `http://www.example.com/contao-3.1.0/contao`
 
 
 Troubleshooting

--- a/system/config/default.php
+++ b/system/config/default.php
@@ -152,7 +152,7 @@ $GLOBALS['TL_CONFIG']['dbCollation'] = 'utf8_general_ci';
  *
  * Here you can enable FTP for managing files and folders ("Safe Mode Hack").
  *
- *   ftpHost = host name (e.g. domain.com or domain.com:21)
+ *   ftpHost = host name (e.g. example.com or example.com:21)
  *   ftpPath = path to installation (e.g. html/)
  *   ftpUser = FTP username
  *   ftpPass = FTP password

--- a/system/modules/comments/classes/Comments.php
+++ b/system/modules/comments/classes/Comments.php
@@ -431,7 +431,7 @@ class Comments extends \Frontend
 	 * - [url][/url]
 	 * - [url=http://][/url]
 	 * - [email][/email]
-	 * - [email=name@domain.com][/email]
+	 * - [email=name@example.com][/email]
 	 * @param string
 	 * @return string
 	 */

--- a/system/modules/core/templates/backend/be_incomplete.html5
+++ b/system/modules/core/templates/backend/be_incomplete.html5
@@ -35,7 +35,7 @@ $lang = (object) $GLOBALS['TL_LANG']['XPT'];
 
       <h3><?php echo $lang->howToFix; ?></h3>
       <p><?php echo $lang->incompleteFixOne; ?></p>
-      <pre>http://www.domain.com/<?php echo $lang->installPath; ?><b>/contao/install.php</b></pre>
+      <pre>http://www.example.com/<?php echo $lang->installPath; ?><b>/contao/install.php</b></pre>
       <p><?php echo $lang->incompleteFixTwo; ?></p>
 
       <h3><?php echo $lang->more; ?></h3>


### PR DESCRIPTION
Motivation:
- `domain.com` points to a commercial website
- the domain name `example.com` (as well as `example.net`, `example.org`, and `example.edu`) was reserved for documentation purposes and examples of the use of domain names and is used in a generic and vendor-neutral manner

![install](https://f.cloud.github.com/assets/1218766/1187979/36afc040-23ac-11e3-9939-35789920b196.png)

Curiously, people actually start using the presumed "example" domain name `domain.com` and land on a [website](http://www.domain.com/) that offers commercial services (see e.g. https://community.contao.org/de/showthread.php?44541-Contao-3-1-Unvollst%E4ndige-Installation)

Therefore, I'd suggest to replace the `domain.com` by the reserved domain name `example.com` (http://www.example.com/) which is originally designed for purposes of that kind (https://en.wikipedia.org/wiki/Example.com).
