### PR TITLE
jQuery.noConflict() option

### DIFF
--- a/system/modules/core/dca/tl_layout.php
+++ b/system/modules/core/dca/tl_layout.php
@@ -111,7 +111,7 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 		'cols_2cll'                   => 'widthLeft',
 		'cols_2clr'                   => 'widthRight',
 		'cols_3cl'                    => 'widthLeft,widthRight',
-		'addJQuery'                   => 'jSource,jquery',
+		'addJQuery'                   => 'jSource,jquery,jNoConflict,jNoConflictGlobalVariable',
 		'addMooTools'                 => 'mooSource,mootools',
 		'static'                      => 'width,align'
 	),
@@ -357,6 +357,21 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 			'inputType'               => 'checkbox',
 			'eval'                    => array('submitOnChange'=>true),
 			'sql'                     => "char(1) NOT NULL default ''"
+		),
+		'jNoConflict' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_layout']['jNoConflict'],
+			'exclude'                 => true,
+			'inputType'               => 'checkbox',
+			'sql'                     => "char(1) NOT NULL default ''"
+		),
+		'jNoConflictGlobalVariable' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_layout']['jNoConflictGlobalVariable'],
+			'exclude'                 => true,
+			'inputType'               => 'text',
+			'eval'                    => array('decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'clr'),
+			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'jSource' => array
 		(

--- a/system/modules/core/languages/de/tl_layout.xlf
+++ b/system/modules/core/languages/de/tl_layout.xlf
@@ -305,6 +305,22 @@
         <source>Here you can select from where to load the jQuery script.</source>
         <target>Hier können Sie auswählen, von wo das jQuery-Skript geladen wird.</target>
       </trans-unit>
+      <trans-unit id="tl_layout.jNoConflict.0">
+        <source>jQuery noConflict()</source>
+        <target>jQuery noConflict()</target>
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflict.1">
+        <source>Call jQuery.noConflict() after loading the jQuery library</source>
+        <target>Aufrufen jQuery.noConflict() nach der Ladung der jQuery-Bibliothek</target>
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflictGlobalVariable.0">
+        <source>jQuery global variable</source>
+        <target>jQuery globale Variable</target>
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflictGlobalVariable.1">
+        <source>Here you can set up a global variable instead of the $ (dollar) when using jQuery.noConflict()</source>
+        <target>Bei Verwendung jQuery.noConflict(), können Sie eine globale Variable anstelle des Dollar($)-Zeichens erstellen</target>
+      </trans-unit>
       <trans-unit id="tl_layout.jquery.0">
         <source>jQuery templates</source>
         <target>jQuery-Templates</target>

--- a/system/modules/core/languages/en/tl_layout.xlf
+++ b/system/modules/core/languages/en/tl_layout.xlf
@@ -230,6 +230,18 @@
       <trans-unit id="tl_layout.jSource.1">
         <source>Here you can select from where to load the jQuery script.</source>
       </trans-unit>
+      <trans-unit id="tl_layout.jNoConflict.0">
+        <source>jQuery noConflict()</source>
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflict.1">
+        <source>Call jQuery.noConflict() after loading the jQuery library</source>
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflictGlobalVariable.0">
+        <source>jQuery global variable</source>
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflictGlobalVariable.1">
+        <source>Here you can set up a global variable instead of the $ (dollar) when using jQuery.noConflict()</source>
+      </trans-unit>
       <trans-unit id="tl_layout.jquery.0">
         <source>jQuery templates</source>
       </trans-unit>

--- a/system/modules/core/languages/hu/tl_layout.xlf
+++ b/system/modules/core/languages/hu/tl_layout.xlf
@@ -305,6 +305,22 @@
         <source>Here you can select from where to load the jQuery script.</source>
         <target>Válassza ki honnan töltődjön be a JQuery script.</target>
       </trans-unit>
+      <trans-unit id="tl_layout.jNoConflict.0">
+        <source>jQuery noConflict()</source>
+        <target>jQuery noConflict()</target>
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflict.1">
+        <source>Call jQuery.noConflict() after loading the jQuery library</source>
+        <target>jQuery.noConflict() hívása a jQuery script betöltése után.</target>
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflictGlobalVariable.0">
+        <source>jQuery global variable</source>
+        <target>jQuery globális változó</target>
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflictGlobalVariable.1">
+        <source>Here you can set up a global variable instead of the $ (dollar) when using jQuery.noConflict()</source>
+        <target>Amennyiben szükség van rá, itt megadhat egy globális Javascript változót a $ (dollár) helyett jQuery.noConflict() használata esetén.</target>
+      </trans-unit>
       <trans-unit id="tl_layout.jquery.0">
         <source>jQuery templates</source>
         <target>JQuery sablonok</target>

--- a/system/modules/core/languages/ru/tl_layout.xlf
+++ b/system/modules/core/languages/ru/tl_layout.xlf
@@ -297,6 +297,22 @@
         <source>Include the jQuery library in the layout.</source>
         <target>Включать библиотеку jQuery в макет.</target>
       </trans-unit>
+      <trans-unit id="tl_layout.jNoConflict.0">
+        <source>jQuery noConflict()</source>
+        <target>jQuery noConflict()</target >
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflict.1">
+        <source>Call jQuery.noConflict() after loading the jQuery library</source>
+        <target>Вызвать jQuery.noConflict() после загрузки библиотеки jQuery</target >
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflictGlobalVariable.0">
+        <source>jQuery global variable</source>
+        <target>Глобальная переменная jQuery</target >
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflictGlobalVariable.1">
+        <source>Here you can set up a global variable instead of the $ (dollar) when using jQuery.noConflict()</source>
+        <target>Здесь вы можете инициализировать глобальную переменную вместо знака доллара $ при использовании jQuery.noConflict()</target >
+      </trans-unit>
       <trans-unit id="tl_layout.jSource.0">
         <source>jQuery source</source>
         <target>Источник jQuery</target>

--- a/system/modules/core/languages/sl/tl_layout.xlf
+++ b/system/modules/core/languages/sl/tl_layout.xlf
@@ -284,6 +284,22 @@
         <source>Include the jQuery library in the layout.</source>
         <target>Dodaj knjižnico jQuery v postavitev strani.</target>
       </trans-unit>
+      <trans-unit id="tl_layout.jNoConflict.0">
+        <source>jQuery noConflict()</source>
+        <target>Funkcija jQuery.noConflict()</target >
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflict.1">
+        <source>Call jQuery.noConflict() after loading the jQuery library</source>
+        <target>Pokličite funkcijo jQuery.noConflict () po tem, ko se je naložila Query knjižnica</target >
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflictGlobalVariable.0">
+        <source>jQuery global variable</source>
+        <target>jQuery globalna spremenljivka</target >
+      </trans-unit>
+      <trans-unit id="tl_layout.jNoConflictGlobalVariable.1">
+        <source>Here you can set up a global variable instead of the $ (dollar) when using jQuery.noConflict()</source>
+        <target>Ko uporabljate funkcijo jQuery.noConflict(), lahko tukaj nastavite globalno spremenljivko, namesto simbola $ (dolar).</target >
+      </trans-unit>
       <trans-unit id="tl_layout.jSource.0">
         <source>jQuery source</source>
         <target>Vir knjižnice jQuery</target>

--- a/system/modules/core/pages/PageRegular.php
+++ b/system/modules/core/pages/PageRegular.php
@@ -385,6 +385,11 @@ class PageRegular extends \Frontend
 						$this->Template->mooScripts .= '<script>window.jQuery || document.write(\'<script src="' . TL_ASSETS_URL . 'assets/jquery/core/' . JQUERY . '/jquery.min.js">\x3C/script>\')</script>' . "\n";
 					}
 				}
+				
+				// Add jQuery.noConflict() when checked
+				if ($objLayout->jNoConflict) {
+					$this->Template->mooScripts .= '<script type="text/javascript">' . "\n/* <![CDATA[ */\n" . ($objLayout->jNoConflictGlobalVariable ? ('var ' . $objLayout->jNoConflictGlobalVariable . ' = ') : '') . 'jQuery.noConflict(); ' . "\n/* ]]> */\n" . '</script>' . "\n";
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Option on tl_layout settings to call jQuery.noConflict() after jQuery library is included

An optional field to set a global variable name which will be set by jQuery.noConflict()

![clipboard01](https://f.cloud.github.com/assets/6246285/2138979/80875c76-9339-11e3-88b7-1619678efa96.jpg)
