### PR TITLE
A vanilla JavaScript AJAX request for the command scheduler

### DIFF
--- a/system/modules/core/pages/PageRegular.php
+++ b/system/modules/core/pages/PageRegular.php
@@ -428,12 +428,6 @@ class PageRegular extends \Frontend
 			$GLOBALS['TL_JAVASCRIPT'][] = 'assets/mootools/core/' . MOOTOOLS . '/mootools-core.js|static';
 		}
 
-		// Load MooTools request for the command scheduler (see #5195)
-		if (!$GLOBALS['TL_CONFIG']['disableCron'] && !$objLayout->addJQuery && !$objLayout->addMooTools)
-		{
-			$GLOBALS['TL_JAVASCRIPT'][] = 'assets/mootools/core/' . MOOTOOLS . '/mootools-request.js|static';
-		}
-
 		// Check whether TL_APPEND_JS exists (see #4890)
 		if (!empty($arrAppendJs))
 		{

--- a/system/modules/core/templates/frontend/fe_page.html5
+++ b/system/modules/core/templates/frontend/fe_page.html5
@@ -78,7 +78,7 @@
 
   <?php if (!$this->disableCron): ?>
     <script>
-      setTimeout(function(){var b=function(a,b){this.x=new XMLHttpRequest;this.x.open("GET",a,!0);this.x.onreadystatechange=function(){4===this.readyState&&200===this.status&&"function"===typeof b&&b(this.responseText)};this.x.send()};new b("system/cron/cron.txt",function(a){a||(a=0);parseInt(a)<Math.round(+new Date/1E3)-<?php echo $this->cronTimeout; ?>&&new b("system/cron/cron.php")})},5E3);
+      setTimeout(function(){var b=function(a,b){try{this.x=new XMLHttpRequest}catch(c){return}this.x.open("GET",a,!0);this.x.onreadystatechange=function(){4===this.readyState&&200===this.status&&"function"===typeof b&&b(this.responseText)};this.x.send()};new b("system/cron/cron.txt",function(a){a||(a=0);parseInt(a)<Math.round(+new Date/1E3)-<?php echo $this->cronTimeout; ?>&&new b("system/cron/cron.php")})},5E3);
     </script>
   <?php endif; ?>
 

--- a/system/modules/core/templates/frontend/fe_page.html5
+++ b/system/modules/core/templates/frontend/fe_page.html5
@@ -80,8 +80,10 @@
     <script>
       <?php if ($this->layout->addJQuery): ?>
         setTimeout(function(){jQuery.ajax("system/cron/cron.txt",{complete:function(e){var t=e.responseText||0;parseInt(t)<Math.round(+(new Date)/1e3)-<?php echo $this->cronTimeout; ?>&&jQuery.ajax("system/cron/cron.php")}})},5e3)
-      <?php else: ?>
+      <?php elseif ($this->layout->addMooTools): ?>
         setTimeout(function(){(new Request({url:"system/cron/cron.txt",onComplete:function(e){e||(e=0),parseInt(e)<Math.round(+(new Date)/1e3)-<?php echo $this->cronTimeout; ?>&&(new Request({url:"system/cron/cron.php"})).get()}})).get()},5e3)
+      <?php else: ?>
+        setTimeout(function(){var b=function(a,b){this.x=new XMLHttpRequest;this.x.open("GET",a,!0);this.x.onreadystatechange=function(){4===this.readyState&&200===this.status&&"function"===typeof b&&b(this.responseText)};this.x.send()};new b("system/cron/cron.txt",function(a){a||(a=0);parseInt(a)<Math.round(+new Date/1E3)-<?php echo $this->cronTimeout; ?>&&new b("system/cron/cron.php")})},5E3);
       <?php endif; ?>
     </script>
   <?php endif; ?>

--- a/system/modules/core/templates/frontend/fe_page.html5
+++ b/system/modules/core/templates/frontend/fe_page.html5
@@ -78,13 +78,7 @@
 
   <?php if (!$this->disableCron): ?>
     <script>
-      <?php if ($this->layout->addJQuery): ?>
-        setTimeout(function(){jQuery.ajax("system/cron/cron.txt",{complete:function(e){var t=e.responseText||0;parseInt(t)<Math.round(+(new Date)/1e3)-<?php echo $this->cronTimeout; ?>&&jQuery.ajax("system/cron/cron.php")}})},5e3)
-      <?php elseif ($this->layout->addMooTools): ?>
-        setTimeout(function(){(new Request({url:"system/cron/cron.txt",onComplete:function(e){e||(e=0),parseInt(e)<Math.round(+(new Date)/1e3)-<?php echo $this->cronTimeout; ?>&&(new Request({url:"system/cron/cron.php"})).get()}})).get()},5e3)
-      <?php else: ?>
-        setTimeout(function(){var b=function(a,b){this.x=new XMLHttpRequest;this.x.open("GET",a,!0);this.x.onreadystatechange=function(){4===this.readyState&&200===this.status&&"function"===typeof b&&b(this.responseText)};this.x.send()};new b("system/cron/cron.txt",function(a){a||(a=0);parseInt(a)<Math.round(+new Date/1E3)-<?php echo $this->cronTimeout; ?>&&new b("system/cron/cron.php")})},5E3);
-      <?php endif; ?>
+      setTimeout(function(){var b=function(a,b){this.x=new XMLHttpRequest;this.x.open("GET",a,!0);this.x.onreadystatechange=function(){4===this.readyState&&200===this.status&&"function"===typeof b&&b(this.responseText)};this.x.send()};new b("system/cron/cron.txt",function(a){a||(a=0);parseInt(a)<Math.round(+new Date/1E3)-<?php echo $this->cronTimeout; ?>&&new b("system/cron/cron.php")})},5E3);
     </script>
   <?php endif; ?>
 

--- a/system/modules/core/templates/frontend/fe_page.xhtml
+++ b/system/modules/core/templates/frontend/fe_page.xhtml
@@ -80,13 +80,7 @@
   <?php if (!$this->disableCron): ?>
     <script type="text/javascript">
       /* <![CDATA[ */
-      <?php if ($this->layout->addJQuery): ?>
-        setTimeout(function(){jQuery.ajax("system/cron/cron.txt",{complete:function(e){var t=e.responseText||0;parseInt(t)<Math.round(+(new Date)/1e3)-<?php echo $this->cronTimeout; ?>&&jQuery.ajax("system/cron/cron.php")}})},5e3)
-      <?php elseif ($this->layout->addMooTools): ?>
-        setTimeout(function(){(new Request({url:"system/cron/cron.txt",onComplete:function(e){e||(e=0),parseInt(e)<Math.round(+(new Date)/1e3)-<?php echo $this->cronTimeout; ?>&&(new Request({url:"system/cron/cron.php"})).get()}})).get()},5e3)
-      <?php else: ?>
         setTimeout(function(){var b=function(a,b){this.x=new XMLHttpRequest;this.x.open("GET",a,!0);this.x.onreadystatechange=function(){4===this.readyState&&200===this.status&&"function"===typeof b&&b(this.responseText)};this.x.send()};new b("system/cron/cron.txt",function(a){a||(a=0);parseInt(a)<Math.round(+new Date/1E3)-<?php echo $this->cronTimeout; ?>&&new b("system/cron/cron.php")})},5E3);
-      <?php endif; ?>
       /* ]]> */
     </script>
   <?php endif; ?>

--- a/system/modules/core/templates/frontend/fe_page.xhtml
+++ b/system/modules/core/templates/frontend/fe_page.xhtml
@@ -80,7 +80,7 @@
   <?php if (!$this->disableCron): ?>
     <script type="text/javascript">
       /* <![CDATA[ */
-        setTimeout(function(){var b=function(a,b){this.x=new XMLHttpRequest;this.x.open("GET",a,!0);this.x.onreadystatechange=function(){4===this.readyState&&200===this.status&&"function"===typeof b&&b(this.responseText)};this.x.send()};new b("system/cron/cron.txt",function(a){a||(a=0);parseInt(a)<Math.round(+new Date/1E3)-<?php echo $this->cronTimeout; ?>&&new b("system/cron/cron.php")})},5E3);
+        setTimeout(function(){var b=function(a,b){try{this.x=new XMLHttpRequest}catch(c){return}this.x.open("GET",a,!0);this.x.onreadystatechange=function(){4===this.readyState&&200===this.status&&"function"===typeof b&&b(this.responseText)};this.x.send()};new b("system/cron/cron.txt",function(a){a||(a=0);parseInt(a)<Math.round(+new Date/1E3)-<?php echo $this->cronTimeout; ?>&&new b("system/cron/cron.php")})},5E3);
       /* ]]> */
     </script>
   <?php endif; ?>

--- a/system/modules/core/templates/frontend/fe_page.xhtml
+++ b/system/modules/core/templates/frontend/fe_page.xhtml
@@ -82,8 +82,10 @@
       /* <![CDATA[ */
       <?php if ($this->layout->addJQuery): ?>
         setTimeout(function(){jQuery.ajax("system/cron/cron.txt",{complete:function(e){var t=e.responseText||0;parseInt(t)<Math.round(+(new Date)/1e3)-<?php echo $this->cronTimeout; ?>&&jQuery.ajax("system/cron/cron.php")}})},5e3)
-      <?php else: ?>
+      <?php elseif ($this->layout->addMooTools): ?>
         setTimeout(function(){(new Request({url:"system/cron/cron.txt",onComplete:function(e){e||(e=0),parseInt(e)<Math.round(+(new Date)/1e3)-<?php echo $this->cronTimeout; ?>&&(new Request({url:"system/cron/cron.php"})).get()}})).get()},5e3)
+      <?php else: ?>
+        setTimeout(function(){var b=function(a,b){this.x=new XMLHttpRequest;this.x.open("GET",a,!0);this.x.onreadystatechange=function(){4===this.readyState&&200===this.status&&"function"===typeof b&&b(this.responseText)};this.x.send()};new b("system/cron/cron.txt",function(a){a||(a=0);parseInt(a)<Math.round(+new Date/1E3)-<?php echo $this->cronTimeout; ?>&&new b("system/cron/cron.php")})},5E3);
       <?php endif; ?>
       /* ]]> */
     </script>


### PR DESCRIPTION
in case neither jQuery nor MooTools are activated in the page layout (see #5195)

Hierdurch wird das Laden von MooTools überflüssig: Man spart dem Besucher einen HTTP-Request und ca. 53KB "Page Weight", was bei einer schlechten mobilen Verbindung durchaus Sinn macht. 
Das Script beschränkt sich auf `XMLHttpRequest` und unterstützt dadurch alle halbwegs aktuellen Browser (ab IE7).
