### PR TITLE
[feature] use simple tokens for newsletter un/subscription mails

### DIFF
--- a/system/modules/newsletter/modules/ModuleSubscribe.php
+++ b/system/modules/newsletter/modules/ModuleSubscribe.php
@@ -274,17 +274,20 @@ class ModuleSubscribe extends \Module
 		$objChannel = \NewsletterChannelModel::findByIds($arrChannels);
 
 		// Prepare the e-mail text
-		$strText = str_replace('##token##', $strToken, $this->nl_subscribe);
-		$strText = str_replace('##domain##', \Idna::decode(\Environment::get('host')), $strText);
-		$strText = str_replace('##link##', \Idna::decode(\Environment::get('base')) . \Environment::get('request') . ((\Config::get('disableAlias') || strpos(\Environment::get('request'), '?') !== false) ? '&' : '?') . 'token=' . $strToken, $strText);
-		$strText = str_replace(array('##channel##', '##channels##'), implode("\n", $objChannel->fetchEach('title')), $strText);
-
+		$arrData = array();
+		$arrData['token'] = $strToken;
+		$arrData['domain'] = \Idna::decode(\Environment::get('host'));
+		$arrData['link'] = \Idna::decode(\Environment::get('base')) . \Environment::get('request') . ((\Config::get('disableAlias') || strpos(\Environment::get('request'), '?') !== false) ? '&' : '?') . 'token=' . $strToken;
+		$channels = implode("\n", $objChannel->fetchEach('title'));
+		$arrData['channel'] = $channels;
+		$arrData['channels'] = $channels;
+		
 		// Activation e-mail
 		$objEmail = new \Email();
 		$objEmail->from = $GLOBALS['TL_ADMIN_EMAIL'];
 		$objEmail->fromName = $GLOBALS['TL_ADMIN_NAME'];
 		$objEmail->subject = sprintf($GLOBALS['TL_LANG']['MSC']['nl_subject'], \Idna::decode(\Environment::get('host')));
-		$objEmail->text = $strText;
+		$objEmail->text = \String::parseSimpleTokens($this->nl_subscribe, $arrData);
 		$objEmail->sendTo($varInput);
 
 		// Redirect to the jumpTo page

--- a/system/modules/newsletter/modules/ModuleUnsubscribe.php
+++ b/system/modules/newsletter/modules/ModuleUnsubscribe.php
@@ -204,15 +204,18 @@ class ModuleUnsubscribe extends \Module
 		}
 
 		// Prepare the e-mail text
-		$strText = str_replace('##domain##', \Idna::decode(\Environment::get('host')), $this->nl_unsubscribe);
-		$strText = str_replace(array('##channel##', '##channels##'), implode("\n", $arrChannels), $strText);
+		$arrData = array();
+		$arrData['domain'] = \Idna::decode(\Environment::get('host'));
+		$channels = implode("\n", $arrChannels);
+		$arrData['channel'] = $channels;
+		$arrData['channels'] = $channels;
 
 		// Confirmation e-mail
 		$objEmail = new \Email();
 		$objEmail->from = $GLOBALS['TL_ADMIN_EMAIL'];
 		$objEmail->fromName = $GLOBALS['TL_ADMIN_NAME'];
 		$objEmail->subject = sprintf($GLOBALS['TL_LANG']['MSC']['nl_subject'], \Idna::decode(\Environment::get('host')));
-		$objEmail->text = $strText;
+		$objEmail->text = \String::parseSimpleTokens($this->nl_unsubscribe, $arrData);
 		$objEmail->sendTo($varInput);
 
 		// Redirect to the jumpTo page


### PR DESCRIPTION
Just a small improvement for Newsletter subscription and unsubscription mails.

> use the parseSimpleToken for e-mail text creation in newsletter unsubscription and subscription mails
