### PR TITLE
Hybrid extending classes defining $arrData are not mixing imported classes with user data anymore.

### DIFF
--- a/system/modules/frontend/Hybrid.php
+++ b/system/modules/frontend/Hybrid.php
@@ -107,6 +107,30 @@ abstract class Hybrid extends Frontend
 		$this->hl = is_array($arrHeadline) ? $arrHeadline['unit'] : 'h1';
 	}
 
+	/**
+	 * Import a library and make it accessible by its name or an optional key.
+	 *
+	 * This has been overridden in Hybrid class to prevent polluting of the $arrData property with object instances.
+	 *
+	 * @param string  $strClass The name of the class to instantiate/import.
+	 *
+	 * @param string  $strKey   The key to use to store the instance (optional, defaults to the objects class name).
+	 *
+	 * @param boolean $blnForce Force the re-importing (optional, defaults to false).
+	 */
+	protected function import($strClass, $strKey=null, $blnForce=false)
+	{
+		$strKey = ($strKey != '') ? $strKey : $strClass;
+		if (property_exists($this, $strKey))
+		{
+			parent::import($strClass, $strKey, $blnForce);
+		}
+
+		if ($blnForce || !is_object($this->arrInstances[$strKey]))
+		{
+			$this->arrInstances[$strKey] = (in_array('getInstance', get_class_methods($strClass))) ? call_user_func(array($strClass, 'getInstance')) : new $strClass();
+		}
+	}
 
 	/**
 	 * Set an object property
@@ -126,6 +150,12 @@ abstract class Hybrid extends Frontend
 	 */
 	public function __get($strKey)
 	{
+		// First check if it is an imported object, if so, return it. See documentation at import() method.
+		if (is_object($this->arrInstances[$strKey]))
+		{
+			return $this->arrInstances[$strKey];
+		}
+
 		return $this->arrData[$strKey];
 	}
 


### PR DESCRIPTION
(At least) Form class is broken due to extending Hybrid class which does mix data with instances.

The `Hybrid` class defines:

``` php
    protected $arrData = array();
```

And the corresponding `php public function __set($strKey, $varValue)` and `php public function __get($strKey)`

The class `Form` defines:

``` php
    /**
     * Current record
     * @var array
     */
    protected $arrData = array();
```

So now ALL callbacks (everything being imported as HOOK) will get stored as "form data" in the form class.
When now storing this data into the database or something else and deserializing it, we end up in creating many instances of incomplete objects.

Due to the nature of Contao we are therefore trashing all the singletons with these incomplete object instances, resulting i.e. in fatal errors like:

```
Fatal error: FrontendUser::__destruct(): The script tried to execute a method or access a property of an incomplete object. Please ensure that the class definition &quot;DB_Mysql&quot; of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide a __autoload() function to load the class definition in .../system/modules/frontend/FrontendUser.php on line 115
```

(Contao 2.11 only I guess, have not checked 3.X as it should be unaffected as the importing has been changed in there to import into `$arrObjects`)

Simply changing the name of `$arrData` in class `Form` to something else (like `$arrFormData`) is not an option, as sadly other extensions (like the famous efg) depend on this array being set.
For efg it applies as all the code from `Form` class has been copied and therefore the HOOK calling code aswell.
Changing the name of `$arrData` in class `Hybrid` to something else (like `$arrHybridData`) is out of question aswell, as then other extensions will again not find the values they need.

I guess this Bug can only be fixed by redefining the import behaviour for the Hybrid class as done in this PR.

We had the problem in the community: https://community.contao.org/de/showthread.php?44982

On a sidekick, this is again a problem with importing and storing persistent references within an instance of a class. I still consider the whole `import()` method a major pitfall of which the syntactic sugar does not provide enough benefits. For Contao 4 at least this behaviour should be dropped altogether.
