### PR TITLE
Update `robots.txt`

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -5,6 +5,9 @@ Disallow: /system/
 Disallow: /templates/
 Disallow: /vendor/
 Disallow: /share/index.php
+Disallow: /build.xml
+Disallow: /composer.json
+Disallow: /composer.lock
 Disallow: /contao-check.php
 Disallow: /flash.php
 Disallow: /README.md


### PR DESCRIPTION
In the upcoming next minor version we'll deliver a few new build and configuration files (which are directly accessible via HTTP).

In order to prevent those files from being crawled by search engines, it might be a good idea to add the following entries to our `robots.txt` file:

```
Disallow: /build.xml
Disallow: /composer.json
Disallow: /composer.lock
```
