### PR TITLE
[WIP] add usage widget

### DIFF
--- a/assets/contao/js/core-uncompressed.js
+++ b/assets/contao/js/core-uncompressed.js
@@ -844,6 +844,42 @@ var Backend =
 	},
 
 	/**
+	 * Open usage wizard in a modal window
+	 * @param object
+	 */
+	openModalUsageWizard: function(options) {
+		var opt = options || {};
+		var max = (window.getSize().y-180).toInt();
+		if (!opt.height || opt.height > max) opt.height = max;
+		var M = new SimpleModal({
+			'width': opt.width,
+			'btn_ok': Contao.lang.close,
+			'draggable': false,
+			'overlayOpacity': .5,
+			'onShow': function() { document.body.setStyle('overflow', 'hidden'); },
+			'onHide': function() {
+				document.body.setStyle('overflow', 'auto');
+				new Request.Contao({
+					field: $('ctrl_'+opt.id),
+					evalScripts: false,
+					onRequest: AjaxRequest.displayBox(Contao.lang.loading + ' …'),
+					onSuccess: function(txt, json) {
+						$('ctrl_'+opt.id).getParent('div').set('html', json.content);
+						json.javascript && Browser.exec(json.javascript);
+						AjaxRequest.hideBox();
+						window.fireEvent('ajax_change');
+					}
+				}).post({'action':'reloadWidget', 'name':opt.id, 'value':$('ctrl_'+opt.id).value, 'widget':opt.type, 'REQUEST_TOKEN':Contao.request_token});
+			}
+		});
+		M.show({
+			'title': opt.title,
+			'contents': '<iframe src="' + opt.url + '" name="simple-modal-iframe" width="100%" height="' + opt.height + '" frameborder="0"></iframe>',
+			'model': 'modal'
+		});
+	},
+
+	/**
 	 * Get the current scroll offset and store it in a cookie
 	 */
 	getScrollOffset: function() {

--- a/system/modules/core/classes/Ajax.php
+++ b/system/modules/core/classes/Ajax.php
@@ -407,6 +407,19 @@ class Ajax extends \Backend
 				}
 				exit; break;
 
+			case 'reloadWidget':
+				// Build the attributes based on the "eval" array
+				$arrAttribs = $GLOBALS['TL_DCA'][$dc->table]['fields'][\Input::post('name')]['eval'];
+
+				$arrAttribs['id'] = \Input::post('name');
+				$arrAttribs['name'] = \Input::post('name');
+				$arrAttribs['value'] = \Input::post('value');
+				$arrAttribs['strTable'] = $dc->table;
+				$arrAttribs['strField'] = \Input::post('name');
+
+				$objWidget = new $GLOBALS['BE_FFL'][\Input::post('widget')]($arrAttribs);
+				echo $objWidget->generate();
+				exit; break;
 			// HOOK: pass unknown actions to callback functions
 			default:
 				$this->executePostActionsHook($dc);

--- a/system/modules/core/config/autoload.php
+++ b/system/modules/core/config/autoload.php
@@ -225,6 +225,7 @@ ClassLoader::addClasses(array
 	'Contao\TextStore'                 => 'system/modules/core/widgets/TextStore.php',
 	'Contao\TimePeriod'                => 'system/modules/core/widgets/TimePeriod.php',
 	'Contao\TrblField'                 => 'system/modules/core/widgets/TrblField.php',
+	'Contao\UsageWizard'               => 'system/modules/core/widgets/UsageWizard.php',
 	'Contao\Upload'                    => 'system/modules/core/widgets/Upload.php',
 ));
 
@@ -263,6 +264,7 @@ TemplateLoader::addFiles(array
 	'be_rebuild_index'    => 'system/modules/core/templates/backend',
 	'be_referer'          => 'system/modules/core/templates/backend',
 	'be_switch'           => 'system/modules/core/templates/backend',
+	'be_usage_wizard'     => 'system/modules/core/templates/backend',
 	'be_welcome'          => 'system/modules/core/templates/backend',
 	'be_widget'           => 'system/modules/core/templates/backend',
 	'be_widget_chk'       => 'system/modules/core/templates/backend',

--- a/system/modules/core/config/config.php
+++ b/system/modules/core/config/config.php
@@ -223,7 +223,8 @@ $GLOBALS['BE_FFL'] = array
 	'keyValueWizard' => 'KeyValueWizard',
 	'imageSize'      => 'ImageSize',
 	'timePeriod'     => 'TimePeriod',
-	'metaWizard'     => 'MetaWizard'
+	'metaWizard'     => 'MetaWizard',
+	'usageWizard'	 => 'UsageWizard'
 );
 
 

--- a/system/modules/core/dca/tl_layout.php
+++ b/system/modules/core/dca/tl_layout.php
@@ -99,7 +99,7 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 	'palettes' => array
 	(
 		'__selector__'                => array('rows', 'cols', 'addJQuery', 'addMooTools', 'static'),
-		'default'                     => '{title_legend},name;{header_legend},rows;{column_legend},cols;{sections_legend:hide},sections,sPosition;{style_legend},framework,stylesheet,external;{feed_legend:hide},newsfeeds,calendarfeeds;{modules_legend},modules;{expert_legend:hide},template,doctype,webfonts,cssClass,onload,head;{jquery_legend},addJQuery;{mootools_legend},addMooTools;{script_legend},analytics,script;{static_legend},static'
+		'default'                     => '{title_legend},name;{header_legend},rows;{column_legend},cols;{sections_legend:hide},sections,sPosition;{style_legend},framework,stylesheet,external;{feed_legend:hide},newsfeeds,calendarfeeds;{modules_legend},modules;{expert_legend:hide},template,doctype,webfonts,cssClass,onload,head;{jquery_legend},addJQuery;{mootools_legend},addMooTools;{script_legend},analytics,script;{static_legend},static;{usage_legend},layoutUsage,mobileLayoutUsage'
 	),
 
 	// Subpalettes
@@ -454,6 +454,43 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 			'reference'               => &$GLOBALS['TL_LANG']['MSC'],
 			'eval'                    => array('tl_class'=>'w50'),
 			'sql'                     => "varchar(32) NOT NULL default ''"
+		),
+		'layoutUsage' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_layout']['layoutUsage'],
+			'inputType'               => 'usageWizard',
+			'exclude'                 => true,
+			'foreignKey'              => 'tl_page.title',
+			'eval'                    => array('tl_class'=>'clr', 'pickerTitle'=>$GLOBALS['TL_LANG']['tl_layout']['layoutUsage'][0],
+				'model' => array(array(
+					'table'=>'tl_page',
+					'label'=>'%s (%s' . $GLOBALS['TL_CONFIG']['urlSuffix'] . ')',
+					'labelValue'=>array('title','alias'),
+					'column'=>array('layout=? AND includeLayout=1'),
+					'value'=>array(\Input::get('id'))
+				))
+
+			),
+			'sql'                     => "blob NULL",
+			'relation'                => array('type'=>'hasOne', 'load'=>'lazy')
+		),
+		'mobileLayoutUsage' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_layout']['mobileLayoutUsage'],
+			'inputType'               => 'usageWizard',
+			'exclude'                 => true,
+			'foreignKey'              => 'tl_page.title',
+			'eval'                    => array('tl_class'=>'clr', 'pickerTitle'=>$GLOBALS['TL_LANG']['tl_layout']['mobileLayoutUsage'][0],
+				'model' => array(array(
+					'table'=>'tl_page',
+					'label'=>'%s (%s' . $GLOBALS['TL_CONFIG']['urlSuffix'] . ')',
+					'labelValue'=>array('title','alias'),
+					'column'=>array('mobileLayout=? AND includeLayout=1'),
+					'value'=>array(\Input::get('id'))
+				))
+			),
+			'sql'                     => "blob NULL",
+			'relation'                => array('type'=>'hasOne', 'load'=>'lazy')
 		)
 	)
 );

--- a/system/modules/core/languages/en/tl_layout.xlf
+++ b/system/modules/core/languages/en/tl_layout.xlf
@@ -284,6 +284,18 @@
       <trans-unit id="tl_layout.align.1">
         <source>Please select the alignment of the page.</source>
       </trans-unit>
+      <trans-unit id="tl_layout.layoutUsage.0">
+        <source>Layout usage</source>
+      </trans-unit>
+      <trans-unit id="tl_layout.layoutUsage.1">
+        <source>You can see an overview of the layout usage on each page.</source>
+      </trans-unit>
+      <trans-unit id="tl_layout.mobileLayoutUsage.0">
+        <source>Mobile layout usage</source>
+      </trans-unit>
+      <trans-unit id="tl_layout.mobileLayoutUsage.1">
+        <source>You can see an overview of the mobile layout usage on each page.</source>
+      </trans-unit>
       <trans-unit id="tl_layout.title_legend">
         <source>Title</source>
       </trans-unit>

--- a/system/modules/core/templates/backend/be_usage_wizard.html5
+++ b/system/modules/core/templates/backend/be_usage_wizard.html5
@@ -1,0 +1,21 @@
+<?php if(!$objTemplate->isAjaxRequest): ?>
+  <div>
+<?php endif; ?>
+
+    <input type="hidden" name="<?php echo $this->name; ?>" id="ctrl_<?php echo $this->id; ?>" value="<?php echo $this->set; ?>">
+
+    <div class="selector_container">
+
+    <ul id="sort_<?php echo $this->id; ?>" class="<?php echo $this->class; ?>">
+
+      <?php foreach ($this->arrValues as $k=>$v): ?>
+        <li data-id="<?php echo $k; ?>"><?php echo $v->icon; ?> <?php echo $v->label; ?></li>
+      <?php endforeach; ?>
+
+      </ul>
+      <p><a href="<?php echo $this->href; ?>" class="tl_submit" onclick="Backend.getScrollOffset();Backend.openModalUsageWizard({'width':765,'title':'<?php echo $this->pickerTitle; ?>','url':this.href,'id':'<?php echo $this->id; ?>','type':'<?php echo $this->type; ?>'});return false"><?php echo $this->changeSelection; ?></a></p>
+    </div>
+
+<?php if(!$objTemplate->isAjaxRequest): ?>
+  </div>
+<?php endif; ?>

--- a/system/modules/core/widgets/UsageWizard.php
+++ b/system/modules/core/widgets/UsageWizard.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2013 Leo Feyer
+ *
+ * @package Core
+ * @link    https://contao.org
+ * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL
+ */
+
+
+/**
+ * Run in a custom namespace, so the class can be replaced
+ */
+namespace Contao;
+
+
+/**
+ * Class UsageWizard
+ *
+ * Provide methods to handle input field "page tree".
+ * @copyright  Leo Feyer 2005-2013
+ * @author     Leo Feyer <https://contao.org>
+ * @package    Core
+ */
+class UsageWizard extends \Widget
+{
+
+	/**
+	 * Submit user input
+	 * @var boolean
+	 */
+	protected $blnSubmitInput = true;
+
+	/**
+	 * Template
+	 * @var string
+	 */
+	protected $strTemplate = 'be_widget';
+
+	/**
+	 * Template
+	 * @var string
+	 */
+	protected $strWidgetTemplate = 'be_usage_wizard';
+
+	/**
+	 * Label for list view
+	 * @var string
+	 */
+	protected $strFieldLabel;
+
+	/**
+	 * Title for Modal Window
+	 * @var string
+	 */
+	protected $strPickerTitle;
+
+	/**
+	 * Multiple flag
+	 * @var boolean
+	 */
+	protected $blnIsMultiple = false;
+
+
+	/**
+	 * Load the database object
+	 * @param array
+	 */
+	public function __construct($arrAttributes=null)
+	{
+		$this->import('Database');
+		parent::__construct($arrAttributes);
+
+		// get eval values
+		$arrEval = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['eval'];
+
+		// set custom Template
+		if(isset($arrEval['template']) && $arrEval['template'] != "")
+		{
+			$this->strWidgetTemplate = $arrEval['template'];
+		}
+
+		$this->blnIsMultiple = true;
+		$this->strPickerTitle = (($this->strPickerTitle!="")?specialchars($arrEval['pickerTitle']):'Usage Wizard');
+
+		$arrModel = array();
+		if(isset($arrEval['model']))
+		{
+			foreach ($arrEval['model'] as $v)
+			{
+				$model = new \stdClass();
+				$model->table = $v['table'];
+				$model->model = \Model::getClassFromTable($v['table']);
+				$model->label = $v['label'];
+				$model->labelValue  = $v['labelValue'];
+				$model->column = $v['column'];
+				$model->value = $v['value'];
+			}
+			$arrModel[] = $model;
+
+		}
+		$this->arrModel = $arrModel;
+	}
+
+
+	/**
+	 * Return an array if the "multiple" attribute is set
+	 * @param mixed
+	 * @return mixed
+	 */
+	protected function validator($varInput)
+	{
+		// Return the value as usual
+		if ($varInput == '')
+		{
+			if (!$this->mandatory)
+			{
+				return '';
+			}
+			else
+			{
+				$this->addError(sprintf($GLOBALS['TL_LANG']['ERR']['mandatory'], $this->strLabel));
+			}
+		}
+		elseif (strpos($varInput, ',') === false)
+		{
+			return $this->blnIsMultiple ? array(intval($varInput)) : intval($varInput);
+		}
+		else
+		{
+			$arrValue = array_map('intval', array_filter(explode(',', $varInput)));
+			return $this->blnIsMultiple ? $arrValue : $arrValue[0];
+		}
+	}
+
+
+	/**
+	 * Generate the widget and return it as string
+	 * @return string
+	 */
+	public function generate()
+	{
+		$arrSet = array();
+		$arrValues = array();
+
+		foreach($this->arrModel as $v)
+		{
+			$class = $v->model;
+			$obj = $class::findBy($v->column, $v->value);
+
+			if ($obj !== null)
+			{
+				while ($obj->next())
+				{
+					$arrSet[] = $obj->id;
+					$objClass = new \stdClass();
+					$objClass->icon = \Image::getHtml($this->getPageStatusIcon($obj));
+					$arrLabelValue = array();
+					for ($i=0; $i<count($v->labelValue); $i++)
+					{
+						$arrLabelValue[] =  $obj->{$v->labelValue[$i]};
+					}
+					$objClass->label = vsprintf($v->label,$arrLabelValue);
+					$arrValues[$obj->id] =  $objClass ;
+				}
+			}
+		}
+
+		// Load the fonts for the drag hint (see #4838)
+		$GLOBALS['TL_CONFIG']['loadGoogleFonts'] = true;
+
+		$objTemplate = new \BackendTemplate($this->strWidgetTemplate);
+		$objTemplate->type = $this->type;
+		$objTemplate->isAjaxRequest = \Environment::get('isAjaxRequest');
+		$objTemplate->name = $this->strName;
+		$objTemplate->id = $this->strId;
+		$objTemplate->set = implode(',', $arrSet);
+		$objTemplate->class = "";
+		$objTemplate->arrValues = $arrValues;
+		$objTemplate->do = \Input::get('do');
+		$objTemplate->table = $this->strTable;
+		$objTemplate->field = $this->strField;
+		$objTemplate->getId = \Input::get('id');
+		$objTemplate->href = 'contao/main.php?do=page&amp;popup=1';
+		$objTemplate->changeSelection = $GLOBALS['TL_LANG']['MSC']['changeSelection'];
+		$objTemplate->pickerTitle = $this->strPickerTitle;
+		$this->Session->set('filePickerRef', '');
+
+		return $objTemplate->parse();
+	}
+}


### PR DESCRIPTION
This Pull Request is a test to get a usage wizard /widget in Contao.
It is still under progress. So feel free to share ;)

I am not sure if it works, but it makes me crazy that I am not know on wich pages my layout is used wich I currently edit ;).

So it works pretty well. You have to copy the `core-uncompressed.js` into `core.js`.

I am not happy about the button underneath the widget `Auswahl ändern`. So we can discuss about this and all the other stuff ;)
### Todo (I will update it if I miss something in here ;))
- [x] Usage Wizard for Layouts
- [ ] Usage Wizard for Moduls
- [ ] Usage Wizard for Files -> This is dificult because there is this tinyMCE. For me it is no problem, because I removed the options to add Images in the tinyMCE. ;) So all thos images wich are added in the are missing ;)
- [ ] Think about insert Tags... `{{insert_module::*}}` `{{image::*}}` Not sure how to handle this.
### Please Notice:

The core widgets normaly have lots of inline HTML and so on. I hat this. because of that ther is an extra `be_usage_widget.html5`. If this is OK so tell me, and I will rework all the other widgets! ;)

So I have read the mails from @leofeyer to not chage the syntax and have the same structure on similar code... But I can't do it like this way. Sorry for that.
### Commit Notes:

initial commit for usage widgets
- added reloadWidget to Ajax.php
- added template be_usage_wizard.html5
- added usage wizard JavaScript for reloading the widget
- added usage widget to the layout
- added UsageWizard.php to the config and autoloader
