### PR TITLE
Prevent from passing non-string values to specialchars() in text widgets

### DIFF
--- a/system/modules/core/forms/FormHidden.php
+++ b/system/modules/core/forms/FormHidden.php
@@ -49,7 +49,7 @@ class FormHidden extends \Widget
 	{
 		return sprintf('<input type="hidden" name="%s" value="%s"%s',
 						$this->strName,
-						specialchars($this->varValue),
+						specialchars((string) $this->varValue),
 						$this->strTagEnding);
 	}
 }

--- a/system/modules/core/forms/FormTextField.php
+++ b/system/modules/core/forms/FormTextField.php
@@ -166,7 +166,7 @@ class FormTextField extends \Widget
 						$this->strId,
 						($this->hideInput ? ' password' : ''),
 						(strlen($this->strClass) ? ' ' . $this->strClass : ''),
-						specialchars($this->varValue),
+						specialchars((string) $this->varValue),
 						$this->getAttributes(),
 						$this->strTagEnding) . $this->addSubmit();
 	}

--- a/system/modules/core/widgets/TextArea.php
+++ b/system/modules/core/widgets/TextArea.php
@@ -131,7 +131,7 @@ class TextArea extends \Widget
 						$this->intRows,
 						$this->intCols,
 						$this->getAttributes(),
-						specialchars($this->varValue),
+						specialchars((string) $this->varValue),
 						$this->wizard);
 	}
 }

--- a/system/modules/core/widgets/TextField.php
+++ b/system/modules/core/widgets/TextField.php
@@ -151,7 +151,7 @@ class TextField extends \Widget
 							$this->strName,
 							$this->strId,
 							(($this->strClass != '') ? ' ' . $this->strClass : ''),
-							specialchars($this->varValue),
+							specialchars((string) $this->varValue),
 							$this->getAttributes(),
 							$this->wizard);
 		}


### PR DESCRIPTION
When there are already values in the database and you change the inputType to text or textarea there might be a possible type issue:

```
htmlspecialchars() expects parameter 1 to be string
```

I don't know if this might happen in the core but for all the extensions that offer to dynamically generate a widget (like Isotope, MetaModels, dma_elementgenerator etc.) this causes potential trouble.
