### PR TITLE
add static method String::toOutputFormat($strString)

### DIFF
--- a/system/modules/core/library/Contao/String.php
+++ b/system/modules/core/library/Contao/String.php
@@ -463,6 +463,28 @@ class String
 
 
 	/**
+	 * Convert a string to the current output format (xhtml/html5)
+	 *
+	 * @param string $strString The string
+	 *
+	 * @return string The string
+	 */
+	public static function toOutputFormat($strString)
+	{
+		global $objPage;
+
+		if ($objPage->outputFormat == 'xhtml')
+		{
+			return static::toXhtml($strString);
+		}
+		else
+		{
+			return static::toHtml5($strString);
+		}
+	}
+
+
+	/**
 	 * Parse simple tokens that can be used to personalize newsletters
 	 *
 	 * @param string $strString The string to be parsed


### PR DESCRIPTION
Convert a string to the current output format (xhtml/html5)

Man könnte vielleicht `String::toXhtml($strString)` und `String::toHtml5($strString)` generell durch `String::toOutputFormat($strString)` ersetzen.
