### PR TITLE
Erweiterbarer Alias

### DIFF
--- a/system/modules/core/elements/ContentAlias.php
+++ b/system/modules/core/elements/ContentAlias.php
@@ -52,6 +52,10 @@ class ContentAlias extends \ContentElement
 		$objElement->typePrefix = 'ce_';
 
 		$objElement = new $strClass($objElement);
+		
+		foreach($objElement->arrData as $key => $value)
+			if(!in_array($key, array('type','pid')) && $this->$key)
+				$objElement->$key = $this->$key;
 
 		// Overwrite spacing and CSS ID
 		$objElement->space = $this->space;


### PR DESCRIPTION
Hi,

In Zeile 56 bis 58 habe ich eine Foreach-Schleife eingefügt, die felder des eingebundenen Elementes überschreibt. Binde ich zum Beispiel das Element ce_hypertext ein, könnte ich das Alias-Element in der dcaconfig durch die Felder linkTitle und titleText erweitern. Die Forschleife nimmt dann das Hyperlink-Element und ersetzt den Linktitel und den Linktext durch die Werte die ich im Alias eingetrgen hab.

Dadurch könnte ich öfter auf das selbe Element zugreifen und es Stellenweise bei Bedarf leicht anpassen. Dadurch müsste ich nicht das ganze Element kopieren um nur einen Wert anpassen zu müssen.

Btw Zeile 61 und 62 werden dadurch evt. überflüssig.
