### PR TITLE
Fix bug in Theme importing

### DIFF
--- a/system/modules/core/classes/Theme.php
+++ b/system/modules/core/classes/Theme.php
@@ -400,6 +400,12 @@ class Theme extends \Backend
 				'tl_theme'       => 'WRITE',
 			);
 
+			foreach (array_keys($arrLocks) as $table)
+			{
+				// Load the DCA
+				$this->loadDataContainer($table);
+			}
+
 			$this->Database->lockTables($arrLocks);
 
 			// Get the current auto_increment values
@@ -420,9 +426,6 @@ class Theme extends \Backend
 				{
 					continue;
 				}
-
-				// Load the DCA
-				$this->loadDataContainer($table);
 
 				// Get the order fields
 				$objDcaExtractor = new \DcaExtractor($table);


### PR DESCRIPTION
The invokation of loadDataContainer() in Theme.php after locking the tables can break Theme import.

Code to reproduce (register as loadDataContainer HOOK):

```
public function loadDataContainerHOOK()
{
    \Database::getInstance()->execute('SELECT * FROM tl_user');
}
```

Steps to reproduce: import any Theme.

Expected result: No problems at all.

Actual result: `Fatal error: Uncaught exception Exception with message Query error: Table 'tl_user' was not locked with LOCK TABLES (SELECT * FROM tl_user) thrown in system/modules/core/library/Contao/Database/Statement.php`

Originally the Problem was described in https://github.com/MetaModels/core/issues/537 but affects all loadDataContainer HOOKs that perform ANY SQL Query on ANY table except on the locked tables.

My PR changes the code so that all data containers are loaded before locking the tables (which should impose no problem at all).
