### PR TITLE
Image::get(): return $target if cached file is copied to it

### DIFF
--- a/system/modules/core/library/Contao/Image.php
+++ b/system/modules/core/library/Contao/Image.php
@@ -165,6 +165,7 @@ class Image
 				if ($target)
 				{
 					\Files::getInstance()->copy($strCacheName, $target);
+					return \System::urlEncode($target);
 				}
 
 				return \System::urlEncode($strCacheName);


### PR DESCRIPTION
Wenn $target angegeben ist, wird, insofern noch keine passende Datei im Cache existiert, am Ende der Wert von $target (bzw. die encodierte Version davon) zurückgegeben

Image.php Zeile 423-428

```
// Resize the original image
if ($target)
{
    \Files::getInstance()->copy($strCacheName, $target);
    return \System::urlEncode($target);
}
```

Ist keine Veränderung der Quelldatei notwendig, wird die Datei nach $target kopiert und anschließend $target zurückgegeben

Image.php Zeile 108-124

```
// No resizing required
if ($objFile->width == $width && $objFile->height == $height)
{
    // Return the target image (thanks to Tristan Lins) (see #4166)
    if ($target)
    {
        // Copy the source image if the target image does not exist or is older than the source image
        if (!file_exists(TL_ROOT . '/' . $target) || $objFile->mtime > filemtime(TL_ROOT . '/' . $target))
        {
            \Files::getInstance()->copy($image, $target);
        }
        return \System::urlEncode($target);
    }
    return \System::urlEncode($image);
}
```

Ist aber eine Größenänderung notwendig und die geänderte Datei liegt im Cache bereits vor, aber noch nicht bei $target, so wird zwar die Datei aus dem Cache nach $target kopiert, aber anschließend nicht $target, sondern der Pfad zur Datei im Cache zurückgegeben

Image.php Zeile 149-173

```
// Check whether the image exists already
if (!$GLOBALS['TL_CONFIG']['debugMode'])
{
    // Custom target (thanks to Tristan Lins) (see #4166)
    if ($target && !$force)
    {
        if (file_exists(TL_ROOT . '/' . $target) && $objFile->mtime <= filemtime(TL_ROOT . '/' . $target))
        {
            return \System::urlEncode($target);
        }
    }

    // Regular cache file
    if (file_exists(TL_ROOT . '/' . $strCacheName))
    {
        // Copy the cached file if it exists
        if ($target)
        {
            \Files::getInstance()->copy($strCacheName, $target);
            // return target
        }

        return \System::urlEncode($strCacheName);
    }
}
```

die Zeile `// return target` stammt von mir
hier müsste meiner Meinung nach `return \System::urlEncode($target);` stehen, da ansonsten das Verhalten von Image::get an dieser Stelle inkonsistent ist
