### PR TITLE
Use new autoload functionality

### DIFF
--- a/system/functions.php
+++ b/system/functions.php
@@ -104,7 +104,7 @@ function __autoload($strClassName)
 
 	trigger_error(sprintf('Could not load class %s', $strClassName), E_USER_ERROR);
 }
-
+spl_autoload_register('__autoload');
 
 /**
  * Error handler


### PR DESCRIPTION
__autoload() function is deprecated and not usable when in CLI interactive mode (Note 2). See: http://php.net/manual/en/language.oop5.autoload.php
