### PR TITLE
more consistent hyperlink element

### DIFF
--- a/system/modules/core/templates/elements/ce_hyperlink.html5
+++ b/system/modules/core/templates/elements/ce_hyperlink.html5
@@ -3,7 +3,9 @@
 <?php $this->block('content'); ?>
 
   <?php echo $this->embed_pre; ?>
-    <a href="<?php echo $this->href; ?>" class="hyperlink_txt" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target; ?>><?php echo $this->link; ?></a>
+    <a href="<?php echo $this->href; ?>" class="hyperlink_txt" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target;
+      ?>><?php echo $this->link;
+    ?></a>
   <?php echo $this->embed_post; ?>
 
 <?php $this->endblock(); ?>

--- a/system/modules/core/templates/elements/ce_hyperlink.html5
+++ b/system/modules/core/templates/elements/ce_hyperlink.html5
@@ -3,9 +3,7 @@
 <?php $this->block('content'); ?>
 
   <?php echo $this->embed_pre; ?>
-    <a href="<?php echo $this->href; ?>" class="hyperlink_txt" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target; ?>>
-      <?php echo $this->link; ?>
-    </a>
+    <a href="<?php echo $this->href; ?>" class="hyperlink_txt" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target; ?>><?php echo $this->link; ?></a>
   <?php echo $this->embed_post; ?>
 
 <?php $this->endblock(); ?>

--- a/system/modules/core/templates/elements/ce_hyperlink.xhtml
+++ b/system/modules/core/templates/elements/ce_hyperlink.xhtml
@@ -3,7 +3,9 @@
 <?php $this->block('content'); ?>
 
   <?php echo $this->embed_pre; ?>
-    <a href="<?php echo $this->href; ?>" class="hyperlink_txt" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target; ?>><?php echo $this->link; ?></a>
+    <a href="<?php echo $this->href; ?>" class="hyperlink_txt" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target;
+      ?>><?php echo $this->link;
+    ?></a>
   <?php echo $this->embed_post; ?>
 
 <?php $this->endblock(); ?>

--- a/system/modules/core/templates/elements/ce_hyperlink.xhtml
+++ b/system/modules/core/templates/elements/ce_hyperlink.xhtml
@@ -3,9 +3,7 @@
 <?php $this->block('content'); ?>
 
   <?php echo $this->embed_pre; ?>
-    <a href="<?php echo $this->href; ?>" class="hyperlink_txt" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target; ?>>
-      <?php echo $this->link; ?>
-    </a>
+    <a href="<?php echo $this->href; ?>" class="hyperlink_txt" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target; ?>><?php echo $this->link; ?></a>
   <?php echo $this->embed_post; ?>
 
 <?php $this->endblock(); ?>

--- a/system/modules/core/templates/elements/ce_hyperlink_image.html5
+++ b/system/modules/core/templates/elements/ce_hyperlink_image.html5
@@ -5,9 +5,9 @@
   <figure class="image_container">
 
     <?php echo $this->embed_pre; ?>
-      <a href="<?php echo $this->href; ?>" class="hyperlink_img" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target; ?>>
-        <img src="<?php echo $this->src; ?>"<?php echo $this->imgSize; ?> alt="<?php echo $this->alt; ?>"<?php if ($this->title): ?> title="<?php echo $this->title; ?>"<?php endif; ?>>
-      </a>
+      <a href="<?php echo $this->href; ?>" class="hyperlink_img" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target;
+      ?>><img src="<?php echo $this->src; ?>"<?php echo $this->imgSize; ?> alt="<?php echo $this->alt; ?>"<?php if ($this->title): ?> title="<?php echo $this->title; ?>"<?php endif;
+      ?>></a>
     <?php echo $this->embed_post; ?>
 
     <?php if ($this->caption): ?>

--- a/system/modules/core/templates/elements/ce_hyperlink_image.html5
+++ b/system/modules/core/templates/elements/ce_hyperlink_image.html5
@@ -6,7 +6,7 @@
 
     <?php echo $this->embed_pre; ?>
       <a href="<?php echo $this->href; ?>" class="hyperlink_img" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target;
-      ?>><img src="<?php echo $this->src; ?>"<?php echo $this->imgSize; ?> alt="<?php echo $this->alt; ?>"<?php if ($this->title): ?> title="<?php echo $this->title; ?>"<?php endif;
+        ?>><img src="<?php echo $this->src; ?>"<?php echo $this->imgSize; ?> alt="<?php echo $this->alt; ?>"<?php if ($this->title): ?> title="<?php echo $this->title; ?>"<?php endif;
       ?>></a>
     <?php echo $this->embed_post; ?>
 

--- a/system/modules/core/templates/elements/ce_hyperlink_image.xhtml
+++ b/system/modules/core/templates/elements/ce_hyperlink_image.xhtml
@@ -5,9 +5,9 @@
   <div class="image_container">
 
     <?php echo $this->embed_pre; ?>
-	  <a href="<?php echo $this->href; ?>" class="hyperlink_img" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target; ?>>
-        <img src="<?php echo $this->src; ?>"<?php echo $this->imgSize; ?> alt="<?php echo $this->alt; ?>"<?php if ($this->title): ?> title="<?php echo $this->title; ?>"<?php endif; ?> />
-      </a>
+	  <a href="<?php echo $this->href; ?>" class="hyperlink_img" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target;
+	  ?>><img src="<?php echo $this->src; ?>"<?php echo $this->imgSize; ?> alt="<?php echo $this->alt; ?>"<?php if ($this->title): ?> title="<?php echo $this->title; ?>"<?php endif;
+	  ?> /></a>
     <?php echo $this->embed_post; ?>
 
     <?php if ($this->caption): ?>

--- a/system/modules/core/templates/elements/ce_hyperlink_image.xhtml
+++ b/system/modules/core/templates/elements/ce_hyperlink_image.xhtml
@@ -6,7 +6,7 @@
 
     <?php echo $this->embed_pre; ?>
 	  <a href="<?php echo $this->href; ?>" class="hyperlink_img" title="<?php echo $this->linkTitle; ?>"<?php echo $this->attribute; ?><?php echo $this->target;
-	  ?>><img src="<?php echo $this->src; ?>"<?php echo $this->imgSize; ?> alt="<?php echo $this->alt; ?>"<?php if ($this->title): ?> title="<?php echo $this->title; ?>"<?php endif;
+	  	?>><img src="<?php echo $this->src; ?>"<?php echo $this->imgSize; ?> alt="<?php echo $this->alt; ?>"<?php if ($this->title): ?> title="<?php echo $this->title; ?>"<?php endif;
 	  ?> /></a>
     <?php echo $this->embed_post; ?>
 


### PR DESCRIPTION
it's more consistent to have the link in one row to prevent problems in styling, because e.g. the back-links in news- or event-reader are in one line (without line break). I think there will be some more, where we have to change.

case study: link with :before element, see attached picture, both links have the same classes
![screenshot 2014-09-06 16 17 05](https://cloud.githubusercontent.com/assets/1232819/4175400/90460150-35d0-11e4-9bfe-c8a9487d90ab.png)
