### PR TITLE
Prevent websitePath from overwriting

### DIFF
--- a/system/initialize.php
+++ b/system/initialize.php
@@ -123,8 +123,6 @@ else
 	define('TL_PATH', null); // cannot be reliably determined
 }
 
-$GLOBALS['TL_CONFIG']['websitePath'] = TL_PATH; // backwards compatibility
-
 
 /**
  * Start the session
@@ -137,6 +135,12 @@ $GLOBALS['TL_CONFIG']['websitePath'] = TL_PATH; // backwards compatibility
  * Get the Config instance
  */
 $objConfig = Config::getInstance();
+
+
+/**
+ * Restore websitePath
+ */
+$GLOBALS['TL_CONFIG']['websitePath'] = TL_PATH; // backwards compatibility
 
 
 /**


### PR DESCRIPTION
The `$GLOBALS['TL_CONFIG']['websitePath']` may be set in `localconfig.php`, in this case some Contao functions, like [System::setCookie()](https://github.com/contao/core/blob/master/system/modules/core/library/Contao/System.php#L462) which still use `$GLOBALS['TL_CONFIG']['websitePath']`, so no cookie will work in case of wrong cookie path.
