### PR TITLE
Path with 36 characters is not a string uuid

### DIFF
--- a/system/modules/core/library/Contao/Validator.php
+++ b/system/modules/core/library/Contao/Validator.php
@@ -273,10 +273,46 @@ class Validator
 	{
 		if (strlen($varValue) == 16)
 		{
+			return static::isBinaryUuid($varValue);
+		}
+
+		return static::isStringUuid($varValue);
+	}
+
+
+	/**
+	 * Validate binary UUID (version 1)
+	 *
+	 * @param mixed $varValue The value to be validated
+	 *
+	 * @return boolean True if the value is a binary UUID
+	 */
+	public static function isBinaryUuid($varValue)
+	{
+		if (strlen($varValue) == 16)
+		{
 			return ($varValue & hex2bin('000000000000F000C000000000000000')) === hex2bin('00000000000010008000000000000000');
 		}
 
-		return preg_match('/^[a-f0-9]{8}\-[a-f0-9]{4}\-1[a-f0-9]{3}\-[89ab][a-f0-9]{3}\-[a-f0-9]{12}$/', $varValue);
+		return false;
+	}
+
+
+	/**
+	 * Validate string UUID (version 1)
+	 *
+	 * @param mixed $varValue The value to be validated
+	 *
+	 * @return boolean True if the value is a string UUID
+	 */
+	public static function isStringUuid($varValue)
+	{
+		if (strlen($varValue) == 36)
+		{
+			return preg_match('/^[a-f0-9]{8}\-[a-f0-9]{4}\-1[a-f0-9]{3}\-[89ab][a-f0-9]{3}\-[a-f0-9]{12}$/', $varValue);
+		}
+
+		return false;
 	}
 
 

--- a/system/modules/core/models/FilesModel.php
+++ b/system/modules/core/models/FilesModel.php
@@ -141,7 +141,7 @@ class FilesModel extends \Model
 		foreach ($arrUuids as $k=>$v)
 		{
 			// Convert UUIDs to binary
-			if (strlen($v) == 36)
+			if (\Validator::isStringUuid($v))
 			{
 				$v = \String::uuidToBin($v);
 			}


### PR DESCRIPTION
Not only filenames with 36 characters are treated as string uuids, also paths like `assets/.............../js/vanilla.js` (sry for obfuscation ...).

![uuid](https://cloud.githubusercontent.com/assets/343404/3101878/6098f68e-e63d-11e3-8608-17d06a303aed.png)

Inside the `FilesModel` there was only a simple `strlen` check, now it also check the value so the false-positive should be greatly reduced :-)
