### PR TITLE
Trim SQL statement to prevent match issues

### DIFF
--- a/system/modules/core/library/Contao/Database/Statement.php
+++ b/system/modules/core/library/Contao/Database/Statement.php
@@ -140,7 +140,7 @@ abstract class Statement
 		}
 
 		$this->resResult = null;
-		$this->strQuery = $this->prepare_query($strQuery);
+		$this->strQuery = trim($this->prepare_query($strQuery));
 
 		// Auto-generate the SET/VALUES subpart
 		if (strncasecmp($this->strQuery, 'INSERT', 6) === 0 || strncasecmp($this->strQuery, 'UPDATE', 6) === 0)


### PR DESCRIPTION
My SQL statement looked similar to this:

``` php
\Database::getInstance()->prepare("
    UPDATE tl_member %s WHERE id=?
")->set(array('published'=>'1'))->execute(1);
```

Due to the line break and whitespace before _UPDATE_, the `set()` method does not recognize it. It uses the first 6 chars to compare against _INSERT_ or _UPDATE_.
