### PR TITLE
Make BackendUser::authenticate() return true to honor documentation.

### DIFF
--- a/system/modules/core/classes/BackendUser.php
+++ b/system/modules/core/classes/BackendUser.php
@@ -179,7 +179,7 @@ class BackendUser extends \User
 		// Do not redirect if authentication is successful
 		if (parent::authenticate() || \Environment::get('script') == 'contao/index.php')
 		{
-			return;
+			return true;
 		}
 
 		$strRedirect = 'contao/';


### PR DESCRIPTION
Before the method was returning null which is in contrast to the implementation in User and FrontendUser classes.
