### PR TITLE
Set English as fallback language

### DIFF
--- a/system/initialize.php
+++ b/system/initialize.php
@@ -160,7 +160,10 @@ elseif (isset($_SESSION['TL_LANGUAGE']))
 }
 else
 {
-	foreach (Environment::get('httpAcceptLanguage') as $v)
+	// set fallback language if httpAcceptLanguage is empty
+	$languages = Environment::get('httpAcceptLanguage') ?: array('en'):
+	
+	foreach ($languages as $v)
 	{
 		if (is_dir(TL_ROOT . '/system/modules/core/languages/' . str_replace('-', '_', $v)))
 		{
@@ -170,6 +173,7 @@ else
 		}
 	}
 
+	unset($languages);
 	unset($v);
 }
 


### PR DESCRIPTION
In some rare cases the initialize.php will not set any language. If you run outside the Page context and User context and the client does not set any httAcceptLanguage. 

It this cases English should be used as fallback.
