### PR TITLE
Remove queries to database INFORMATION_SCHEMA

### DIFF
--- a/system/modules/core/library/Contao/Database/Mysql.php
+++ b/system/modules/core/library/Contao/Database/Mysql.php
@@ -139,14 +139,14 @@ class Mysql extends \Database
 	protected function list_fields($strTable)
 	{
 		$arrReturn = array();
-		$objFields = $this->query("SELECT * FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `TABLE_SCHEMA` LIKE '{$this->arrConfig['dbDatabase']}' AND `TABLE_NAME` LIKE '%$strTable'");
+		$objFields = $this->query("SHOW FULL COLUMNS FROM $strTable");
 
 		while ($objFields->next())
 		{
 			$arrTmp = array();
-			$arrChunks = preg_split('/(\([^\)]+\))/', $objFields->COLUMN_TYPE, -1, PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY);
+			$arrChunks = preg_split('/(\([^\)]+\))/', $objFields->Type, -1, PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY);
 
-			$arrTmp['name'] = $objFields->COLUMN_NAME;
+			$arrTmp['name'] = $objFields->Field;
 			$arrTmp['type'] = $arrChunks[0];
 
 			if (!empty($arrChunks[1]))
@@ -176,9 +176,9 @@ class Mysql extends \Database
 				$arrTmp['attributes'] = trim($arrChunks[2]);
 			}
 
-			if ($objFields->COLUMN_KEY != '')
+			if ($objFields->Key != '')
 			{
-				switch ($objFields->COLUMN_KEY)
+				switch ($objFields->Key)
 				{
 					case 'PRI':
 						$arrTmp['index'] = 'PRIMARY';
@@ -199,10 +199,10 @@ class Mysql extends \Database
 			}
 
 			// Do not modify the order!
-			$arrTmp['collation'] = $objFields->COLLATION_NAME;
-			$arrTmp['null'] = ($objFields->IS_NULLABLE == 'YES') ? 'NULL' : 'NOT NULL';
-			$arrTmp['default'] = $objFields->COLUMN_DEFAULT;
-			$arrTmp['extra'] = $objFields->EXTRA;
+			$arrTmp['collation'] = $objFields->Collation;
+			$arrTmp['null'] = ($objFields->Null == 'YES') ? 'NULL' : 'NOT NULL';
+			$arrTmp['default'] = $objFields->Default;
+			$arrTmp['extra'] = $objFields->Extra;
 
 			$arrReturn[] = $arrTmp;
 		}

--- a/system/modules/core/library/Contao/Database/Mysqli.php
+++ b/system/modules/core/library/Contao/Database/Mysqli.php
@@ -122,14 +122,14 @@ class Mysqli extends \Database
 	protected function list_fields($strTable)
 	{
 		$arrReturn = array();
-		$objFields = $this->query("SELECT * FROM `INFORMATION_SCHEMA`.`COLUMNS` WHERE `TABLE_SCHEMA` LIKE '{$this->arrConfig['dbDatabase']}' AND `TABLE_NAME` LIKE '%$strTable'");
+		$objFields = $this->query("SHOW FULL COLUMNS FROM $strTable");
 
 		while ($objFields->next())
 		{
 			$arrTmp = array();
-			$arrChunks = preg_split('/(\([^\)]+\))/', $objFields->COLUMN_TYPE, -1, PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY);
+			$arrChunks = preg_split('/(\([^\)]+\))/', $objFields->Type, -1, PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY);
 
-			$arrTmp['name'] = $objFields->COLUMN_NAME;
+			$arrTmp['name'] = $objFields->Field;
 			$arrTmp['type'] = $arrChunks[0];
 
 			if (!empty($arrChunks[1]))
@@ -144,6 +144,7 @@ class Mysqli extends \Database
 				else
 				{
 					$arrSubChunks = explode(',', $arrChunks[1]);
+
 					$arrTmp['length'] = trim($arrSubChunks[0]);
 
 					if (!empty($arrSubChunks[1]))
@@ -158,9 +159,9 @@ class Mysqli extends \Database
 				$arrTmp['attributes'] = trim($arrChunks[2]);
 			}
 
-			if ($objFields->COLUMN_KEY != '')
+			if ($objFields->Key != '')
 			{
-				switch ($objFields->COLUMN_KEY)
+				switch ($objFields->Key)
 				{
 					case 'PRI':
 						$arrTmp['index'] = 'PRIMARY';
@@ -181,10 +182,10 @@ class Mysqli extends \Database
 			}
 
 			// Do not modify the order!
-			$arrTmp['collation'] = $objFields->COLLATION_NAME;
-			$arrTmp['null'] = ($objFields->IS_NULLABLE == 'YES') ? 'NULL' : 'NOT NULL';
-			$arrTmp['default'] = $objFields->COLUMN_DEFAULT;
-			$arrTmp['extra'] = $objFields->EXTRA;
+			$arrTmp['collation'] = $objFields->Collation;
+			$arrTmp['null'] = ($objFields->Null == 'YES') ? 'NULL' : 'NOT NULL';
+			$arrTmp['default'] = $objFields->Default;
+			$arrTmp['extra'] = $objFields->Extra;
 
 			$arrReturn[] = $arrTmp;
 		}
@@ -201,7 +202,6 @@ class Mysqli extends \Database
 
 		return $arrReturn;
 	}
-
 
 	/**
 	 * Change the current database


### PR DESCRIPTION
Some shared web hosting like OVH in France disable the access to
database INFORMATION_SCHEMA. What do you think about these mods ?

Some posts with this issue :
https://community.contao.org/en/showthread.php?22355-Contao-3-2-3-installation-on-hostgator&highlight=information_schema

https://community.contao.org/en/showthread.php?22320-Can-t-install-3-2-2&highlight=information_schema
