### PR TITLE
ContentAlias element now preserves original values of the aliased element

### DIFF
--- a/system/modules/core/elements/ContentAlias.php
+++ b/system/modules/core/elements/ContentAlias.php
@@ -48,13 +48,16 @@ class ContentAlias extends \ContentElement
 			return '';
 		}
 
+		$objElement->originalId = $objElement->id;
 		$objElement->id = $this->id;
 		$objElement->typePrefix = 'ce_';
 
 		$objElement = new $strClass($objElement);
 
 		// Overwrite spacing and CSS ID
+		$objElement->originalSpace = $objElement->space;
 		$objElement->space = $this->space;
+		$objElement->originalCssID = $objElement->cssID;
 		$objElement->cssID = $this->cssID;
 
 		return $objElement->generate();


### PR DESCRIPTION
Ein einfacher fix für bug/request #6622

Das Alias Element überschreibt weiterhin die Werte `id`, `space` und `cssID` - allerdings werden die alten Werte jetzt jeweils in `originalId`, `originalSpace` und `originalCssID` beibehalten, damit Templates von eigen-entwickelten Content Elementen die Inklusion  berücksichtigen können.
