### PR TITLE
Pass current ContentModel to getContentElement() istead of ID

### DIFF
--- a/system/modules/core/dca/tl_content.php
+++ b/system/modules/core/dca/tl_content.php
@@ -1128,11 +1128,14 @@ class tl_content extends Backend
 		{
 			$class .=  ' h64';
 		}
+		
+		$objModel = new \ContentModel();
+		$objModel->setRow($arrRow);
 
 		return '
 <div class="cte_type ' . $key . '">' . $type . '</div>
 <div class="' . trim($class) . '">
-' . $this->getContentElement($arrRow['id']) . '
+' . $this->getContentElement($objModel) . '
 </div>' . "\n";
 	}
 


### PR DESCRIPTION
Instead of passing the ID of a content element to `getContentElement` the already fetched row should be applyed to the `ContentModel`.

I need to customize the content element row and want to call the `tl_content::addCteType`. At the moment I have to reimplement the whole method because of this limitation.

Besides you do not have to create yet another database request (I know Contao does not really care about database requests in the backend).
