### PR TITLE
Preserve tags in styles (e.g. for inline SVG)

### DIFF
--- a/system/modules/core/classes/StyleSheets.php
+++ b/system/modules/core/classes/StyleSheets.php
@@ -202,18 +202,17 @@ class StyleSheets extends \Backend
 	public function compileDefinition($row, $blnWriteToFile=false, $vars=array(), $parent=array())
 	{
 		$blnDebug = $GLOBALS['TL_CONFIG']['debugMode'];
+		$return = '';
 
 		if ($blnWriteToFile)
 		{
 			$strGlue = '../../';
 			$lb = ($blnDebug ? "\n    " : '');
-			$return = '';
 		}
 		else
 		{
 			$strGlue = '';
 			$lb = "\n    ";
-			$return = "\n" . '<pre'. ($row['invisible'] ? ' class="disabled"' : '') .'>';
 		}
 
 		$blnNeedsPie = false;
@@ -951,7 +950,7 @@ class StyleSheets extends \Backend
 		}
 		else
 		{
-			$return .= "\n}</pre>\n";
+			$return = "\n" . '<pre'. ($row['invisible'] ? ' class="disabled"' : '') .'>' . htmlspecialchars($return) . "\n}</pre>\n";
 		}
 
 		// Replace global variables

--- a/system/modules/core/dca/tl_style.php
+++ b/system/modules/core/dca/tl_style.php
@@ -594,7 +594,7 @@ $GLOBALS['TL_DCA']['tl_style'] = array
 		(
 			'label'                   => &$GLOBALS['TL_LANG']['tl_style']['own'],
 			'inputType'               => 'textarea',
-			'eval'                    => array('decodeEntities'=>true, 'style'=>'height:120px'),
+			'eval'                    => array('preserveTags'=>true, 'style'=>'height:120px'),
 			'sql'                     => "text NULL"
 		),
 		'invisible' => array


### PR DESCRIPTION
It is currently not possible to use inline code in the custom code section (e.g. http://www.karlhorky.com/2012/06/cross-browser-image-grayscale-with-css.html)
