### PR TITLE
Fixed display blank option label if foreignKey query does not return any values

### DIFF
--- a/system/docs/CHANGELOG.md
+++ b/system/docs/CHANGELOG.md
@@ -19,6 +19,9 @@ Make the swipe CSS selectors more specific (see #6666).
 ### Fixed
 Correctly optimize floating-point numbers in style sheets (see #6674).
 
+### Fixed
+Display blank option label if foreignKey query does not return any values.
+
 
 Version 3.2.4 (2014-01-20)
 --------------------------

--- a/system/modules/core/library/Contao/Widget.php
+++ b/system/modules/core/library/Contao/Widget.php
@@ -1279,7 +1279,8 @@ abstract class Widget extends \Controller
 		// Foreign key
 		elseif (isset($arrData['foreignKey']))
 		{
-			$arrData['options'] = array();
+			// Make sure options is an array if it's not set at all yet
+			$arrData['options'] = $arrData['options'] ?: array();
 			$arrKey = explode('.', $arrData['foreignKey'], 2);
 			$objOptions = \Database::getInstance()->query("SELECT id, " . $arrKey[1] . " AS value FROM " . $arrKey[0] . " WHERE tstamp>0 ORDER BY value");
 

--- a/system/modules/core/library/Contao/Widget.php
+++ b/system/modules/core/library/Contao/Widget.php
@@ -1279,13 +1279,12 @@ abstract class Widget extends \Controller
 		// Foreign key
 		elseif (isset($arrData['foreignKey']))
 		{
+			$arrData['options'] = array();
 			$arrKey = explode('.', $arrData['foreignKey'], 2);
 			$objOptions = \Database::getInstance()->query("SELECT id, " . $arrKey[1] . " AS value FROM " . $arrKey[0] . " WHERE tstamp>0 ORDER BY value");
 
 			if ($objOptions->numRows)
 			{
-				$arrData['options'] = array();
-
 				while($objOptions->next())
 				{
 					$arrData['options'][$objOptions->id] = $objOptions->value;


### PR DESCRIPTION
This is because of the next few lines comparing if `options` is an array which it is not.
