### PR TITLE
Removed version number from backend login screen

### DIFF
--- a/system/modules/core/templates/backend/be_login.html5
+++ b/system/modules/core/templates/backend/be_login.html5
@@ -38,7 +38,7 @@
   <![endif]-->
 
   <div id="header">
-    <h1>Contao Open Source CMS <?php echo VERSION; ?></h1>
+    <h1>Contao Open Source CMS</h1>
   </div>
 
   <div id="container">


### PR DESCRIPTION
The version number in the backend login screen is just too much information about the system behind in case of issues like #6855 or other security related tickets.
Please remove this, thanks.
