### PR TITLE
Add class to table lement

### DIFF
--- a/system/modules/core/templates/elements/ce_table.html5
+++ b/system/modules/core/templates/elements/ce_table.html5
@@ -2,7 +2,7 @@
 
 <?php $this->block('content'); ?>
 
-  <table id="<?php echo $this->id; ?>"<?php if ($this->sortable): ?> class="sortable"<?php endif; ?>>
+  <table id="<?php echo $this->id; ?>" class="<?php echo $this->class; ?><?php if ($this->sortable): ?> sortable<?php endif; ?>">
 
     <?php if ($this->summary != ''): ?>
       <caption><?php echo $this->summary; ?></caption>


### PR DESCRIPTION
Commit 3c86df84f9650bb15db9de680d77ce1b58cf676a has broken the css class alignment to table elements. Instead of dropping it, it should be set to the table element
