### PR TITLE
[3.4-dev] Don't resize uploaded SVG images

### DIFF
--- a/system/modules/core/classes/FileUpload.php
+++ b/system/modules/core/classes/FileUpload.php
@@ -286,8 +286,8 @@ class FileUpload extends \Backend
 
 		$objFile = new \File($strImage, true);
 
-		// Not an image
-		if (!$objFile->isSvgImage && !$objFile->isGdImage)
+		// Not a GD image
+		if (!$objFile->isGdImage)
 		{
 			return false;
 		}


### PR DESCRIPTION
Resizing SVG images doesn't reduce the file size, so they shouldn't be resized on upload.
