### PR TITLE
Support extending system templates with the same name

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -40,14 +40,15 @@ abstract class Controller extends \System
 	/**
 	 * Find a particular template file and return its path
 	 *
-	 * @param string $strTemplate The name of the template
-	 * @param string $strFormat   The file extension
+	 * @param string  $strTemplate The name of the template
+	 * @param string  $strFormat   The file extension
+	 * @param boolean $blnCustom   If false, custom templates are ignored
 	 *
 	 * @return string The path to the template file
 	 *
 	 * @throws \Exception If $strFormat is unknown
 	 */
-	public static function getTemplate($strTemplate, $strFormat='html5')
+	public static function getTemplate($strTemplate, $strFormat='html5', $blnCustom=true)
 	{
 		$arrAllowed = trimsplit(',', \Config::get('templateFiles'));
 		array_push($arrAllowed, 'html5'); // see #3398
@@ -60,7 +61,7 @@ abstract class Controller extends \System
 		$strTemplate = basename($strTemplate);
 
 		// Check for a theme folder
-		if (TL_MODE == 'FE')
+		if (TL_MODE == 'FE' && $blnCustom)
 		{
 			global $objPage;
 			$strCustom = str_replace('../', '', $objPage->templateGroup);
@@ -71,7 +72,7 @@ abstract class Controller extends \System
 			}
 		}
 
-		return \TemplateLoader::getPath($strTemplate, $strFormat);
+		return \TemplateLoader::getPath($strTemplate, $strFormat, $blnCustom ? 'templates' : false);
 	}
 
 

--- a/system/modules/core/library/Contao/Template/Base.php
+++ b/system/modules/core/library/Contao/Template/Base.php
@@ -64,6 +64,8 @@ abstract class Base extends \Controller
 	 * Parse the template file and return it as string
 	 *
 	 * @return string The template markup
+	 *
+	 * @throws \Exception If a template extends itself
 	 */
 	public function parse()
 	{
@@ -71,15 +73,31 @@ abstract class Base extends \Controller
 
 		// Start with the template itself
 		$this->strParent = $this->strTemplate;
+		$strParent = null;
 
 		// Include the parent templates
 		while ($this->strParent !== null)
 		{
-			$strParent = $this->getTemplate($this->strParent, $this->strFormat);
+			if ($strParent == $this->strParent)
+			{
+				// Try to load the base template
+				$strPathBase = $this->getTemplate($this->strParent, $this->strFormat, false);
+				if ($strPath == $strPathBase)
+				{
+					throw new \Exception('A template cannot extend itself');
+				}
+				$strPath = $strPathBase;
+			}
+			else
+			{
+				$strPath = $this->getTemplate($this->strParent, $this->strFormat);
+			}
+
+			$strParent = $this->strParent;
 			$this->strParent = null;
 
 			ob_start();
-			include $strParent;
+			include $strPath;
 
 			// Capture the output of the root template
 			if ($this->strParent === null)

--- a/system/modules/core/library/Contao/TemplateLoader.php
+++ b/system/modules/core/library/Contao/TemplateLoader.php
@@ -93,7 +93,8 @@ class TemplateLoader
 	 *
 	 * @param string $template The template name
 	 * @param string $format   The output format (e.g. "html5")
-	 * @param string $custom   The custom templates folder (defaults to "templates")
+	 * @param mixed  $custom   The custom templates folder (defaults to "templates")
+	 *                         or false to ignore custom templates
 	 *
 	 * @return string The path to the template file
 	 *
@@ -104,13 +105,13 @@ class TemplateLoader
 		$file = $template .  '.' . $format;
 
 		// Check the theme folder first
-		if (file_exists(TL_ROOT . '/' . $custom . '/' . $file))
+		if ($custom && file_exists(TL_ROOT . '/' . $custom . '/' . $file))
 		{
 			return TL_ROOT . '/' . $custom . '/' . $file;
 		}
 
 		// Then check the global templates directory (see #5547)
-		if ($custom != 'templates')
+		if ($custom && $custom != 'templates')
 		{
 			if (file_exists(TL_ROOT . '/templates/' . $file))
 			{


### PR DESCRIPTION
Would make it possible to create a custom template extending a template from system/modules and at the same time overwriting it by giving it the same name. For example `templates/fe_page.html5`:

``` html+php
<?php $this->extend('fe_page'); ?>
<?php $this->block('body'); ?>
  ...
<?php $this->endblock(); ?>
```

This would result in an infinite loop in the current implementation.
