### PR TITLE
Add col_first and col_last classes for one-column galleries

### DIFF
--- a/system/modules/core/elements/ContentGallery.php
+++ b/system/modules/core/elements/ContentGallery.php
@@ -316,12 +316,12 @@ class ContentGallery extends \ContentElement
 
 				if ($j == 0)
 				{
-					$class_td = ' col_first';
+					$class_td .= ' col_first';
 				}
 
 				if ($j == ($this->perRow - 1))
 				{
-					$class_td = ' col_last';
+					$class_td .= ' col_last';
 				}
 
 				$objCell = new \stdClass();


### PR DESCRIPTION
If you create a gallery with only one thumbnail per row the CSS class `col_first` is missing.

Related Issues: #2803, #5140
