### PR TITLE
insertId des Undo-Eintrages an ondelete_callback übermitteln

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -1400,7 +1400,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 					if (is_array($callback))
 					{
 						$this->import($callback[0]);
-						$this->$callback[0]->$callback[1]($this);
+						$this->$callback[0]->$callback[1]($this, $objUndoStmt->insertId);
 					}
 				}
 			}


### PR DESCRIPTION
Bevor der `ondelete_callback` im DC_Table ausgeführt wird, wird ja der Eintrag in der Undo-Tabelle vorgenommen. Jedoch kann es vorkommen, dass durch den ondelete_callback weitere Inhalte gelöscht werden, die durch ein Undo wieder rückgängig gemacht werden sollen.

Daher ist es hilfreich, wenn die ID des Undo-Befehls an den Callback übermittelt wird.
