### PR TITLE
Add unique index for username and email to tl_member

### DIFF
--- a/system/modules/core/dca/tl_member.php
+++ b/system/modules/core/dca/tl_member.php
@@ -36,8 +36,8 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			'keys' => array
 			(
 				'id' => 'primary',
-				'username' => 'index',
-				'email' => 'index',
+				'username' => 'unique',
+				'email' => 'unique',
 				'autologin' => 'unique',
 				'activation' => 'index'
 			)
@@ -267,7 +267,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			'search'                  => true,
 			'inputType'               => 'text',
 			'eval'                    => array('mandatory'=>true, 'maxlength'=>255, 'rgxp'=>'email', 'unique'=>true, 'decodeEntities'=>true, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'contact', 'tl_class'=>'w50'),
-			'sql'                     => "varchar(255) NOT NULL default ''"
+			'sql'                     => "varchar(255) NULL"
 		),
 		'website' => array
 		(
@@ -317,7 +317,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			'flag'                    => 1,
 			'inputType'               => 'text',
 			'eval'                    => array('mandatory'=>true, 'unique'=>true, 'rgxp'=>'extnd', 'nospace'=>true, 'maxlength'=>64, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'login'),
-			'sql'                     => "varchar(64) COLLATE utf8_bin NOT NULL default ''"
+			'sql'                     => "varchar(64) COLLATE utf8_bin NULL"
 		),
 		'password' => array
 		(


### PR DESCRIPTION
It is currently possible to register with an already existing username and/or email if you add a 4-byte UTF-8 character to the end of the username/email.

![contao-register](https://cloud.githubusercontent.com/assets/367169/3615431/9572c080-0dc8-11e4-838f-ac5dbb917900.png)

Adding an unique index to the username and email columns would fix this issue. But I don't know if changing the columns to allow NULL values has backwards compatibility issues.
