### PR TITLE
Add a hook to `DC_Folder::cut()`

### DIFF
--- a/system/modules/core/drivers/DC_Folder.php
+++ b/system/modules/core/drivers/DC_Folder.php
@@ -532,6 +532,16 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 				\Dbafs::moveResource($source, $destination);
 			}
 
+			// HOOK: hook to trigger when file or folder is moved
+			if (isset($GLOBALS['TL_HOOKS']['moveFile']) && is_array($GLOBALS['TL_HOOKS']['moveFile']))
+			{
+				foreach ($GLOBALS['TL_HOOKS']['moveFile'] as $callback)
+				{
+					$this->import($callback[0]);
+					$strBuffer = $this->$callback[0]->$callback[1]($source, $destination);
+				}
+			}
+
 			// Add a log entry
 			$this->log('File or folder "'.$source.'" has been moved to "'.$destination.'"', __METHOD__, TL_FILES);
 		}


### PR DESCRIPTION
A hook to trigger when file or folder is moved. This is needed to custom log and track files.
