### PR TITLE
Also add the href data for active items to the breadcrumb template

### DIFF
--- a/system/modules/core/modules/ModuleBreadcrumb.php
+++ b/system/modules/core/modules/ModuleBreadcrumb.php
@@ -194,6 +194,7 @@ class ModuleBreadcrumb extends \Module
 			(
 				'isRoot'   => false,
 				'isActive' => true,
+				'href'     => $this->generateFrontendUrl($pages[0]),
 				'title'    => specialchars($pages[0]['pageTitle'] ?: $pages[0]['title']),
 				'link'     => $pages[0]['title'],
 				'data'     => $pages[0],


### PR DESCRIPTION
Is there a reason to **not** add the `href` of an active item to the breadcrumb template?

It would be great to have the `href` in the template for active items as well.
I'm dealing with Google's Rich Snippets for breadcrumbs and there the `href`for the active menu item is needed.

I could also go and write a hook to achieve this, but that's for sure not the idea behind :)
