### PR TITLE
Fix upload paths for theme import and export

### DIFF
--- a/system/modules/core/classes/Theme.php
+++ b/system/modules/core/classes/Theme.php
@@ -1044,6 +1044,12 @@ class Theme extends \Backend
 				}
 			}
 
+			// Standardize the upload path if it is not "files"
+			if (\Config::get('uploadPath') != 'files' && $t == 'tl_style' && in_array($k, array('bgimage', 'liststyleimage')))
+			{
+				$v = preg_replace('@^'.preg_quote(\Config::get('uploadPath'), '@').'/@', 'files/', $v);
+			}
+
 			$value = $xml->createTextNode($v);
 			$field->appendChild($value);
 		}

--- a/system/modules/core/classes/Theme.php
+++ b/system/modules/core/classes/Theme.php
@@ -577,6 +577,11 @@ class Theme extends \Backend
 							}
 							else
 							{
+								if (\Config::get('uploadPath') != 'files')
+								{
+									$value = preg_replace('@^files/@', \Config::get('uploadPath') . '/', $value);
+								}
+
 								// Do not use the FilesModel here – tables are locked!
 								$objFile = $this->Database->prepare("SELECT uuid FROM tl_files WHERE path=?")
 														  ->limit(1)
@@ -599,6 +604,11 @@ class Theme extends \Backend
 									if (strncmp($vv, 'tl_files/', 9) === 0)
 									{
 										$vv = substr($vv, 3);
+									}
+
+									if (\Config::get('uploadPath') != 'files')
+									{
+										$vv = preg_replace('@^files/@', \Config::get('uploadPath') . '/', $vv);
 									}
 
 									// Do not use the FilesModel here – tables are locked!


### PR DESCRIPTION
While working on #7465 I found three missing `"files"` to `Config::get('uploadPath')` conversions.
