### PR TITLE
Fix the broken image hyperlink content element

### DIFF
--- a/system/modules/core/elements/ContentHyperlink.php
+++ b/system/modules/core/elements/ContentHyperlink.php
@@ -59,7 +59,7 @@ class ContentHyperlink extends \ContentElement
 		}
 
 		// Use an image instead of the title
-		if ($this->useImage && $this->singleSRC != '' && is_numeric($this->singleSRC))
+		if ($this->useImage && $this->singleSRC != '')
 		{
 			$objModel = \FilesModel::findByUuid($this->singleSRC);
 


### PR DESCRIPTION
Motivation:
- Instead of an image hyperlink a normal text link is shown

Due to the [change](https://github.com/contao/core/commit/0b1621f49f5702ddfa16a78b6c938c61bd59b3aa#diff-2) of the SQL `singleSRC` field type from `char` to `binary` the [check for a numerical field value](https://github.com/contao/core/blob/develop/system/modules/core/elements/ContentHyperlink.php#L62) fails now which in turns means that e.g. the front end template object for `ce_hyperlink_image` cannot be instantiated.

Credit goes to @peter.fl who found and reported the issue.
