### PR TITLE
Strip html entities from linkTitle

### DIFF
--- a/system/modules/core/elements/ContentHyperlink.php
+++ b/system/modules/core/elements/ContentHyperlink.php
@@ -119,7 +119,7 @@ class ContentHyperlink extends \ContentElement
 		$this->Template->embed_pre = $embed[0];
 		$this->Template->embed_post = $embed[1];
 		$this->Template->link = $this->linkTitle;
-		$this->Template->linkTitle = specialchars($this->titleText ?: $this->linkTitle);
+		$this->Template->linkTitle = specialchars($this->titleText ?: $this->linkTitle, true);
 		$this->Template->target = '';
 
 		// Override the link target


### PR DESCRIPTION
Strip html entities from linkTitle `<a title=""></a>` attribute. When using custom inserttags, that return html entities, the markup will become invalid, because html entities will be rendered inside the attribute value `<a title="<i class="fa fa-pencil"></i> Submit">Submit</a>`
