### PR TITLE
prevent empty update statement

### DIFF
--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -329,6 +329,11 @@ abstract class Model
 			$arrSet = $this->preSave($arrSet);
 			$intPk  = $this->{static::$strPk};
 
+			if (count($arrSet) == 0)
+			{
+				return $this;
+			}
+
 			// Track primary key changes
 			if (isset($this->arrModified[static::$strPk]))
 			{


### PR DESCRIPTION
Weiß aber nicht, ob das 1. so gut ist und 2. das auch bei insert so gemacht werden müsste.

Auf jeden Fall ist das leere update im ModuleRegistration beim Anlegen des Nutzerverzeichnisses aufgetreten.
