### PR TITLE
Strip disallowed tags from the markdown content element

### DIFF
--- a/system/modules/core/elements/ContentMarkdown.php
+++ b/system/modules/core/elements/ContentMarkdown.php
@@ -63,5 +63,6 @@ class ContentMarkdown extends \ContentElement
 	protected function compile()
 	{
 		$this->Template->content = \Michelf\MarkdownExtra::defaultTransform($this->code);
+		$this->Template->content = \Input::stripTags($this->Template->content, \Config::get('allowedTags'));
 	}
 }


### PR DESCRIPTION
Since HTML is allowed in Markdown, disallowed tags should be stripped. Currently no tags are stripped from a markdown content element.

To reproduce create a markdown content element with the following content (release/3.3.0 branch):

``` Markdown
* Shouldn't be removed: `<noframes>`
* Should be removed: <noframes>
```
