### PR TITLE
Pass pageId to navigation template

### DIFF
--- a/system/modules/core/modules/Module.php
+++ b/system/modules/core/modules/Module.php
@@ -233,6 +233,7 @@ abstract class Module extends \Frontend
 		$objTemplate->type = get_class($this);
 		$objTemplate->cssID = $this->cssID; // see #4897
 		$objTemplate->level = 'level_' . $level++;
+		$objTemplate->pageId = $pid;
 
 		// Get page object
 		global $objPage;


### PR DESCRIPTION
Sometimes it is good to know which page actually the parent page in the navigation template. This PR passed the ID to the template. 
