### PR TITLE
- wrapped text content in an extra "content"-div

### DIFF
--- a/system/modules/core/templates/elements/ce_text.html5
+++ b/system/modules/core/templates/elements/ce_text.html5
@@ -3,7 +3,9 @@
 <?php $this->block('content'); ?>
 
   <?php if (!$this->addBefore): ?>
-    <?php echo $this->text; ?>
+    <div class="content">
+      <?php echo $this->text; ?>
+    </div>
   <?php endif; ?>
 
   <?php if ($this->addImage): ?>
@@ -27,7 +29,9 @@
   <?php endif; ?>
 
   <?php if ($this->addBefore): ?>
-    <?php echo $this->text; ?>
+    <div class="content">
+      <?php echo $this->text; ?>
+    </div>
   <?php endif; ?>
 
 <?php $this->endblock(); ?>

--- a/system/modules/core/templates/elements/ce_text.xhtml
+++ b/system/modules/core/templates/elements/ce_text.xhtml
@@ -3,7 +3,9 @@
 <?php $this->block('content'); ?>
 
   <?php if (!$this->addBefore): ?>
-    <?php echo $this->text; ?>
+    <div class="content">
+      <?php echo $this->text; ?>
+    </div>
   <?php endif; ?>
 
   <?php if ($this->addImage): ?>
@@ -27,7 +29,9 @@
   <?php endif; ?>
 
   <?php if ($this->addBefore): ?>
-    <?php echo $this->text; ?>
+    <div class="content">
+      <?php echo $this->text; ?>
+    </div>
   <?php endif; ?>
 
 <?php $this->endblock(); ?>


### PR DESCRIPTION
- wrapped text content in an extra "content"-div to give more flexibility in your styling
- apply an "overflow: hidden" to the new "content"-div to avoid the text to flow around the image
  ![contao-text-content](https://cloud.githubusercontent.com/assets/5244986/3711855/55d05874-14ef-11e4-8815-d022060b51d3.jpg)
