### PR TITLE
file names with 16 characters currently treated as UUIDs in insert tags

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -1564,7 +1564,7 @@ abstract class Controller extends \System
 						$strFile = $arrChunks[0];
 					}
 
-					if (\Validator::isUuid($strFile))
+					if (\Validator::isTextUuid($strFile))
 					{
 						// Handle UUIDs
 						$objFile = \FilesModel::findByUuid($strFile);
@@ -1642,7 +1642,7 @@ abstract class Controller extends \System
 
 				// Files (UUID or template path)
 				case 'file':
-					if (\Validator::isUuid($elements[1]))
+					if (\Validator::isTextUuid($elements[1]))
 					{
 						$objFile = \FilesModel::findByUuid(\String::uuidToBin($elements[1]));
 

--- a/system/modules/core/library/Contao/Validator.php
+++ b/system/modules/core/library/Contao/Validator.php
@@ -274,6 +274,11 @@ class Validator
 			$varValue = \String::binToUuid($varValue);
 		}
 
+		return \Validator::isTextUuid($varValue);
+	}
+
+	public static function isTextUuid($varValue)
+	{
 		return preg_match('/^[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12}$/', $varValue);
 	}
 }


### PR DESCRIPTION
File names within a file or image insert tag that happen to be 16 characters long are currently treated as a UUID and the corresponding file is not found. This is because `\Validator::isUuid` always returns true for 16 character data, because it auto-converts from a binary to a text UUID.

This patch adds a new function `isTextUuid`, which only accepts textual UUIDs, and uses this function where the insert tags are processed.
