### PR TITLE
style selector can be longer than 255 (1024, now)

### DIFF
--- a/system/modules/core/dca/tl_style.php
+++ b/system/modules/core/dca/tl_style.php
@@ -170,8 +170,8 @@ $GLOBALS['TL_DCA']['tl_style'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_style']['selector'],
 			'search'                  => true,
 			'inputType'               => 'text',
-			'eval'                    => array('mandatory'=>true, 'maxlength'=>255, 'decodeEntities'=>true, 'tl_class'=>'long'),
-			'sql'                     => "varchar(255) NOT NULL default ''"
+			'eval'                    => array('mandatory'=>true, 'maxlength'=>1024, 'decodeEntities'=>true, 'tl_class'=>'long'),
+			'sql'                     => "text NULL"
 		),
 		'category' => array
 		(


### PR DESCRIPTION
use TEXT insead of bigger VARCHAR to be MySQL 4.1 compatibile

Hab ich gebraucht: 

```
.mod_navigation a:hover,
.mod_navigation span.active,
.mod_navigation span.trail,
.mod_navigation a.trail,
.mod_changelanguage a:hover,
.mod_changelanguage span.active,
#main_menu.mod_navigation a:hover,
#main_menu.mod_navigation a.trail,
#main_menu.mod_navigation span.trail
```

dieses ganze span/a .active/.trail ...
255 Buchstaben sind einfach zu wenig
