### PR TITLE
Corrected doctype in mail_default.html5/xhtml template

### DIFF
--- a/system/modules/core/templates/mail/mail_default.html5
+++ b/system/modules/core/templates/mail/mail_default.html5
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 3.2//EN\">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=<?php echo $this->charset; ?>">

--- a/system/modules/core/templates/mail/mail_default.xhtml
+++ b/system/modules/core/templates/mail/mail_default.xhtml
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 3.2//EN\">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=<?php echo $this->charset; ?>">


### PR DESCRIPTION
Like in the issue #1916, the problem with the wrong doctype in the mail_default-template still exists.
So I've corrected this
