### PR TITLE
Change check of the array key "value" from isset to array_key_exists

### DIFF
--- a/system/modules/core/widgets/SelectMenu.php
+++ b/system/modules/core/widgets/SelectMenu.php
@@ -126,7 +126,7 @@ class SelectMenu extends \Widget
 
 		foreach ($this->arrOptions as $strKey=>$arrOption)
 		{
-			if (isset($arrOption['value']))
+			if (array_key_exists('value', $arrOption))
 			{
 				$arrOptions[] = sprintf('<option value="%s"%s>%s</option>',
 										 specialchars($arrOption['value']),


### PR DESCRIPTION
The problem occured if inlcudeBlankOption is set to true in the dca and the sql field type is varbinary cause "https://github.com/contao/core/blob/master/system/modules/core/library/Contao/Widget.php#L1377" returns null to the value key and isset failes if the value of an array key is null
