### PR TITLE
Fix #7280, ER2 client not working on PHP 5.6+

### DIFF
--- a/system/modules/repository/classes/RepositoryBackendModule.php
+++ b/system/modules/repository/classes/RepositoryBackendModule.php
@@ -219,6 +219,11 @@ class RepositoryBackendModule extends BackendModule
 			case 'local':
 				return $this->RepositoryServer->getExtensionList((object)$aOptions);
 			case 'soap':
+				// PHP 5.6 now have cookie support for SOAP, but using cookies in the request end up with a
+				// "bad request" response, so we unset them before sending it. (see #7280)
+				if (isset($this->client->_cookies)) {
+					unset($this->client->_cookies);
+				}
 				return $this->client->getExtensionList($aOptions);
 			default:
 				return array();

--- a/system/modules/repository/classes/RepositoryCatalog.php
+++ b/system/modules/repository/classes/RepositoryCatalog.php
@@ -226,6 +226,11 @@ class RepositoryCatalog extends RepositoryBackendModule
 			case 'local':
 				return $this->RepositoryServer->getAuthorList((object)$aOptions);
 			case 'soap':
+				// PHP 5.6 now have cookie support for SOAP, but using cookies in the request end up with a
+				// "bad request" response, so we unset them before sending it. (see #7280)
+				if (isset($this->client->_cookies)) {
+					unset($this->client->_cookies);
+				}
 				return $this->client->getAuthorList($aOptions);
 			default:
 				return array();
@@ -238,6 +243,11 @@ class RepositoryCatalog extends RepositoryBackendModule
 			case 'local':
 				return $this->RepositoryServer->getTagList((object)$aOptions);
 			case 'soap':
+				// PHP 5.6 now have cookie support for SOAP, but using cookies in the request end up with a
+				// "bad request" response, so we unset them before sending it. (see #7280)
+				if (isset($this->client->_cookies)) {
+					unset($this->client->_cookies);
+				}
 				return $this->client->getTagList($aOptions);
 			default:
 				return array();

--- a/system/modules/repository/classes/RepositoryManager.php
+++ b/system/modules/repository/classes/RepositoryManager.php
@@ -1354,6 +1354,11 @@ class RepositoryManager extends RepositoryBackendModule
 			case 'local':
 				return $this->RepositoryServer->getFileList((object)$aOptions);
 			case 'soap':
+				// PHP 5.6 now have cookie support for SOAP, but using cookies in the request end up with a
+				// "bad request" response, so we unset them before sending it. (see #7280)
+				if (isset($this->client->_cookies)) {
+					unset($this->client->_cookies);
+				}
 				return $this->client->getFileList($aOptions);
 			default:
 				return array();
@@ -1371,6 +1376,11 @@ class RepositoryManager extends RepositoryBackendModule
 			case 'local':
 				return $this->RepositoryServer->getPackage((object)$aOptions);
 			case 'soap':
+				// PHP 5.6 now have cookie support for SOAP, but using cookies in the request end up with a
+				// "bad request" response, so we unset them before sending it. (see #7280)
+				if (isset($this->client->_cookies)) {
+					unset($this->client->_cookies);
+				}
 				return $this->client->getPackage($aOptions);
 			default:
 				return array();
@@ -1388,6 +1398,11 @@ class RepositoryManager extends RepositoryBackendModule
 			case 'local':
 				return $this->RepositoryServer->recordAction((object)$aOptions);
 			case 'soap':
+				// PHP 5.6 now have cookie support for SOAP, but using cookies in the request end up with a
+				// "bad request" response, so we unset them before sending it. (see #7280)
+				if (isset($this->client->_cookies)) {
+					unset($this->client->_cookies);
+				}
 				return $this->client->recordAction($aOptions);
 			default:
 				return array();


### PR DESCRIPTION
PHP 5.6 seems to introduce a (maybe buggy) cookie support for SOAP clients.
We now unset cookies from the SOAP client before each request.
