### PR TITLE
Typo in FormCaptcha.php

### DIFF
--- a/system/modules/core/forms/FormCaptcha.php
+++ b/system/modules/core/forms/FormCaptcha.php
@@ -20,7 +20,7 @@ namespace Contao;
 /**
  * Class FormCaptcha
  *
- * File upload field.
+ * Captcha field.
  * @copyright  Leo Feyer 2005-2013
  * @author     Leo Feyer <https://contao.org>
  * @package    Core


### PR DESCRIPTION
I think this is a small error in the description of the FormCaptcha.php class.

It reads 'File upload field' instead of 'Captcha field'.
