### PR TITLE
Stop Error: Contao is not defined

### DIFF
--- a/system/modules/core/library/Contao/Template.php
+++ b/system/modules/core/library/Contao/Template.php
@@ -363,7 +363,7 @@ abstract class Template extends \Controller
 						. "$(document.body).setStyle('margin-bottom',$('debug').hasClass('closed')?'60px':'320px');"
 						. "$('tog').addEvent('click',function(e) {"
 							. "$('debug').toggleClass('closed');"
-							. "Cookie.write('CONTAO_CONSOLE',$('debug').hasClass('closed')?'closed':'',{path:'/'});"
+							. "Cookie.write('CONTAO_CONSOLE',$('debug').hasClass('closed')?'closed':'',{path:(typeof Contao === 'undefined' ? '/' : Contao.path)});"
 							. "$(document.body).setStyle('margin-bottom',$('debug').hasClass('closed')?'60px':'320px');"
 						. "});"
 						. "window.addEvent('resize',function() {"

--- a/system/modules/core/library/Contao/Template.php
+++ b/system/modules/core/library/Contao/Template.php
@@ -363,7 +363,7 @@ abstract class Template extends \Controller
 						. "$(document.body).setStyle('margin-bottom',$('debug').hasClass('closed')?'60px':'320px');"
 						. "$('tog').addEvent('click',function(e) {"
 							. "$('debug').toggleClass('closed');"
-							. "Cookie.write('CONTAO_CONSOLE',$('debug').hasClass('closed')?'closed':'',{path:Contao.path});"
+							. "Cookie.write('CONTAO_CONSOLE',$('debug').hasClass('closed')?'closed':'',{path:'/'});"
 							. "$(document.body).setStyle('margin-bottom',$('debug').hasClass('closed')?'60px':'320px');"
 						. "});"
 						. "window.addEvent('resize',function() {"


### PR DESCRIPTION
Click on <span id="tog"> in Frontend -when Debug-Mode is active
(debugMode=true)- will create an Error in Firebug and/or Chrome's Dev-Tools:
("ReferenceError: Contao is not defined
http://blabla/
Line ...).
Every reload the debug-ouput is visible and need space, because the
cookie could not set with javascript. So a click on the green arrow is
demanded. Again and again...

Changing  Template::output() on line 366 from »Contao.path« to »/« will
solve the problem. Without lose the Issue
»https://github.com/contao/core/issues/5460« and the problem with
Cookies without set path.

I hope, it will help also other Developer in Frontend-Dev-Process.
Martin
