### PR TITLE
Create the label only if label set

### DIFF
--- a/system/modules/core/forms/Form.php
+++ b/system/modules/core/forms/Form.php
@@ -209,7 +209,7 @@ class Form extends \Hybrid
 					continue;
 				}
 
-				if ($objWidget->name != '')
+				if ($objWidget->name != '' && $objWidget->label)
 				{
 					$arrLabels[$objWidget->name] = $this->replaceInsertTags($objWidget->label); // see #4268
 				}


### PR DESCRIPTION
Wenn kein Label gesetzt ist, sollte es im `$arrLabels` nicht gesetzt werden, da sonst in der E-Mail nicht der `$objWidget->name` sondern nichts vor dem Doppelpunkt steht.

https://github.com/ralfhartmann/core/blob/7e765df5b778a96b1dfa05d4eccbe870f41fabe6/system/modules/core/forms/Form.php#L304
