### PR TITLE
Disable DROP statements in safe mode

### DIFF
--- a/system/modules/core/library/Contao/Database/Installer.php
+++ b/system/modules/core/library/Contao/Database/Installer.php
@@ -254,6 +254,13 @@ class Installer extends \Controller
 			}
 		}
 
+		// Remove all DROP statements if the safe mode is active
+		if (\Config::get('coreOnlyMode'))
+		{
+			unset($return['DROP']);
+			unset($return['ALTER_DROP']);
+		}
+
 		return $return;
 	}
 


### PR DESCRIPTION
Many users accidentally drop all tables and columns of third party extensions during an update because the safe mode (coreOnlyMode) is active. Disabling all DROP statements in safe mode would fix this issue.

In the community forum I found three threads about that problem from this week:
- https://community.contao.org/de/showthread.php?50636
- https://community.contao.org/de/showthread.php?50709
- https://community.contao.org/de/showthread.php?50714
