### PR TITLE
Use php 5.6's upcoming hash_equals() function if available

### DIFF
--- a/system/modules/core/controllers/BackendInstall.php
+++ b/system/modules/core/controllers/BackendInstall.php
@@ -340,7 +340,7 @@ class BackendInstall extends \Backend
 		// The password has been generated with crypt()
 		if (\Encryption::test(\Config::get('installPassword')))
 		{
-			if (crypt(\Input::postRaw('password'), \Config::get('installPassword')) == \Config::get('installPassword'))
+			if (\Encryption::verify(\Input::postRaw('password'), \Config::get('installPassword')))
 			{
 				$this->setAuthCookie();
 				\Config::persist('installCount', 0);

--- a/system/modules/core/controllers/BackendPassword.php
+++ b/system/modules/core/controllers/BackendPassword.php
@@ -80,7 +80,7 @@ class BackendPassword extends \Backend
 			else
 			{
 				// Make sure the password has been changed
-				if (crypt($pw, $this->User->password) == $this->User->password)
+				if (\Encryption::verify($pw, $this->User->password))
 				{
 					\Message::addError($GLOBALS['TL_LANG']['MSC']['pw_change']);
 				}

--- a/system/modules/core/library/Contao/Encryption.php
+++ b/system/modules/core/library/Contao/Encryption.php
@@ -199,6 +199,25 @@ class Encryption
 
 
 	/**
+	 * Verifies a given password against a hash
+	 *
+	 * @param string $strPassword The plaintext password
+	 * @param string $strHash The hash to check against
+	 *
+	 * @return boolean True if the input matches the hash
+	 */
+	public static function verify($strPassword, $strHash)
+	{
+		// Use core function to prevent timing attacks if possible
+		if (function_exists('hash_equals')) {
+			return hash_equals(crypt($strPassword, $strHash), $strHash);
+		}
+
+		return crypt($strPassword, $strHash) === $strHash;
+	}
+
+
+	/**
 	 * Test whether a password hash has been generated with crypt()
 	 *
 	 * @param string $strHash The password hash

--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -303,7 +303,7 @@ abstract class User extends \System
 		// The password has been generated with crypt()
 		if (\Encryption::test($this->password))
 		{
-			$blnAuthenticated = (crypt(\Input::postRaw('password'), $this->password) == $this->password);
+			$blnAuthenticated = \Encryption::verify(\Input::postRaw('password'), $this->password);
 		}
 		else
 		{

--- a/system/modules/core/modules/ModuleCloseAccount.php
+++ b/system/modules/core/modules/ModuleCloseAccount.php
@@ -94,7 +94,7 @@ class ModuleCloseAccount extends \Module
 				// The password has been generated with crypt()
 				if (\Encryption::test($this->User->password))
 				{
-					$blnAuthenticated = (crypt($objWidget->value, $this->User->password) == $this->User->password);
+					$blnAuthenticated = \Encryption::verify($objWidget->value, $this->User->password);
 				}
 				else
 				{


### PR DESCRIPTION
PHP 5.6 will ship with a new function called `hash_equals()` for timing attack safe string comparison. This pull request uses it if available and otherwise falls back to the current behavior.

I know it does not belong to `Encryption` because it's about hashing, not about encryption. But we already have all the other methods there so I stuck to that pattern.

More on `hash_equals()` and PHP 5.6: http://www.php.net/manual/en/migration56.new-features.php

PS: Just to make it clear. I still think https://github.com/contao/core/pull/5853 is the better way to go.
