### PR TITLE
Hardening the generation of pathconfig.php.

### DIFF
--- a/contao/install.php
+++ b/contao/install.php
@@ -819,7 +819,7 @@ class InstallTool extends Backend
 
 		try
 		{
-			File::putContent('system/config/pathconfig.php', '<?php' . "\n\n// Relative path to the installation\nreturn '" . TL_PATH . "';\n");
+			File::putContent('system/config/pathconfig.php', '<?php' . "\n\n// Relative path to the installation\nreturn " . var_export(TL_PATH, true) . ";\n");
 		}
 		catch (Exception $e)
 		{


### PR DESCRIPTION
Prevent PHP injection possibility, by using `var_export()` to generate the pathconfig.php.
