### PR TITLE
Allow to define default flags for inserttags

### DIFF
--- a/system/modules/core/config/config.php
+++ b/system/modules/core/config/config.php
@@ -472,3 +472,4 @@ $GLOBALS['TL_ASSETS'] = array
  */
 $GLOBALS['TL_MODELS'] = array();
 $GLOBALS['TL_PERMISSIONS'] = array();
+$GLOBALS['TL_INSERTTAG_FLAGS'] = array();

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -698,6 +698,12 @@ abstract class Controller extends \System
 			$tag = array_shift($flags);
 			$elements = explode('::', $tag);
 
+            if (isset($GLOBALS['TL_INSERTTAG_FLAGS'][$elements[0]]))
+            {
+                $flags = array_merge($GLOBALS['TL_INSERTTAG_FLAGS'][$elements[0]], $flags);
+                $flags = array_unique($flags);
+            }
+
 			// Load the value from cache
 			if (isset($arrCache[$strTag]) && !in_array('refresh', $flags))
 			{

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -698,11 +698,11 @@ abstract class Controller extends \System
 			$tag = array_shift($flags);
 			$elements = explode('::', $tag);
 
-            if (isset($GLOBALS['TL_INSERTTAG_FLAGS'][$elements[0]]))
-            {
-                $flags = array_merge($GLOBALS['TL_INSERTTAG_FLAGS'][$elements[0]], $flags);
-                $flags = array_unique($flags);
-            }
+			if (isset($GLOBALS['TL_INSERTTAG_FLAGS'][$elements[0]]))
+			{
+				$flags = array_merge($GLOBALS['TL_INSERTTAG_FLAGS'][$elements[0]], $flags);
+				$flags = array_unique($flags);
+			}
 
 			// Load the value from cache
 			if (isset($arrCache[$strTag]) && !in_array('refresh', $flags))


### PR DESCRIPTION
It would be useful to force some insert tag flags for own insert tags. I need it to force an insert tag being always refreshed. There is currently no way to do it in the `replaceInsertTags` hook.

This implementation provides an generic implementation where every flag can be forced for an insert tag.
