### PR TITLE
Show template name in source code

### DIFF
--- a/system/docs/CHANGELOG.md
+++ b/system/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ Version 3.3.beta1 (2014-XX-XX)
 ------------------------------
 
 ### New
+Display the used template path in the source code when in debug mode.
+
+### New
 Added more static convenience methods to the `Config` class:
 
  - `set()`: temporarily set a configuration value

--- a/system/modules/core/library/Contao/Template.php
+++ b/system/modules/core/library/Contao/Template.php
@@ -272,10 +272,21 @@ abstract class Template extends \Controller
 			}
 		}
 
+		$strTemplatePath = \Controller::getTemplate($this->strTemplate, $this->strFormat);
+		$strBuffer = '';
+
+		if (\Config::get('debugMode')) {
+			$strBuffer .= "\n" . '<!-- TEMPLATE START: ' . str_replace(TL_ROOT . '/', '', $strTemplatePath) . ' -->' . "\n";
+		}
+
 		ob_start();
-		include $this->getTemplate($this->strTemplate, $this->strFormat);
-		$strBuffer = ob_get_contents();
+		include $strTemplatePath;
+		$strBuffer .= ob_get_contents();
 		ob_end_clean();
+
+		if (\Config::get('debugMode')) {
+			$strBuffer .= "\n" . '<!-- TEMPLATE END: ' . str_replace(TL_ROOT . '/', '', $strTemplatePath) . ' -->' . "\n";
+		}
 
 		return $strBuffer;
 	}

--- a/system/modules/core/library/Contao/Template.php
+++ b/system/modules/core/library/Contao/Template.php
@@ -275,7 +275,8 @@ abstract class Template extends \Controller
 		$strTemplatePath = \Controller::getTemplate($this->strTemplate, $this->strFormat);
 		$strBuffer = '';
 
-		if (\Config::get('debugMode')) {
+		if (\Config::get('debugMode'))
+		{
 			$strBuffer .= "\n" . '<!-- TEMPLATE START: ' . str_replace(TL_ROOT . '/', '', $strTemplatePath) . ' -->' . "\n";
 		}
 
@@ -284,7 +285,8 @@ abstract class Template extends \Controller
 		$strBuffer .= ob_get_contents();
 		ob_end_clean();
 
-		if (\Config::get('debugMode')) {
+		if (\Config::get('debugMode'))
+		{
 			$strBuffer .= "\n" . '<!-- TEMPLATE END: ' . str_replace(TL_ROOT . '/', '', $strTemplatePath) . ' -->' . "\n";
 		}
 


### PR DESCRIPTION
I think this could be very useful. People keep asking which template has been used to render a specific part of the website so why not just output it in the HTML source code when the debug mode is enabled? ;-)

![bildschirmfoto 2014-04-01 um 13 44 19](https://cloud.githubusercontent.com/assets/481937/2578575/078bdbc8-b993-11e3-9b22-ae8a69a961a1.png)
