### PR TITLE
Simplified Model::mergeRow

### DIFF
--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -277,7 +277,7 @@ abstract class Model
 	 */
 	public function mergeRow(array $arrData)
 	{
-	    $this->setRow(array_diff_key($arrData, $this->arrModified));
+		$this->setRow(array_diff_key($arrData, $this->arrModified));
 
 		return $this;
 	}

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -277,13 +277,7 @@ abstract class Model
 	 */
 	public function mergeRow(array $arrData)
 	{
-		foreach ($arrData as $k=>$v)
-		{
-			if (!isset($this->arrModified[$k]) && $this->arrData[$k] !== $v)
-			{
-				$this->$k = $v;
-			}
-		}
+	    $this->setRow(array_diff_key($arrData, $this->arrModified));
 
 		return $this;
 	}


### PR DESCRIPTION
This way a developer only needs to override setRow() to handle all fields
