### PR TITLE
Check explicitly for RTE value

### DIFF
--- a/system/modules/core/classes/DataContainer.php
+++ b/system/modules/core/classes/DataContainer.php
@@ -453,7 +453,7 @@ class DataContainer extends \Backend
 		$updateMode = '';
 
 		// Replace the textarea with an RTE instance
-		if (isset($arrData['eval']['rte']))
+		if (isset($arrData['eval']['rte']) && $arrData['eval']['rte'] != '')
 		{
 			list ($file, $type) = explode('|', $arrData['eval']['rte'], 2);
 


### PR DESCRIPTION
Otherwise when `$arrData['eval']['rte']` is empty it throws error. For example in isotope module  as pointed here https://github.com/isotope/core/issues/1123

Edit:
Also related here
https://github.com/isotope/core/commit/1c64fa6ad30f772166913ed954542b34066b1bb4
