### PR TITLE
Modal window buttons

### DIFF
--- a/assets/contao/js/core-uncompressed.js
+++ b/assets/contao/js/core-uncompressed.js
@@ -718,9 +718,10 @@ var Backend =
 	openModalWindow: function(width, title, content) {
 		new SimpleModal({
 			'width': width,
-			'hideFooter': true,
 			'draggable': false,
 			'overlayOpacity': .5,
+			'btn_ok': Contao.lang.close,
+			template: "<div class=\"simple-modal-header\"><h1>{_TITLE_}</h1></div><div class=\"simple-modal-body\"><div class=\"contents\">{_CONTENTS_}</div></div><div class=\"simple-modal-footer simple-modal-closebutton\"></div>",
 			'onShow': function() { document.body.setStyle('overflow', 'hidden'); },
 			'onHide': function() { document.body.setStyle('overflow', 'auto'); }
 		}).show({
@@ -737,9 +738,10 @@ var Backend =
 		var opt = options || {};
 		var M = new SimpleModal({
 			'width': opt.width,
-			'hideFooter': true,
 			'draggable': false,
 			'overlayOpacity': .5,
+			'btn_ok': Contao.lang.close,
+			template: "<div class=\"simple-modal-header\"><h1>{_TITLE_}</h1></div><div class=\"simple-modal-body\"><div class=\"contents\">{_CONTENTS_}</div></div><div class=\"simple-modal-footer simple-modal-closebutton\"></div>",
 			'onShow': function() { document.body.setStyle('overflow', 'hidden'); },
 			'onHide': function() { document.body.setStyle('overflow', 'auto'); }
 		});
@@ -759,9 +761,10 @@ var Backend =
 		if (!opt.height || opt.height > max) opt.height = max;
 		var M = new SimpleModal({
 			'width': opt.width,
-			'hideFooter': true,
 			'draggable': false,
 			'overlayOpacity': .5,
+			'btn_ok': Contao.lang.close,
+			template: "<div class=\"simple-modal-header\"><h1>{_TITLE_}</h1></div><div class=\"simple-modal-body\"><div class=\"contents\">{_CONTENTS_}</div></div><div class=\"simple-modal-footer simple-modal-closebutton\"></div>",
 			'onShow': function() { document.body.setStyle('overflow', 'hidden'); },
 			'onHide': function() { document.body.setStyle('overflow', 'auto'); }
 		});

--- a/system/themes/default/src/main.css
+++ b/system/themes/default/src/main.css
@@ -362,10 +362,48 @@ h2.sub_headline_index {
 	left:0;
 	bottom:0;
 	width:100%;
-	height:52px;
+	height:42px;
+	z-index:4;
+}
+.simple-modal .simple-modal-closebutton{
+    height:0px;
+    border:none;
+    margin:0px;
+    padding:0px;
+}
+.simple-modal .simple-modal-closebutton .btn.primary {
+    position:relative;
+    bottom:35px;
+    right:20px;
+}
+.popup .tl_formbody_submit .tl_submit {
+	font-family:Verdana,​sans-serif;
+    border:1px solid rgba(0, 0, 0, 0);
+    border-radius:3px 3px 3px 3px;
+    cursor:pointer;
+    display:inline-block;
+    font-size:13px;
+    line-height:normal;
+    padding:2px 10px 3px;
+    text-decoration:none;
+    transition:all 0.2s linear 0s;
+	background-image:none;
+    background-color:#999999;
+    background-repeat:repeat-x;
+    color:#FFFFFF;
+    text-shadow:0 1px 0 rgba(0, 0, 0, 0.25);
+}
+.popup .tl_formbody_submit .tl_submit:hover {
+    background-color:#666666;
+    border:1px solid #666666;
 }
 .tl_submit_container {
 	padding:12px 18px;
+	background:#f3f3f3;
+	border-top:1px solid #fff;
+}
+.popup .tl_formbody_submit .tl_submit_container {
+	padding:7px 35px 10px;
 	background:#f3f3f3;
 	border-top:1px solid #fff;
 }


### PR DESCRIPTION
As suggested in https://github.com/contao/core/issues/5985 here is a pullrequest to get the Close Button in one line with the tl_submit Buttons.

Moved the tl_submit buttons to the footer in the modal window …
- [x] Added Modal Window Footer again
- [x] Added template var to define an extra Footer Class
- [x] Added CSS to style the tl_submit Buttons to look like the Modal Window button
- [x] Added CSS to move the modal Window Button to the right place

For Testing I have over copied the minified files. (Not forget to purge the generated JS and CSS files)

Is it possible to get this in the 3.2 Release?
