### PR TITLE
Always cache fallback language

### DIFF
--- a/system/modules/core/library/Contao/Automator.php
+++ b/system/modules/core/library/Contao/Automator.php
@@ -611,7 +611,7 @@ class Automator extends \System
 	 */
 	public function generateLanguageCache()
 	{
-		$arrLanguages = array();
+		$arrLanguages = array('en');
 		$objLanguages = \Database::getInstance()->query("SELECT language FROM tl_member UNION SELECT language FROM tl_user UNION SELECT REPLACE(language, '-', '_') FROM tl_page WHERE type='root'");
 
 		// Only cache the languages which are in use (see #6013)


### PR DESCRIPTION
When you don't have any user, member or page with language `en` configured, English will never be cached and thus the `System::convertXlfToPhp()` method will always be called (as `en` is fallback) and convert XML to PHP for every single page view. Yet another 3% performance gain ;-)
