### PR TITLE
Generate theme.xml after export theme hooks

### DIFF
--- a/system/modules/core/classes/Theme.php
+++ b/system/modules/core/classes/Theme.php
@@ -717,9 +717,6 @@ class Theme extends \Backend
 		$strTmp = md5(uniqid(mt_rand(), true));
 		$objArchive = new \ZipWriter('system/tmp/'. $strTmp);
 
-		// Add the XML document
-		$objArchive->addString($xml->saveXML(), 'theme.xml');
-
 		// Add the folders
 		$arrFolders = deserialize($objTheme->folders);
 
@@ -747,6 +744,9 @@ class Theme extends \Backend
 				\System::importStatic($callback[0])->$callback[1]($xml, $objArchive, $objTheme->id);
 			}
 		}
+
+		// Add the XML document
+		$objArchive->addString($xml->saveXML(), 'theme.xml');
 
 		// Close the archive
 		$objArchive->close();


### PR DESCRIPTION
Related: #7341

If `$xml` gets modfied in the `exportTheme` hook, the changes should be saved to the theme.xml file.
