### PR TITLE
Change the input type for back end search fields

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -4840,7 +4840,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 '.implode("\n", $options_sorter).'
 </select>
 <span> = </span>
-<input type="text" name="tl_value" class="tl_text' . ($active ? ' active' : '') . '" value="'.specialchars($session['search'][$this->strTable]['value']).'">
+<input type="search" name="tl_value" class="tl_text' . ($active ? ' active' : '') . '" value="'.specialchars($session['search'][$this->strTable]['value']).'">
 </div>';
 	}
 


### PR DESCRIPTION
This PR changes the form input type from `text` to `search` for back end search fields of all kind. That allows the browser's own rendering engine to render the search fields according to their respective functionality. In any case, there is no harm for browsers that not yet support this type attribute value.
