### PR TITLE
Rich text editor file in own module folder

### DIFF
--- a/system/modules/core/classes/BackendTemplate.php
+++ b/system/modules/core/classes/BackendTemplate.php
@@ -83,7 +83,12 @@ class BackendTemplate extends \Template
 					$file = 'ace';
 				}
 
-				$strFile = sprintf('%s/system/config/%s.php', TL_ROOT, $file);
+				if(strpos($file, 'tinyPath::')  !== false ) {
+					$file_path = explode('::', $file);
+					$strFile = TL_ROOT . $file_path[1];
+				} else {
+					$strFile = sprintf('%s/system/config/%s.php', TL_ROOT, $file);
+				}
 
 				if (!file_exists($strFile))
 				{


### PR DESCRIPTION
Please make it possible to place rte setting file in your own module folder instead of confined to /system/config folder.
Usage: 

``` php
 'eval' => array('rte'=>'tinyPath::/system/modules/myModule/assets/myRTE.php', 
```

I choose "tinyPath::" because inside class DataContainer.php your are looking for the occurrence of word 'tiny' in first 4 characters.

``` php
//line 445
if (isset($arrData['eval']['rte']) && strncmp($arrData['eval']['rte'], 'tiny', 4) === 0)
```
