### PR TITLE
[POC] [WIP] Add generic proxy support.

### DIFF
--- a/system/config/default.php
+++ b/system/config/default.php
@@ -344,5 +344,7 @@ $GLOBALS['TL_CONFIG']['defaultFolderChmod']   = 0755;
 $GLOBALS['TL_CONFIG']['maxPaginationLinks']   = 7;
 $GLOBALS['TL_CONFIG']['proxyServerIps']       = '';
 $GLOBALS['TL_CONFIG']['sslProxyDomain']       = '';
+$GLOBALS['TL_CONFIG']['proxyDomain']          = '';
+$GLOBALS['TL_CONFIG']['proxySSL']             = false;
 $GLOBALS['TL_CONFIG']['debugMode']            = false;
 $GLOBALS['TL_CONFIG']['maintenanceMode']      = false;

--- a/system/modules/core/dca/tl_settings.php
+++ b/system/modules/core/dca/tl_settings.php
@@ -28,7 +28,7 @@ $GLOBALS['TL_DCA']['tl_settings'] = array
 	'palettes' => array
 	(
 		'__selector__'                => array('useSMTP'),
-		'default'                     => '{title_legend},websiteTitle;{date_legend},dateFormat,timeFormat,datimFormat,timeZone;{global_legend:hide},adminEmail,characterSet,minifyMarkup,gzipScripts,coreOnlyMode,bypassCache,debugMode,maintenanceMode;{backend_legend:hide},resultsPerPage,maxResultsPerPage,fileSyncExclude,doNotCollapse,staticFiles,staticPlugins;{frontend_legend},urlSuffix,cacheMode,rewriteURL,useAutoItem,addLanguageToUrl,doNotRedirectEmpty,folderUrl,disableAlias;{proxy_legend:hide},proxyServerIps,sslProxyDomain;{privacy_legend:hide},privacyAnonymizeIp,privacyAnonymizeGA;{security_legend},allowedTags,displayErrors,logErrors,disableRefererCheck,disableIpCheck;{files_legend:hide},allowedDownload,validImageTypes,editableFiles,templateFiles,maxImageWidth,jpgQuality,gdMaxImgWidth,gdMaxImgHeight;{uploads_legend:hide},uploadPath,uploadTypes,uploadFields,maxFileSize,imageWidth,imageHeight;{search_legend:hide},enableSearch,indexProtected;{smtp_legend:hide},useSMTP;{modules_legend:hide},inactiveModules;{cron_legend:hide},disableCron;{timeout_legend:hide},undoPeriod,versionPeriod,logPeriod,sessionTimeout,autologin,lockPeriod;{chmod_legend:hide},defaultUser,defaultGroup,defaultChmod;{update_legend:hide},liveUpdateBase'
+		'default'                     => '{title_legend},websiteTitle;{date_legend},dateFormat,timeFormat,datimFormat,timeZone;{global_legend:hide},adminEmail,characterSet,minifyMarkup,gzipScripts,coreOnlyMode,bypassCache,debugMode,maintenanceMode;{backend_legend:hide},resultsPerPage,maxResultsPerPage,fileSyncExclude,doNotCollapse,staticFiles,staticPlugins;{frontend_legend},urlSuffix,cacheMode,rewriteURL,useAutoItem,addLanguageToUrl,doNotRedirectEmpty,folderUrl,disableAlias;{proxy_legend:hide},proxyServerIps,sslProxyDomain,proxyDomain;{privacy_legend:hide},privacyAnonymizeIp,privacyAnonymizeGA;{security_legend},allowedTags,displayErrors,logErrors,disableRefererCheck,disableIpCheck;{files_legend:hide},allowedDownload,validImageTypes,editableFiles,templateFiles,maxImageWidth,jpgQuality,gdMaxImgWidth,gdMaxImgHeight;{uploads_legend:hide},uploadPath,uploadTypes,uploadFields,maxFileSize,imageWidth,imageHeight;{search_legend:hide},enableSearch,indexProtected;{smtp_legend:hide},useSMTP;{modules_legend:hide},inactiveModules;{cron_legend:hide},disableCron;{timeout_legend:hide},undoPeriod,versionPeriod,logPeriod,sessionTimeout,autologin,lockPeriod;{chmod_legend:hide},defaultUser,defaultGroup,defaultChmod;{update_legend:hide},liveUpdateBase'
 	),
 
 	// Subpalettes
@@ -213,6 +213,18 @@ $GLOBALS['TL_DCA']['tl_settings'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_settings']['sslProxyDomain'],
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'url', 'tl_class'=>'w50')
+		),
+		'proxyDomain' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_settings']['proxyDomain'],
+			'inputType'               => 'text',
+			'eval'                    => array('rgxp'=>'url', 'tl_class'=>'w50')
+		),
+		'proxySSL' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_settings']['proxySSL'],
+			'inputType'               => 'checkbox',
+			'eval'                    => array('tl_class'=>'m12 w50')
 		),
 		'cacheMode' => array
 		(

--- a/system/modules/core/languages/en/tl_settings.xlf
+++ b/system/modules/core/languages/en/tl_settings.xlf
@@ -116,6 +116,18 @@
       <trans-unit id="tl_settings.sslProxyDomain.1">
         <source>If your website is available via an SSL proxy server, please enter its domain here (e.g. &lt;em&gt;sslsites.de&lt;/em&gt;).</source>
       </trans-unit>
+      <trans-unit id="tl_settings.proxyDomain.0">
+        <source>Generic proxy domain</source>
+      </trans-unit>
+      <trans-unit id="tl_settings.proxyDomain.1">
+        <source>If your website is available via a generic proxy server, please enter its domain here (e.g. &lt;em&gt;sites.de&lt;/em&gt;).</source>
+      </trans-unit>
+      <trans-unit id="tl_settings.proxySSL.0">
+        <source>Proxy domain use SSL</source>
+      </trans-unit>
+      <trans-unit id="tl_settings.proxySSL.1">
+        <source>If your proxy domain use SSL, but your delivering server not, check this option.</source>
+      </trans-unit>
       <trans-unit id="tl_settings.privacyAnonymizeIp.0">
         <source>Anonymize IP addresses</source>
       </trans-unit>

--- a/system/modules/core/library/Contao/Environment.php
+++ b/system/modules/core/library/Contao/Environment.php
@@ -310,10 +310,19 @@ class Environment
 		$host = static::get('httpHost');
 		$xhost = static::get('httpXForwardedHost');
 
-		// SSL proxy
-		if ($xhost != '' && $xhost == $GLOBALS['TL_CONFIG']['sslProxyDomain'])
+		if ($xhost != '')
 		{
-			return 'https://' .  $xhost . '/' . $host;
+			// SSL proxy
+			if ($xhost == $GLOBALS['TL_CONFIG']['sslProxyDomain'])
+			{
+				return 'https://' .  $xhost . '/' . $host;
+			}
+
+			// Regular proxy (e.g. load balancing proxy)
+			else if ($xhost != '' && $xhost == $GLOBALS['TL_CONFIG']['proxyDomain'])
+			{
+				return ($GLOBALS['TL_CONFIG']['proxySSL'] ? 'https://' : 'http://') . $xhost;
+			}
 		}
 
 		return (static::get('ssl') ? 'https://' : 'http://') . $host;


### PR DESCRIPTION
- [x] Respect the `X-Forwarded-Host` header
- [ ] Allow multiple proxy domains
- [ ] Use a domain mapping table for `X-Forwarded-Host`

Ich experimentiere gerade im Rahmen einer Kundenaquise mit Contao und seiner "load balancing" Fähigkeit rum. Sowohl mit Varnish, nginx als auch Apache. Dabei stoße ich an ein paar Probleme. Vorwiegend entstehen die Probleme beim load balancer, denn die Nodes haben dort NICHT den gleichen Hostname, wie der Proxy.

Das sieht dann so aus:

```
WWW
 |
 \- contao.example.com (Varnish)
     |
     \- contao.example.com (load balancing via nginx oder Apache)
        |
        |- node1.contao.example.com (Apache) --- MariaDB Cluster Node 1 -\
        |                                                                 |
        \- node2.contao.example.com (Apache) --- MariaDB Cluster Node 2 -/
```

Ich könnte theoretisch bei den Nodes die Hauptdomain als Alias eintragen und dem Apache beibringen, aber normalerweise macht man das so nicht. Außerdem wird es dann schwierig die einzelnen Nodes zu testen.

Via `initconfig.php` experimentiere ich gerade ein wenig rum, bspw. so:

``` php
if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
    if (isset($_SERVER['HTTP_HOST']) && substr($_SERVER['HTTP_HOST'], 0, 4) == 'node') {
        $_SERVER['HTTP_HOST'] = preg_replace('~^node\d+~\.', '', $_SERVER['HTTP_HOST']);
    }
    if (isset($_SERVER['SERVER_NAME']) && substr($_SERVER['SERVER_NAME'], 0, 4) == 'node') {
        $_SERVER['SERVER_NAME'] = preg_replace('~^node\d+~\.', '', $_SERVER['SERVER_NAME']);
    }
}
```

Allerdings geht das ganze im Multidomain Betrieb wieder nicht bzw. wenn ich einen DNS in der Rootpage eintrage, also forziere ich einen HTTP_HOST:

``` php
if (isset($_SERVER['HTTP_HOST']) && substr($_SERVER['HTTP_HOST'], 0, 4) == 'node') {
    if (!isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
        $_SERVER['HTTP_X_FORWARDED_HOST'] = $_SERVER['HTTP_HOST'];
    }

    $_SERVER['HTTP_HOST'] = preg_replace('~^node\d+~\.', '', $_SERVER['HTTP_HOST']);
}
if (isset($_SERVER['SERVER_NAME']) && substr($_SERVER['SERVER_NAME'], 0, 4) == 'node') {
    if (!isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
        $_SERVER['HTTP_X_FORWARDED_HOST'] = $_SERVER['SERVER_NAME'];
    }

    $_SERVER['SERVER_NAME'] = preg_replace('~^node\d+~\.', '', $_SERVER['SERVER_NAME']);
}
```

Sieht etwas merkwürdig aus, aber damit kann ich erreichen, dass ich jeden Node auch unter `nodeX.contao.example.com` erreichen kann. Das ganze funktioniert allerdings nur mit diesem Patch, weil mir Contao sonst die falsche FE URL generiert. Jetzt behandelt Contao den `X-Forwarded-Host` Header imo korrekt, während er vorher gar nicht für non-ssl-proxy-Aufrufe berücksichtigt wurde.

So lassen sich auch mehrere Domains im Cluster in einer Installation verwalten, so lange die Node-Domains mit `nodeX.` anfangen.

---

Was dem ganzen noch zu gute kommt, ich habe noch einen Staging Node der mit syncCto mit node1 und node2 Synchronisiert wird. Dabei ist mir aufgefallen, dass man diese Funktion auch wunderbar für syncCto ausnutzen könnte, um Multi-Domain Systeme unter einer staging Installation zu unterstützen, aktuell verwende ich dafür in meiner `initconfig.php` (das ist natürlich ein bad practice Beispiel, aber rein zum experimentieren ausreichend):

``` php
if (isset($_SERVER['HTTP_HOST']) && substr($_SERVER['HTTP_HOST'], 0, 5) == 'stage') {
    $GLOBALS['TL_CONFIG']['proxyDomain'] = $_SERVER['HTTP_X_FORWARDED_HOST'] = $_SERVER['HTTP_HOST'];
    $_SERVER['HTTP_HOST']                = preg_replace('~^stage[\.-]~', '', $_SERVER['HTTP_HOST']);
}
else if (isset($_SERVER['SERVER_NAME']) && substr($_SERVER['SERVER_NAME'], 0, 5) == 'stage') {
    $GLOBALS['TL_CONFIG']['proxyDomain'] = $_SERVER['HTTP_X_FORWARDED_HOST'] = $_SERVER['SERVER_NAME'];
    $_SERVER['SERVER_NAME']              = preg_replace('~^stage[\.-]~', '', $_SERVER['SERVER_NAME']);
}
```

Mein Staging Node läuft als `stage.contao.example.com`, rufe ich die Domain auf, läuft Contao jetzt als HTTP_HOST `contao.example.com` und nutzt als `X-Forwarded-Host` die `stage.contao.example.com`. Ich kann also ohne Probleme auf der Staging Installation arbeiten, auch wenn ich `contao.example.com` als Domain in die Rootpage eingetragen habe :-)

Falls hier Interesse besteht das Feature weiter zu verfolgen, wäre eine Domain-Mapping-Tabelle die man in den Systemeinstellungen pflegen kann sicherlich hilfreicher, als dass alles in der `initconfig.php` von Hand machen zu müssen. Sollte der Patch auf Interesse stoßen, liefere ich da gerne noch was.
