### PR TITLE
ce_content :: added save callback to youtube field to extract video id from a url

### DIFF
--- a/system/modules/core/dca/tl_content.php
+++ b/system/modules/core/dca/tl_content.php
@@ -627,7 +627,7 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'label'                   => &$GLOBALS['TL_LANG']['tl_content']['youtube'],
 			'exclude'                 => true,
 			'inputType'               => 'text',
-			'eval'                    => array('rgxp'=>'url', 'mandatory'=>true),
+			'eval'                    => array('rgxp'=>'url', 'mandatory'=>true, 'decodeEntities'=>true),
 			'sql'                     => "varchar(16) NOT NULL default ''",
 			'save_callback' => array
 			(
@@ -1693,8 +1693,7 @@ class tl_content extends Backend
 	 */
 	public function extractYoutubeId($varValue, DataContainer $dc)
 	{
-		$url = \Contao\Input::decodeEntities($varValue);
-		$url = parse_url($url, PHP_URL_QUERY);
+		$url = parse_url($varValue, PHP_URL_QUERY);
 		if (false === $url || null === $url) {
 			return $varValue;
 		}

--- a/system/modules/core/dca/tl_content.php
+++ b/system/modules/core/dca/tl_content.php
@@ -628,7 +628,11 @@ $GLOBALS['TL_DCA']['tl_content'] = array
 			'exclude'                 => true,
 			'inputType'               => 'text',
 			'eval'                    => array('rgxp'=>'url', 'mandatory'=>true),
-			'sql'                     => "varchar(16) NOT NULL default ''"
+			'sql'                     => "varchar(16) NOT NULL default ''",
+			'save_callback' => array
+			(
+				array('tl_content', 'extractYoutubeId')
+			)
 		),
 		'posterSRC' => array
 		(
@@ -1679,6 +1683,30 @@ class tl_content extends Backend
 
 		return $varValue;
 	}
+
+
+	/**
+	 * Extract the video id from a youtube url
+	 * @param mixed
+	 * @param \DataContainer
+	 * @return mixed
+	 */
+	public function extractYoutubeId($varValue, DataContainer $dc)
+    {
+		$url = \Contao\Input::decodeEntities($varValue);
+		$url = parse_url($url, PHP_URL_QUERY);
+		if (false === $url || null === $url) {
+			return $varValue;
+		}
+
+		$parts = array();
+		parse_str($url, $parts);
+		if (array_key_exists('v', $parts)) {
+			return $parts['v'];
+		}
+
+		return $varValue;
+    }
 
 
 	/**

--- a/system/modules/core/dca/tl_content.php
+++ b/system/modules/core/dca/tl_content.php
@@ -1694,20 +1694,20 @@ class tl_content extends Backend
 	public function extractYoutubeId($varValue, DataContainer $dc)
 	{
 		$url = parse_url($varValue);
-		if (false === $url ||
-			!array_key_exists('host', $url) ||
-			!array_key_exists('path', $url)
-		) {
+		if (false === $url || !array_key_exists('host', $url) || !array_key_exists('path', $url))
+		{
 			return $varValue;
 		}
 
 		// http(s)://youtu.be/<video_id>
-		if (false !== stripos($url['host'], 'youtu.be')) {
+		if (false !== stripos($url['host'], 'youtu.be'))
+		{
 			return substr($url['path'], 1);
 		}
 		// http(s)://www.youtube.com/watch?v=<video_id>
 		// http(s)://m.youtube.com/watch?v=<video_id>
-		elseif ('/watch' === $url['path'] && array_key_exists('query', $url)) {
+		elseif ('/watch' === $url['path'] && array_key_exists('query', $url))
+		{
 			$query = array();
 			parse_str($url['query'], $query);
 			if (array_key_exists('v', $query)) {
@@ -1715,11 +1715,13 @@ class tl_content extends Backend
 			}
 		}
 		// http(s)://www.youtube.com/embed/<video_id>
-		elseif ('/embed/' === substr($url['path'], 0, 7)) {
+		elseif ('/embed/' === substr($url['path'], 0, 7))
+		{
 			return substr($url['path'], 7);
 		}
 		// http(s)://www.youtube.com/v/<video_id>
-		elseif ('/v/' === substr($url['path'], 0, 3)) {
+		elseif ('/v/' === substr($url['path'], 0, 3))
+		{
 			return substr($url['path'], 3);
 		}
 

--- a/system/modules/core/dca/tl_content.php
+++ b/system/modules/core/dca/tl_content.php
@@ -1692,7 +1692,7 @@ class tl_content extends Backend
 	 * @return mixed
 	 */
 	public function extractYoutubeId($varValue, DataContainer $dc)
-    {
+	{
 		$url = \Contao\Input::decodeEntities($varValue);
 		$url = parse_url($url, PHP_URL_QUERY);
 		if (false === $url || null === $url) {
@@ -1706,7 +1706,7 @@ class tl_content extends Backend
 		}
 
 		return $varValue;
-    }
+	}
 
 
 	/**


### PR DESCRIPTION
Quite a few users struggle with extraction of the video id from a youtube url. Especially with the recently added forced playlist.
This patch adds a save callback to the ce_content.youtube field that extracts the video id from a complete url. The user can just copy and paste whatever the address bar says.
