### PR TITLE
Add support for nested blocks in templates

### DIFF
--- a/system/modules/core/templates/frontend/fe_page.html5
+++ b/system/modules/core/templates/frontend/fe_page.html5
@@ -2,21 +2,38 @@
 <html lang="<?php echo $this->language; ?>">
 <head>
 
-  <meta charset="<?php echo $this->charset; ?>">
-  <title><?php echo $this->title; ?></title>
-  <base href="<?php echo $this->base; ?>">
+  <?php $this->block('head'); ?>
 
-  <meta name="robots" content="<?php echo $this->robots; ?>">
-  <meta name="description" content="<?php echo $this->description; ?>">
-  <meta name="keywords" content="<?php echo $this->keywords; ?>">
-  <meta name="generator" content="Contao Open Source CMS">
+    <?php $this->block('charset'); ?>
+      <meta charset="<?php echo $this->charset; ?>">
+    <?php $this->endblock(); ?>
 
-  <?php echo $this->viewport; ?>
-  <?php echo $this->framework; ?>
-  <?php echo $this->stylesheets; ?>
-  <?php echo $this->mooScripts; ?>
-  <?php echo $this->head; ?>
-  <!--[if lt IE 9]><script src="<?php echo TL_ASSETS_URL; ?>assets/html5shiv/<?php echo $GLOBALS['TL_ASSETS']['HTML5SHIV']; ?>/html5shiv-printshiv.js"></script><![endif]-->
+    <?php $this->block('title'); ?>
+      <title><?php echo $this->title; ?></title>
+    <?php $this->endblock(); ?>
+
+    <?php $this->block('base'); ?>
+      <base href="<?php echo $this->base; ?>">
+    <?php $this->endblock(); ?>
+
+    <?php $this->block('meta'); ?>
+      <meta name="robots" content="<?php echo $this->robots; ?>">
+      <meta name="description" content="<?php echo $this->description; ?>">
+      <meta name="keywords" content="<?php echo $this->keywords; ?>">
+      <meta name="generator" content="Contao Open Source CMS">
+    <?php $this->endblock(); ?>
+
+    <?php echo $this->viewport; ?>
+    <?php echo $this->framework; ?>
+    <?php echo $this->stylesheets; ?>
+    <?php echo $this->mooScripts; ?>
+    <?php echo $this->head; ?>
+
+    <?php $this->block('html5shiv'); ?>
+      <!--[if lt IE 9]><script src="<?php echo TL_ASSETS_URL; ?>assets/html5shiv/<?php echo $GLOBALS['TL_ASSETS']['HTML5SHIV']; ?>/html5shiv-printshiv.js"></script><![endif]-->
+    <?php $this->endblock(); ?>
+
+  <?php $this->endblock(); ?>
 
 </head>
 <body id="top" class="{{ua::class}}<?php if ($this->class) echo ' ' . $this->class; ?>"<?php if ($this->onload): ?> onload="<?php echo $this->onload; ?>"<?php endif; ?>>
@@ -27,50 +44,66 @@
 
     <div id="wrapper">
 
-      <?php if ($this->header): ?>
-        <header id="header">
-          <div class="inside">
-            <?php echo $this->header; ?>
-          </div>
-        </header>
-      <?php endif; ?>
+      <?php $this->block('wrapper'); ?>
 
-      <?php echo $this->sections('before'); ?>
+        <?php if ($this->header): ?>
+          <header id="header">
+            <div class="inside">
+              <?php echo $this->header; ?>
+            </div>
+          </header>
+        <?php endif; ?>
 
-      <div id="container">
-        <div id="main">
-          <div class="inside">
-            <?php echo $this->main; ?>
-          </div>
-          <?php echo $this->sections('main'); ?>
+        <?php echo $this->sections('before'); ?>
+
+        <div id="container">
+
+          <?php $this->block('container'); ?>
+
+            <div id="main">
+
+              <?php $this->block('main'); ?>
+
+                <div class="inside">
+                  <?php echo $this->main; ?>
+                </div>
+                <?php echo $this->sections('main'); ?>
+
+              <?php $this->endblock(); ?>
+
+            </div>
+
+            <?php if ($this->left): ?>
+              <aside id="left">
+                <div class="inside">
+                  <?php echo $this->left; ?>
+                </div>
+              </aside>
+            <?php endif; ?>
+
+            <?php if ($this->right): ?>
+              <aside id="right">
+                <div class="inside">
+                  <?php echo $this->right; ?>
+                </div>
+              </aside>
+            <?php endif; ?>
+
+          <?php $this->endblock(); ?>
+
         </div>
 
-        <?php if ($this->left): ?>
-          <aside id="left">
+        <?php echo $this->sections('after'); ?>
+
+        <?php if ($this->footer): ?>
+          <footer id="footer">
             <div class="inside">
-              <?php echo $this->left; ?>
+              <?php echo $this->footer; ?>
             </div>
-          </aside>
+          </footer>
         <?php endif; ?>
 
-        <?php if ($this->right): ?>
-          <aside id="right">
-            <div class="inside">
-              <?php echo $this->right; ?>
-            </div>
-          </aside>
-        <?php endif; ?>
-      </div>
-
-      <?php echo $this->sections('after'); ?>
-
-      <?php if ($this->footer): ?>
-        <footer id="footer">
-          <div class="inside">
-            <?php echo $this->footer; ?>
-          </div>
-        </footer>
-      <?php endif; ?>
+      <?php $this->endblock(); ?>
 
     </div>
 
@@ -78,7 +111,9 @@
 
   <?php $this->endblock(); ?>
 
-  <?php echo $this->mootools; ?>
+  <?php $this->block('mootools'); ?>
+    <?php echo $this->mootools; ?>
+  <?php $this->endblock(); ?>
 
 </body>
 </html>

--- a/system/modules/core/templates/frontend/fe_page.xhtml
+++ b/system/modules/core/templates/frontend/fe_page.xhtml
@@ -2,22 +2,36 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>">
 <head>
 
-  <meta http-equiv="Content-Type" content="text/html; charset=<?php echo $this->charset; ?>" />
-  <title><?php echo $this->title; ?></title>
-  <base href="<?php echo $this->base; ?>" />
+  <?php $this->block('head'); ?>
 
-  <meta name="robots" content="<?php echo $this->robots; ?>" />
-  <meta name="description" content="<?php echo $this->description; ?>" />
-  <meta name="keywords" content="<?php echo $this->keywords; ?>" />
-  <meta name="generator" content="Contao Open Source CMS" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <meta http-equiv="Content-Script-Type" content="text/javascript" />
+    <?php $this->block('charset'); ?>
+      <meta http-equiv="Content-Type" content="text/html; charset=<?php echo $this->charset; ?>" />
+    <?php $this->endblock(); ?>
 
-  <?php echo $this->viewport; ?>
-  <?php echo $this->framework; ?>
-  <?php echo $this->stylesheets; ?>
-  <?php echo $this->mooScripts; ?>
-  <?php echo $this->head; ?>
+    <?php $this->block('title'); ?>
+      <title><?php echo $this->title; ?></title>
+    <?php $this->endblock(); ?>
+
+    <?php $this->block('base'); ?>
+      <base href="<?php echo $this->base; ?>" />
+    <?php $this->endblock(); ?>
+
+    <?php $this->block('meta'); ?>
+      <meta name="robots" content="<?php echo $this->robots; ?>" />
+      <meta name="description" content="<?php echo $this->description; ?>" />
+      <meta name="keywords" content="<?php echo $this->keywords; ?>" />
+      <meta name="generator" content="Contao Open Source CMS" />
+      <meta http-equiv="Content-Style-Type" content="text/css" />
+      <meta http-equiv="Content-Script-Type" content="text/javascript" />
+    <?php $this->endblock(); ?>
+
+    <?php echo $this->viewport; ?>
+    <?php echo $this->framework; ?>
+    <?php echo $this->stylesheets; ?>
+    <?php echo $this->mooScripts; ?>
+    <?php echo $this->head; ?>
+
+  <?php $this->endblock(); ?>
 
 </head>
 <body id="top" class="{{ua::class}}<?php if ($this->class) echo ' ' . $this->class; ?>"<?php if ($this->onload): ?> onload="<?php echo $this->onload; ?>"<?php endif; ?>>
@@ -28,50 +42,66 @@
 
     <div id="wrapper">
 
-      <?php if ($this->header): ?>
-        <div id="header">
-          <div class="inside">
-            <?php echo $this->header; ?>
-          </div>
-        </div>
-      <?php endif; ?>
+      <?php $this->block('wrapper'); ?>
 
-      <?php echo $this->sections('before'); ?>
-
-      <div id="container">
-        <div id="main">
-          <div class="inside">
-            <?php echo $this->main; ?>
-          </div>
-          <?php echo $this->sections('main'); ?>
-        </div>
-
-        <?php if ($this->left): ?>
-          <div id="left">
+        <?php if ($this->header): ?>
+          <div id="header">
             <div class="inside">
-              <?php echo $this->left; ?>
+              <?php echo $this->header; ?>
             </div>
           </div>
         <?php endif; ?>
 
-        <?php if ($this->right): ?>
-          <div id="right">
+        <?php echo $this->sections('before'); ?>
+
+        <div id="container">
+
+          <?php $this->block('container'); ?>
+
+            <div id="main">
+
+              <?php $this->block('main'); ?>
+
+                <div class="inside">
+                  <?php echo $this->main; ?>
+                </div>
+                <?php echo $this->sections('main'); ?>
+
+              <?php $this->endblock(); ?>
+
+            </div>
+
+            <?php if ($this->left): ?>
+              <div id="left">
+                <div class="inside">
+                  <?php echo $this->left; ?>
+                </div>
+              </div>
+            <?php endif; ?>
+
+            <?php if ($this->right): ?>
+              <div id="right">
+                <div class="inside">
+                  <?php echo $this->right; ?>
+                </div>
+              </div>
+            <?php endif; ?>
+
+          <?php $this->endblock(); ?>
+
+        </div>
+
+        <?php echo $this->sections('after'); ?>
+
+        <?php if ($this->footer): ?>
+          <div id="footer">
             <div class="inside">
-              <?php echo $this->right; ?>
+              <?php echo $this->footer; ?>
             </div>
           </div>
         <?php endif; ?>
-      </div>
 
-      <?php echo $this->sections('after'); ?>
-
-      <?php if ($this->footer): ?>
-        <div id="footer">
-          <div class="inside">
-            <?php echo $this->footer; ?>
-          </div>
-        </div>
-      <?php endif; ?>
+      <?php $this->endblock(); ?>
 
     </div>
 
@@ -79,7 +109,9 @@
 
   <?php $this->endblock(); ?>
 
-  <?php echo $this->mootools; ?>
+  <?php $this->block('mootools'); ?>
+    <?php echo $this->mootools; ?>
+  <?php $this->endblock(); ?>
 
 </body>
 </html>


### PR DESCRIPTION
Nesting blocks would make the templates much more flexible. This way you can use more blocks and overwrite smaller parts of a base template.

[Twig also supports it](http://twig.sensiolabs.org/doc/templates.html#template-inheritance).

I also added more blocks to the `fe_page` templates to show how this could be used.

Related issue: #6508
### Example:

Base template: 

``` html+php
<body>
  <?php $this->block('body'); ?>
    <div id="content">
      <?php $this->block('content'); ?>
        <p>I am the default content.</p>
      <?php $this->endblock(); ?>
    </div>
  <?php $this->endblock(); ?>
</body>
```

Extended template:

``` html+php
<?php $this->extend('...'); ?>
<?php $this->block('body'); ?>
  <p>Extending body.</p>
  <?php $this->parent(); ?>
<?php $this->endblock(); ?>
<?php $this->block('content'); ?>
  <p>Replacing content.</p>
<?php $this->endblock(); ?>
```

Output:

``` html
<body>
  <p>Extending body.</p>
  <div id="content">
    <p>Replacing content.</p>
  </div>
</body>
```
