### PR TITLE
Add a class to the body

### DIFF
--- a/system/modules/core/forms/Form.php
+++ b/system/modules/core/forms/Form.php
@@ -190,6 +190,13 @@ class Form extends \Hybrid
 
 					if ($objWidget->hasErrors())
 					{
+						// Add class 
+                        			global $objPage;
+                        			if(strpos($objPage->cssClass,'error') === false)
+                        			{
+                            				$objPage->cssClass = trim($objPage->cssClass . ' error');
+                        			}
+						
 						$doNotSubmit = true;
 					}
 


### PR DESCRIPTION
Fügt dem body eine Klasse `error` hinzu falls das Formular nicht valide ist.

Damit kann zum Beispiel die Formular-Überschrift im Fehlerfall eingefärbt werden, das Formular hervorgehoben werden, etc. In meinem Fall muss ich das Akkordeon-Element, indem sich das Formular befindet, offen halten.
