### PR TITLE
Fix missing tableless state in form_message

### DIFF
--- a/system/modules/core/forms/Form.php
+++ b/system/modules/core/forms/Form.php
@@ -546,6 +546,7 @@ class Form extends \Hybrid
 
 					$objTemplate->message = $message;
 					$objTemplate->class = strtolower($tl);
+					$objTemplate->tableless = $this->tableless ? true : false;
 
 					$this->Template->fields .= $objTemplate->parse() . "\n";
 				}


### PR DESCRIPTION
The form message templates checks if form is tableless, but currently the state is not set. This pull request passes the tableless state to form_message template.
