### PR TITLE
[3.4-dev] Fix async flag for TL_JAVASCRIPT

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -1947,18 +1947,23 @@ abstract class Controller extends \System
 		if (!empty($GLOBALS['TL_JAVASCRIPT']) && is_array($GLOBALS['TL_JAVASCRIPT']))
 		{
 			$objCombiner = new \Combiner();
+			$objCombinerAsync = new \Combiner();
 
 			foreach (array_unique($GLOBALS['TL_JAVASCRIPT']) as $javascript)
 			{
 				$options = \String::resolveFlaggedUrl($javascript);
 
-				if ($options->static)
+				if ($options->static && $options->async)
+				{
+					$objCombinerAsync->add($javascript, filemtime(TL_ROOT . '/' . $javascript));
+				}
+				elseif ($options->static)
 				{
 					$objCombiner->add($javascript, filemtime(TL_ROOT . '/' . $javascript));
 				}
 				else
 				{
-					$strScripts .= \Template::generateScriptTag(static::addStaticUrlTo($javascript), $blnXhtml) . "\n";
+					$strScripts .= \Template::generateScriptTag(static::addStaticUrlTo($javascript), $blnXhtml, $options->async) . "\n";
 				}
 			}
 
@@ -1966,6 +1971,10 @@ abstract class Controller extends \System
 			if ($objCombiner->hasEntries())
 			{
 				$strScripts = \Template::generateScriptTag($objCombiner->getCombinedFile(), $blnXhtml) . "\n" . $strScripts;
+			}
+			if ($objCombinerAsync->hasEntries())
+			{
+				$strScripts = \Template::generateScriptTag($objCombinerAsync->getCombinedFile(), $blnXhtml, true) . "\n" . $strScripts;
 			}
 		}
 


### PR DESCRIPTION
Currently the `async` flag doesn’t work correctly:

``` php
$GLOBALS['TL_JAVASCRIPT'][] = 'script.js|async';
// Output: <script src="script.js"></script>

$GLOBALS['TL_JAVASCRIPT'][] = 'script.js|static|async';
// Output: <script src="assets/js/e057c6f76856.js"></script>
```

After the fix:

``` php
$GLOBALS['TL_JAVASCRIPT'][] = 'script.js|async';
// Output: <script src="script.js" async></script>

$GLOBALS['TL_JAVASCRIPT'][] = 'script.js|static|async';
// Output: <script src="assets/js/9e6682604751.js" async></script>
```

Related: #7172
