### PR TITLE
Always apply the IE security fix in the Environment class

### DIFF
--- a/system/modules/core/library/Contao/Environment.php
+++ b/system/modules/core/library/Contao/Environment.php
@@ -167,6 +167,25 @@ class Environment
 
 
 	/**
+	 * Return the query string (e.g. id=2)
+	 *
+	 * @return string The query string
+	 */
+	protected static function queryString()
+	{
+		if (!isset($_SERVER['QUERY_STRING']))
+		{
+			return '';
+		}
+
+		// IE security fix (thanks to Michiel Leideman)
+		$strRequest = str_replace(array('<', '>', '"'), array('%3C', '%3E', '%22'), $_SERVER['QUERY_STRING']);
+
+		return $strRequest;
+	}
+
+
+	/**
 	 * Return the request URI [path]?[query] (e.g. /contao/index.php?id=2)
 	 *
 	 * @return string The request URI
@@ -175,12 +194,17 @@ class Environment
 	{
 		if (!empty($_SERVER['REQUEST_URI']))
 		{
-			return $_SERVER['REQUEST_URI'];
+			$strRequest = $_SERVER['REQUEST_URI'];
 		}
 		else
 		{
-			return '/' . preg_replace('/^\//', '', static::get('scriptName')) . (!empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '');
+			$strRequest = '/' . preg_replace('/^\//', '', static::get('scriptName')) . (!empty($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '');
 		}
+
+		// IE security fix (thanks to Michiel Leideman)
+		$strRequest = str_replace(array('<', '>', '"'), array('%3C', '%3E', '%22'), $strRequest);
+
+		return $strRequest;
 	}
 
 
@@ -421,16 +445,7 @@ class Environment
 	 */
 	protected static function request()
 	{
-		$strRequest = preg_replace('/^' . preg_quote(TL_PATH, '/') . '\/?/', '', static::get('requestUri'));
-
-		// From version 2.9, do not fallback to $this->script
-		// anymore if the request string is empty (see #1844).
-
-		// IE security fix (thanks to Michiel Leideman)
-		$strRequest = str_replace(array('<', '>', '"'), array('%3C', '%3E', '%22'), $strRequest);
-
-		// Do not urldecode() here (thanks to Russ McRee)!
-		return $strRequest;
+		return preg_replace('/^' . preg_quote(TL_PATH, '/') . '\/?/', '', static::get('requestUri'));
 	}
 
 

--- a/system/modules/core/library/Contao/Pagination.php
+++ b/system/modules/core/library/Contao/Pagination.php
@@ -227,7 +227,7 @@ class Pagination
 		$this->strUrl = preg_replace('/\?.*$/', '', \Environment::get('request'));
 
 		// Prepare the URL
-		foreach (preg_split('/&(amp;)?/', $_SERVER['QUERY_STRING'], -1, PREG_SPLIT_NO_EMPTY) as $fragment)
+		foreach (preg_split('/&(amp;)?/', \Environment::get('queryString'), -1, PREG_SPLIT_NO_EMPTY) as $fragment)
 		{
 			if (strpos($fragment, $this->strParameter . '=') === false)
 			{

--- a/system/modules/listing/modules/ModuleListing.php
+++ b/system/modules/listing/modules/ModuleListing.php
@@ -237,7 +237,7 @@ class ModuleListing extends \Module
 		$strUrl = preg_replace('/\?.*$/', '', \Environment::get('request'));
 		$blnQuery = false;
 
-		foreach (preg_split('/&(amp;)?/', $_SERVER['QUERY_STRING']) as $fragment)
+		foreach (preg_split('/&(amp;)?/', \Environment::get('queryString')) as $fragment)
 		{
 			if ($fragment != '' && strncasecmp($fragment, 'order_by', 8) !== 0 && strncasecmp($fragment, 'sort', 4) !== 0 && strncasecmp($fragment, $id, strlen($id)) !== 0)
 			{


### PR DESCRIPTION
Apply the IE security fix to both Environment::get('queryString') and Environment::get('requestUri') and use Environment::get('queryString') instead of $_SERVER['QUERY_STRING'].
