### PR TITLE
Add hook to modify or customize search logic

### DIFF
--- a/system/modules/core/library/Contao/Search.php
+++ b/system/modules/core/library/Contao/Search.php
@@ -346,6 +346,20 @@ class Search
 			throw new \Exception('Empty keyword string');
 		}
 
+		// HOOK: add custom logic
+		if (isset($GLOBALS['TL_HOOKS']['searchFor']) && is_array($GLOBALS['TL_HOOKS']['searchFor']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['searchFor'] as $callback)
+			{
+				$varResult = \System::importStatic($callback[0])->$callback[1]($strKeywords, $blnOrSearch, $arrPid, $intRows, $intOffset, $blnFuzzy);
+
+				if ($varResult instanceof \Database\Result)
+				{
+					return $varResult;
+				}
+			}
+		}
+
 		// Split keywords
 		$arrChunks = array();
 		preg_match_all('/"[^"]+"|[\+\-]?[^ ]+\*?/', $strKeywords, $arrChunks);


### PR DESCRIPTION
In a current project I need to modify the search results. I noticed there is no way to do this with the internal search module.

The idea behind the hook is that I can modify the properties (e.g. keywords) by using references, but I can also overwrite the whole result by returning a custom `\Database\Result`.

_I have not tested this impelementation, so this is RFC!_
