### PR TITLE
Remove inline styles from image captions

### DIFF
--- a/system/modules/core/templates/elements/ce_accordion.html5
+++ b/system/modules/core/templates/elements/ce_accordion.html5
@@ -25,7 +25,7 @@
         <?php endif; ?>
 
         <?php if ($this->caption): ?>
-          <figcaption class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></figcaption>
+          <figcaption class="caption"><?php echo $this->caption; ?></figcaption>
         <?php endif; ?>
 
       </figure>

--- a/system/modules/core/templates/elements/ce_accordion.xhtml
+++ b/system/modules/core/templates/elements/ce_accordion.xhtml
@@ -25,7 +25,7 @@
         <?php endif; ?>
 
         <?php if ($this->caption): ?>
-          <div class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></div>
+          <div class="caption"><?php echo $this->caption; ?></div>
         <?php endif; ?>
 
       </div>

--- a/system/modules/core/templates/elements/ce_hyperlink_image.html5
+++ b/system/modules/core/templates/elements/ce_hyperlink_image.html5
@@ -9,7 +9,7 @@
     <?php echo $this->embed_post; ?>
 
     <?php if ($this->caption): ?>
-      <figcaption class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></figcaption>
+      <figcaption class="caption"><?php echo $this->caption; ?></figcaption>
     <?php endif; ?>
 
   </figure>

--- a/system/modules/core/templates/elements/ce_hyperlink_image.xhtml
+++ b/system/modules/core/templates/elements/ce_hyperlink_image.xhtml
@@ -9,7 +9,7 @@
     <?php echo $this->embed_post; ?>
 
     <?php if ($this->caption): ?>
-      <div class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></div>
+      <div class="caption"><?php echo $this->caption; ?></div>
     <?php endif; ?>
 
   </div>

--- a/system/modules/core/templates/elements/ce_image.html5
+++ b/system/modules/core/templates/elements/ce_image.html5
@@ -15,7 +15,7 @@
     <?php endif; ?>
 
     <?php if ($this->caption): ?>
-      <figcaption class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></figcaption>
+      <figcaption class="caption"><?php echo $this->caption; ?></figcaption>
     <?php endif; ?>
 
   </figure>

--- a/system/modules/core/templates/elements/ce_image.xhtml
+++ b/system/modules/core/templates/elements/ce_image.xhtml
@@ -15,7 +15,7 @@
     <?php endif; ?>
 
     <?php if ($this->caption): ?>
-      <div class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></div>
+      <div class="caption"><?php echo $this->caption; ?></div>
     <?php endif; ?>
 
   </div>

--- a/system/modules/core/templates/elements/ce_text.html5
+++ b/system/modules/core/templates/elements/ce_text.html5
@@ -20,7 +20,7 @@
       <?php endif; ?>
 
       <?php if ($this->caption): ?>
-        <figcaption class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></figcaption>
+        <figcaption class="caption"><?php echo $this->caption; ?></figcaption>
       <?php endif; ?>
 
     </figure>

--- a/system/modules/core/templates/elements/ce_text.xhtml
+++ b/system/modules/core/templates/elements/ce_text.xhtml
@@ -20,7 +20,7 @@
       <?php endif; ?>
 
       <?php if ($this->caption): ?>
-        <div class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></div>
+        <div class="caption"><?php echo $this->caption; ?></div>
       <?php endif; ?>
 
     </div>

--- a/system/modules/core/templates/gallery/gallery_default.html5
+++ b/system/modules/core/templates/gallery/gallery_default.html5
@@ -11,7 +11,7 @@
               <?php $this->insert('picture_default', $col->picture); ?>
             <?php endif; ?>
             <?php if ($col->caption): ?>
-              <figcaption class="caption" style="width:<?php echo $col->arrSize[0]; ?>px"><?php echo $col->caption; ?></figcaption>
+              <figcaption class="caption"><?php echo $col->caption; ?></figcaption>
             <?php endif; ?>
           </figure>
         </li>

--- a/system/modules/core/templates/gallery/gallery_default.xhtml
+++ b/system/modules/core/templates/gallery/gallery_default.xhtml
@@ -11,7 +11,7 @@
               <?php $this->insert('picture_default', $col->picture); ?>
             <?php endif; ?>
             <?php if ($col->caption): ?>
-              <div class="caption" style="width:<?php echo $col->arrSize[0]; ?>px"><?php echo $col->caption; ?></div>
+              <div class="caption"><?php echo $col->caption; ?></div>
             <?php endif; ?>
           </div>
         </li>

--- a/system/modules/core/templates/modules/mod_random_image.html5
+++ b/system/modules/core/templates/modules/mod_random_image.html5
@@ -15,7 +15,7 @@
     <?php endif; ?>
 
     <?php if ($this->caption): ?>
-      <figcaption class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></figcaption>
+      <figcaption class="caption"><?php echo $this->caption; ?></figcaption>
     <?php endif; ?>
 
   </figure>

--- a/system/modules/core/templates/modules/mod_random_image.xhtml
+++ b/system/modules/core/templates/modules/mod_random_image.xhtml
@@ -15,7 +15,7 @@
     <?php endif; ?>
 
     <?php if ($this->caption): ?>
-      <div class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></div>
+      <div class="caption"><?php echo $this->caption; ?></div>
     <?php endif; ?>
 
   </div>

--- a/system/modules/faq/templates/modules/mod_faqpage.html5
+++ b/system/modules/faq/templates/modules/mod_faqpage.html5
@@ -29,7 +29,7 @@
                 <?php endif; ?>
 
                 <?php if ($faq->caption): ?>
-                  <figcaption class="caption" style="width:<?php echo $faq->arrSize[0]; ?>px"><?php echo $faq->caption; ?></figcaption>
+                  <figcaption class="caption"><?php echo $faq->caption; ?></figcaption>
                 <?php endif; ?>
 
               </figure>

--- a/system/modules/faq/templates/modules/mod_faqpage.xhtml
+++ b/system/modules/faq/templates/modules/mod_faqpage.xhtml
@@ -29,7 +29,7 @@
                 <?php endif; ?>
 
                 <?php if ($faq->caption): ?>
-                  <div class="caption" style="width:<?php echo $faq->arrSize[0]; ?>px"><?php echo $faq->caption; ?></div>
+                  <div class="caption"><?php echo $faq->caption; ?></div>
                 <?php endif; ?>
 
               </div>

--- a/system/modules/faq/templates/modules/mod_faqreader.html5
+++ b/system/modules/faq/templates/modules/mod_faqreader.html5
@@ -26,7 +26,7 @@
           <?php endif; ?>
 
           <?php if ($this->caption): ?>
-            <figcaption class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></figcaption>
+            <figcaption class="caption"><?php echo $this->caption; ?></figcaption>
           <?php endif; ?>
 
         </figure>

--- a/system/modules/faq/templates/modules/mod_faqreader.xhtml
+++ b/system/modules/faq/templates/modules/mod_faqreader.xhtml
@@ -26,7 +26,7 @@
           <?php endif; ?>
 
           <?php if ($this->caption): ?>
-            <div class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></div>
+            <div class="caption"><?php echo $this->caption; ?></div>
           <?php endif; ?>
 
         </div>

--- a/system/modules/news/templates/news/news_latest.html5
+++ b/system/modules/news/templates/news/news_latest.html5
@@ -19,7 +19,7 @@
       <?php endif; ?>
 
       <?php if ($this->caption): ?>
-        <figcaption class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></figcaption>
+        <figcaption class="caption"><?php echo $this->caption; ?></figcaption>
       <?php endif; ?>
 
     </figure>

--- a/system/modules/news/templates/news/news_latest.xhtml
+++ b/system/modules/news/templates/news/news_latest.xhtml
@@ -19,7 +19,7 @@
       <?php endif; ?>
 
       <?php if ($this->caption): ?>
-        <div class="caption" style="width:<?php echo $this->arrSize[0]; ?>px"><?php echo $this->caption; ?></div>
+        <div class="caption"><?php echo $this->caption; ?></div>
       <?php endif; ?>
 
     </div>


### PR DESCRIPTION
The inline styles for image captions don’t make sense anymore. Because of the new responsive images feature the image width is dynamic.

Related: #3517, [Forum thread 54806](https://community.contao.org/de/showthread.php?54806#post353565)
