### PR TITLE
Fix Dbafs::addResource and native record order.

### DIFF
--- a/system/modules/core/library/Contao/Dbafs.php
+++ b/system/modules/core/library/Contao/Dbafs.php
@@ -77,7 +77,7 @@ class Dbafs
 		unset($arrChunks);
 
 		$objModel  = null;
-		$objModels = \FilesModel::findMultipleByPaths($arrPaths);
+		$objModels = \FilesModel::findMultipleByPaths($arrPaths, array('order' => 'path'));
 
 		// Unset the entries in $arrPaths if the DB entry exists
 		if ($objModels !== null)


### PR DESCRIPTION
If the native record order does not match the paths order, the `Dbafs::addResource` return `null`.

Short example:

```
$arrPaths = array(
    `files/Media`,
    `files/Media/Images`,
    `files/Media/Images/Bild.jpg`
);
```

In the database, the records in native order:

| ID | PID | Path | isDir |
| --- | --- | --- | --- |
| 1 | 3 | files/Media/Images/Bild.jpg |  |
| 2 | 0 | files/Media | X |
| 3 | 2 | files/Media/Images | X |

This situation may happen, when you first create `Bild.jpg` in another directory, and then move it into a directory that is created later.

Then `\FilesModel::findMultipleByPaths($arrPaths)` will return:

```
Collection(
  Model(files/Media/Images/Bild.jpg),
  Model(files/Media),
  Model(files/Media/Images)
)
```

But [the following logic](https://github.com/tristanlins/contao-core/blob/3fe261e118b6b4ee06c07ab59091981489c41e20/system/modules/core/library/Contao/Dbafs.php#L85-L98) will only work if the last item in the collection is the final file model.

---

Another solution may be to move the [if condition](https://github.com/tristanlins/contao-core/blob/3fe261e118b6b4ee06c07ab59091981489c41e20/system/modules/core/library/Contao/Dbafs.php#L94-L98) into the [while loop](https://github.com/tristanlins/contao-core/blob/3fe261e118b6b4ee06c07ab59091981489c41e20/system/modules/core/library/Contao/Dbafs.php#L91-L92), like this:

``` php
if ($objModels !== null)
{
    while ($objModels->next())
    {
        if (($i = array_search($objModels->path, $arrPaths)) !== false)
        {
            unset($arrPaths[$i]);
            $arrPids[$objModels->path] = $objModels->uuid;
        }

        // Store the model if it exists
        if ($objModels->path == $strResource)
        {
            $objModel = $objModels->current();
        }
    }
}
```
