### PR TITLE
Use `===` to compare password hashes

### DIFF
--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -303,12 +303,12 @@ abstract class User extends \System
 		// The password has been generated with crypt()
 		if (\Encryption::test($this->password))
 		{
-			$blnAuthenticated = (crypt(\Input::postRaw('password'), $this->password) == $this->password);
+			$blnAuthenticated = (crypt(\Input::postRaw('password'), $this->password) === $this->password);
 		}
 		else
 		{
 			list($strPassword, $strSalt) = explode(':', $this->password);
-			$blnAuthenticated = ($strSalt == '') ? ($strPassword == sha1(\Input::postRaw('password'))) : ($strPassword == sha1($strSalt . \Input::postRaw('password')));
+			$blnAuthenticated = ($strSalt == '') ? ($strPassword === sha1(\Input::postRaw('password'))) : ($strPassword === sha1($strSalt . \Input::postRaw('password')));
 
 			// Store a SHA-512 encrpyted version of the password
 			if ($blnAuthenticated)


### PR DESCRIPTION
Hash strings should be compared with `===` because PHP compares two numerical strings as numbers.

`"5938266572196464632409940308852871296620" == "5938266572196464000000000000000000000000"` evaluates to `true` before PHP 5.4.4. Details: http://www.phpsadness.com/sad/47.
