### PR TITLE
Added universal polyfills for developers

### DIFF
--- a/system/modules/core/config/config.php
+++ b/system/modules/core/config/config.php
@@ -464,6 +464,10 @@ $GLOBALS['TL_ASSETS'] = array
 	'SLIMBOX'      => '1.8'
 );
 
+/**
+ * JavaScript Polyfills
+ */
+$GLOBALS['TL_JS_POLYFILLS'] = array();
 
 /**
  * Other global arrays

--- a/system/modules/core/dca/tl_layout.php
+++ b/system/modules/core/dca/tl_layout.php
@@ -99,7 +99,7 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 	'palettes' => array
 	(
 		'__selector__'                => array('rows', 'cols', 'addJQuery', 'addMooTools', 'static'),
-		'default'                     => '{title_legend},name;{header_legend},rows;{column_legend},cols;{sections_legend:hide},sections,sPosition;{webfonts_legend:hide},webfonts;{style_legend},framework,stylesheet,external;{feed_legend:hide},newsfeeds,calendarfeeds;{modules_legend},modules;{expert_legend:hide},template,doctype,viewport,titleTag,cssClass,onload,head;{jquery_legend},addJQuery;{mootools_legend},addMooTools;{script_legend:hide},analytics,script;{static_legend},static'
+		'default'                     => '{title_legend},name;{header_legend},rows;{column_legend},cols;{sections_legend:hide},sections,sPosition;{webfonts_legend:hide},webfonts;{style_legend},framework,stylesheet,external;{feed_legend:hide},newsfeeds,calendarfeeds;{modules_legend},modules;{expert_legend:hide},template,doctype,viewport,titleTag,cssClass,onload,disablePolyfills,head;{jquery_legend},addJQuery;{mootools_legend},addMooTools;{script_legend:hide},analytics,script;{static_legend},static'
 	),
 
 	// Subpalettes
@@ -358,6 +358,15 @@ $GLOBALS['TL_DCA']['tl_layout'] = array
 			'inputType'               => 'text',
 			'eval'                    => array('decodeEntities'=>true, 'maxlength'=>255, 'tl_class'=>'w50'),
 			'sql'                     => "varchar(255) NOT NULL default ''"
+		),
+		'disablePolyfills' => array
+		(
+			'label'                   => &$GLOBALS['TL_LANG']['tl_layout']['disablePolyfills'],
+			'exclude'                 => true,
+			'filter'                  => true,
+			'inputType'               => 'checkbox',
+			'eval'                    => array('tl_class'=>'m12 clr'),
+			'sql'                     => "char(1) NOT NULL default ''"
 		),
 		'head' => array
 		(

--- a/system/modules/core/languages/en/tl_layout.xlf
+++ b/system/modules/core/languages/en/tl_layout.xlf
@@ -230,6 +230,12 @@
       <trans-unit id="tl_layout.onload.1">
         <source>Here you can add a body &lt;em&gt;onload&lt;/em&gt; attribute.</source>
       </trans-unit>
+      <trans-unit id="tl_layout.disablePolyfills.0">
+        <source>Disable loading JavaScript Polyfills</source>
+      </trans-unit>
+      <trans-unit id="tl_layout.disablePolyfills.1">
+        <source>Here you can disable loading JavaScript Polyfills for the page. Note that this might affect the proper functioning of included JavaScripts.</source>
+      </trans-unit>
       <trans-unit id="tl_layout.head.0">
         <source>Additional &amp;lt;head&amp;gt; tags</source>
       </trans-unit>


### PR DESCRIPTION
We currently have the possibility to develop our JavaScripts either using jQuery or MooTools. Very often I prefer to use none of those libraries and rely on pure (Vanilla) JS only and I think I'm not the only developer doing so :-)

The problem I always have - and this is especially true when I'm developing extensions that can be used anywhere rather than just for a single customer project - are polyfills. Polyfills are great because they ensure you can write normal JavaScript for newer browsers and the polyfill will take care for older ones so my code just works fine everywhere.

However, we have the problem that everybody ships their own polyfills. Extension A ships the same polyfill as extension B and C because they all need it and don't know of each other. Of course this creates a useless overhead of data.
What makes it even worse is that a lot of those polyfills are loaded even if they are not needed at all because the browser already supports the needed feature.

So I wanted to create a universal solution and searched the internet for something that lazy loads polyfills. And I eventually found https://github.com/kbjr/polyfill.js :-)

Polyfill.js dynamically loads required polyfills only when they're needed and as soon as they're ready, executes your code.
I have implemented a very easy solution. Contao will load the core of Polyfill.js only if a developer wants it to do so and any expert can still disable it in the page layout.
## Usage

Let's say you as a developer need the `window.onhashchange` event. Relying on a polyfill is now as easy as that:

**config.php**

``` php
$GLOBALS['TL_JS_POLYFILLS'][] = 'hashchange';
```

**Your template code**

``` html
<script>
window.addEventListener('ContaoPolyfillsLoaded', function() {
    // You can now savely use window.onhashchange in your code
});
</script>
```
## What polyfills can I use?

Anything from that list: https://github.com/kbjr/polyfill.js#available-polyfills
## I need a different polyfill!

Contribute! You can do that easily, see: https://github.com/kbjr/polyfill.js#contributing-a-new-polyfill
And the good thing about it is that Contao does not need to change. As soon as it's merged it will be available via `polyfill.herokuapp.com` :)
