### PR TITLE
DCA Sorting Filter für options_callback

### DIFF
--- a/system/modules/core/dca/tl_page.php
+++ b/system/modules/core/dca/tl_page.php
@@ -1240,7 +1240,14 @@ class tl_page extends Backend
 	 */
 	public function getPageLayouts()
 	{
-		$objLayout = $this->Database->execute("SELECT l.id, l.name, t.name AS theme FROM tl_layout l LEFT JOIN tl_theme t ON l.pid=t.id ORDER BY t.name, l.name");
+		$this->loadDataContainer('tl_layout');
+		$arrFields = $arrValues = array();
+		foreach($GLOBALS['TL_DCA']['tl_layout']['list']['sorting']['filter'] as $filter) {
+			$arrFields[] = 'l.'.$filter[0];
+			$arrValues[] = $filter[1];
+		}
+
+		$objLayout = $this->Database->prepare("SELECT l.id, l.name, l.swUserId, t.name AS theme FROM tl_layout l LEFT JOIN tl_theme t ON l.pid=t.id".($arrFields ? ' WHERE '.implode('AND',$arrFields) : '')." ORDER BY t.name, l.name")->execute($arrValues);
 
 		if ($objLayout->numRows < 1)
 		{


### PR DESCRIPTION
Ho! :)

in der DCA sind ja Filter für die Listenansicht möglich. Damit kann ich Beispielsweise mit etwas Code den Usern auch nur die Einträge anzeigen lassen, die sie selbst angelegt haben. Allerdings können die User die Einträge dann über die options_callback trotzdem sehen. 

Daher habe ich in dieser Methode den Filter aus tl_layout hinzugefügt, damit die Filter auch hier greifen. Ggf. kann ja hier eine Hilfsfunktion in system/helper/functions.php hinterlegt werden, um einen dca_filter($table, $prefix) oder etwas in der Art - für andere Callbacks.

Grüße
Sio
