### PR TITLE
Add a post authenticate hook

### DIFF
--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -202,7 +202,18 @@ abstract class User extends \System
 		$this->Database->prepare("UPDATE tl_session SET tstamp=$time WHERE sessionID=?")
 					   ->execute(session_id());
 
-		$this->setCookie($this->strCookie, $this->strHash, ($time + $GLOBALS['TL_CONFIG']['sessionTimeout']), null, null, false, true);
+		$this->setCookie($this->strCookie, $this->strHash, ($time + \Config::get('sessionTimeout')), null, null, false, true);
+
+		// HOOK: post authenticate callback
+		if (isset($GLOBALS['TL_HOOKS']['postAuthenticate']) && is_array($GLOBALS['TL_HOOKS']['postAuthenticate']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['postAuthenticate'] as $callback)
+			{
+				$this->import($callback[0], 'objAuth', true);
+				$this->objAuth->$callback[1]($this);
+			}
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
Sometimes it is really useful to have a callback when a user is authenticated. It is triggered all times the user is authenticated no matter if he just logged in or is authenicated from the session cookie.

I have to provide a permission service which gets some data from the authenticated user. So it's not enough using the postLogin hook. 

Using the `initializeSystem` hook and call `User::authenticate` by my own is a bad idea, because it would force every script to require a logged in user.
