### PR TITLE
Add Hook 'getAdaptiveImage'

### DIFF
--- a/system/modules/core/library/Contao/Image.php
+++ b/system/modules/core/library/Contao/Image.php
@@ -104,7 +104,20 @@ class Image
 			\System::log('Image type "' . $objFile->extension . '" was not allowed to be processed', __METHOD__, TL_ERROR);
 			return null;
 		}
+		
+		// HOOK: add custom logic
+		if (isset($GLOBALS['TL_HOOKS']['getAdaptiveImage']) && is_array($GLOBALS['TL_HOOKS']['getAdaptiveImage']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['getAdaptiveImage'] as $callback)
+			{
+				$return = \System::importStatic($callback[0])->$callback[1]($image, $width, $height, $mode, $objFile, $target);
 
+				if (is_string($return))
+				{
+					return \System::urlEncode($return);
+				}
+			}
+		}
 		// No resizing required
 		if (($objFile->width == $width || !$width) && ($objFile->height == $height || !$height))
 		{


### PR DESCRIPTION
Is it possible to add this Hook? I have an extension which resize Images for mobile Devices.
For my function I can't use the 'getImage'-Hook because it's called to late.
In this function I would like to implement own complex queries of data and many options for mobile websites.
My purpose is that the function works for all images whatever equal modules or elements or further extensions. 
Otherwise it makes no sense :)
