### PR TITLE
Revise algorithm to get "proxied" Client-IP

### DIFF
--- a/system/modules/core/library/Contao/Environment.php
+++ b/system/modules/core/library/Contao/Environment.php
@@ -356,20 +356,20 @@ class Environment
 		{
 			$arrIps = array($strXip);
 		}
+		// Append IP of last proxy 
+		$arrIps[] = $_SERVER['REMOTE_ADDR'];
 
 		$arrIps = array_reverse($arrIps);
 
-		// Return the first untrusted IP address (see #5830)
+		// Return the nearest untrusted or (if all are trusted) the most distant IP address (see #5830)
 		foreach ($arrIps as $strIp)
 		{
 			if (!in_array($strIp, $arrTrusted))
 			{
-				return substr($strIp, 0, 64);
+				break;
 			}
 		}
-
-		// If all X-Forward-For IPs are trusted, return the remote address
-		return substr($_SERVER['REMOTE_ADDR'], 0, 64);
+		return substr($strIp, 0, 64);
 	}
 
 


### PR DESCRIPTION
I am working on a single-sign-on with other applications where Contao is the master. This depends on a correct handling of the X-Forwarded-For header.

To validate the Session, I send a http-sub-request to Contao with the cookies received from the client. Now, Contao validates the session and sends back the session cookies. These cookies from the sub-request were forwarded to the client. This is the same as sending the request through a proxy.

With the current implementation this only works with `$GLOBALS['TL_CONFIG']['disableIpCheck'] = true;` (and at localhost).

**EDIT**: To clarify the problem imagine the following proxy-chain: client > proxy1 > proxy2 > proxy3 > webserver.
With an empty `$GLOBALS['TL_CONFIG']['proxyServerIps']` `Environment::ip()` returns **proxy2** (expect **proxy3**) which is the last element in the XFF added by proxy3.
With `$GLOBALS['TL_CONFIG']['proxyServerIps']` set to "client,proxy1,proxy2,proxy3" or "client,proxy1,proxy2" `Environment:ip()` returns **proxy3** (expect **client**).
The last proxy is never checked.
To solve this we need to append the last proxy (REMOTE_ADDR) to the array of IPs to be checked and return either the first (seen from Contao) untrusted address (wich is an untrusted proxy or the client) or (if all addresses are trusted) the last (seen from Contao).

Here my SSO-Implementation:

On Contao-side I have the following code in `./share/sso_username.php` which just prints the username and sends the cookies.

``` php
<?php
define('TL_MODE', 'FE');
require '../system/initialize.php';

class SsoUsername extends Frontend
{
    public function __construct()
    {
        $this->import('FrontendUser', 'User');
        parent::__construct();
        define('BE_USER_LOGGED_IN', $this->getLoginStatus('BE_USER_AUTH'));
        define('FE_USER_LOGGED_IN', $this->getLoginStatus('FE_USER_AUTH'));
    }
    public function run()
    {
        $this->User->authenticate();
        header('Content-Type: text/plain');
        echo $this->User->username;
    }
}

(new SsoUsername())->run();
```

On the other side (in this case phpBB3) my authentication plugin has the following function to get Contaos frontend-user.

``` php
define('SSO_USERNAME_URL', 'http://localhost/share/sso_username.php');

/**
* Get the username of current Contao session and forward Cookies from sub-request to the client.
*
* @return username of current Contao session
*/
function get_current_user_contao() {
    static $user_contao = false;

    // Do it once per request
    if ($user_contao !== false) {
        return $user_contao;
    }

    // Create context for sub-request, append remote address to XFF-Header
    $ctx = stream_context_create(array(
        'http'=>array(
            'method'=>"GET",
            'protocol_version'=>0.9,
            'header'=>
                'X-Forwarded-For: ' . (!empty($_SERVER['HTTP_X_FORWARDED_FOR']) ? "${_SERVER['HTTP_X_FORWARDED_FOR']}, " :'') . "${_SERVER['REMOTE_ADDR']}\r\n" .
                "Cookie: ${_SERVER['HTTP_COOKIE']}\r\n"
        )
    ));

    // request the username
    $user_contao = file_get_contents(SSO_USERNAME_URL, false, $ctx);

    // forward cookies
    foreach ($http_response_header as $h) {
        list($k, $v) = explode(':', $h, 2);
        if (strtolower($k) === 'set-cookie') {
            header($h, false);
        }
    }

    // return username
    return $user_contao;
}
```
