### PR TITLE
Harden the core classes against unserialize() object injections.

### DIFF
--- a/system/modules/core/classes/BackendUser.php
+++ b/system/modules/core/classes/BackendUser.php
@@ -76,6 +76,11 @@ class BackendUser extends \User
 	 */
 	public function __destruct()
 	{
+		if (!$this->Session)
+		{
+			return;
+		}
+
 		$session = $this->Session->getData();
 
 		if (!isset($_GET['act']) && !isset($_GET['key']) && !isset($_GET['token']) && !isset($_GET['state']) && \Input::get('do') != 'feRedirect' && !\Environment::get('isAjaxRequest'))
@@ -126,6 +131,20 @@ class BackendUser extends \User
 			$this->Database->prepare("UPDATE " . $this->strTable . " SET session=? WHERE id=?")
 						   ->execute(serialize($session), $this->intId);
 		}
+	}
+
+
+	/**
+	 * Prevent unserializing see #6695
+	 */
+	public function __wakeup()
+	{
+		foreach(get_object_vars($this) as $k => $v)
+		{
+			$this->$k = null;
+		}
+
+		throw new \Exception(__CLASS__ . ' is not serializable.');
 	}
 
 

--- a/system/modules/core/classes/FrontendUser.php
+++ b/system/modules/core/classes/FrontendUser.php
@@ -88,6 +88,11 @@ class FrontendUser extends \User
 	 */
 	public function __destruct()
 	{
+		if (!$this->Session)
+		{
+			return;
+		}
+
 		$session = $this->Session->getData();
 
 		if (!isset($_GET['pdf']) && !isset($_GET['file']) && !isset($_GET['id']) && $session['referer']['current'] != \Environment::get('requestUri'))
@@ -103,6 +108,20 @@ class FrontendUser extends \User
 			$this->Database->prepare("UPDATE " . $this->strTable . " SET session=? WHERE id=?")
 						   ->execute(serialize($session), $this->intId);
 		}
+	}
+
+
+	/**
+	 * Prevent unserializing see #6695
+	 */
+	public function __wakeup()
+	{
+		foreach(get_object_vars($this) as $k => $v)
+		{
+			$this->$k = null;
+		}
+
+		throw new \Exception(__CLASS__ . ' is not serializable.');
 	}
 
 

--- a/system/modules/core/library/Contao/Config.php
+++ b/system/modules/core/library/Contao/Config.php
@@ -94,6 +94,20 @@ class Config
 
 
 	/**
+	 * Prevent unserializing see #6695
+	 */
+	public function __wakeup()
+	{
+		foreach(get_object_vars($this) as $k => $v)
+		{
+			$this->$k = null;
+		}
+
+		throw new \Exception(__CLASS__ . ' is not serializable.');
+	}
+
+
+	/**
 	 * Prevent cloning of the object (Singleton)
 	 */
 	final public function __clone() {}

--- a/system/modules/core/library/Contao/Database.php
+++ b/system/modules/core/library/Contao/Database.php
@@ -88,7 +88,7 @@ abstract class Database
 	 */
 	public function __destruct()
 	{
-		if (!$this->arrConfig['dbPconnect'])
+		if (is_array($this->arrConfig) && (!$this->arrConfig['dbPconnect']))
 		{
 			$this->disconnect();
 
@@ -96,6 +96,20 @@ abstract class Database
 			$strKey = md5(implode('', $this->arrConfig));
 			unset(static::$arrInstances[$strKey]);
 		}
+	}
+
+
+	/**
+	 * Prevent unserializing see #6695
+	 */
+	public function __wakeup()
+	{
+		foreach(get_object_vars($this) as $k => $v)
+		{
+			$this->$k = null;
+		}
+
+		throw new \Exception(__CLASS__ . ' is not serializable.');
 	}
 
 

--- a/system/modules/core/library/Contao/Database/Result.php
+++ b/system/modules/core/library/Contao/Database/Result.php
@@ -101,6 +101,20 @@ abstract class Result
 
 
 	/**
+	 * Prevent unserializing see #6695
+	 */
+	public function __wakeup()
+	{
+		foreach(get_object_vars($this) as $k => $v)
+		{
+			$this->$k = null;
+		}
+
+		throw new \Exception(__CLASS__ . ' is not serializable.');
+	}
+
+
+	/**
 	 * Set a particular field of the current row
 	 *
 	 * @param mixed  $strKey   The field name

--- a/system/modules/core/library/Contao/File.php
+++ b/system/modules/core/library/Contao/File.php
@@ -144,6 +144,20 @@ class File extends \System
 
 
 	/**
+	 * Prevent unserializing see #6695
+	 */
+	public function __wakeup()
+	{
+		foreach(get_object_vars($this) as $k => $v)
+		{
+			$this->$k = null;
+		}
+
+		throw new \Exception(__CLASS__ . ' is not serializable.');
+	}
+
+
+	/**
 	 * Return an object property
 	 *
 	 * Supported keys:

--- a/system/modules/core/library/Contao/Files/Ftp.php
+++ b/system/modules/core/library/Contao/Files/Ftp.php
@@ -55,6 +55,20 @@ class Ftp extends \Files
 
 
 	/**
+	 * Prevent unserializing see #6695
+	 */
+	public function __wakeup()
+	{
+		foreach(get_object_vars($this) as $k => $v)
+		{
+			$this->$k = null;
+		}
+
+		throw new \Exception(__CLASS__ . ' is not serializable.');
+	}
+
+
+	/**
 	 * Establish an FTP connection
 	 *
 	 * @throws \Exception If an FTP connection cannot be established

--- a/system/modules/core/library/Contao/Session.php
+++ b/system/modules/core/library/Contao/Session.php
@@ -72,6 +72,11 @@ class Session
 	 */
 	public function __destruct()
 	{
+		if (!$this->arrSession)
+		{
+			return;
+		}
+
 		switch (TL_MODE)
 		{
 			case 'BE':
@@ -86,6 +91,20 @@ class Session
 				$_SESSION = $this->arrSession;
 				break;
 		}
+	}
+
+
+	/**
+	 * Prevent unserializing see #6695
+	 */
+	public function __wakeup()
+	{
+		foreach(get_object_vars($this) as $k => $v)
+		{
+			$this->$k = null;
+		}
+
+		throw new \Exception(__CLASS__ . ' is not serializable.');
 	}
 
 

--- a/system/modules/core/library/Contao/ZipReader.php
+++ b/system/modules/core/library/Contao/ZipReader.php
@@ -127,7 +127,24 @@ class ZipReader
 	 */
 	public function __destruct()
 	{
-		@fclose($this->resFile);
+		if (is_resource($this->resFile))
+		{
+			@fclose($this->resFile);
+		}
+	}
+
+
+	/**
+	 * Prevent unserializing see #6695
+	 */
+	public function __wakeup()
+	{
+		foreach(get_object_vars($this) as $k => $v)
+		{
+			$this->$k = null;
+		}
+
+		throw new \Exception(__CLASS__ . ' is not serializable.');
 	}
 
 

--- a/system/modules/core/library/Contao/ZipWriter.php
+++ b/system/modules/core/library/Contao/ZipWriter.php
@@ -127,6 +127,20 @@ class ZipWriter
 
 
 	/**
+	 * Prevent unserializing see #6695
+	 */
+	public function __wakeup()
+	{
+		foreach(get_object_vars($this) as $k => $v)
+		{
+			$this->$k = null;
+		}
+
+		throw new \Exception(__CLASS__ . ' is not serializable.');
+	}
+
+
+	/**
 	 * Add a file to the archive
 	 *
 	 * @param string $strFile The file path


### PR DESCRIPTION
See #6695.

We implement a `__wakeup()` method in all classes having a `__destruct()`
method that unsets all object properties and throws an exception.
In addition, some of the `__destruct()` methods also have been hardened.

This is to be considered a replacement or at least a complement to #6724 as we do not have any BC break.

Note that this currently ONLY fixes the Contao Core classes and NOT swiftmailer or simplepie.
I have not yet investigated if and how those can be fixed.

These files might have to be hardened also:
system/modules/core/vendor/swiftmailer/classes/Swift/Mime/SimpleMimeEntity.php
system/modules/core/vendor/swiftmailer/classes/Swift/Transport/AbstractSmtpTransport.php
system/modules/core/vendor/swiftmailer/classes/Swift/ByteStream/TemporaryFileByteStream.php
system/modules/core/vendor/swiftmailer/classes/Swift/KeyCache/DiskKeyCache.php
system/modules/core/vendor/simplepie/SimplePie/Item.php
system/modules/core/vendor/simplepie/SimplePie.php
system/modules/core/vendor/simplepie/SimplePie.php
system/modules/core/vendor/simplepie/SimplePie.php
