### PR TITLE
ce_downloads - Add templatevariable for direct href-link to File

### DIFF
--- a/system/modules/core/elements/ContentDownload.php
+++ b/system/modules/core/elements/ContentDownload.php
@@ -101,10 +101,12 @@ class ContentDownload extends \ContentElement
 		}
 
 		$strHref .= ((\Config::get('disableAlias') || strpos($strHref, '?') !== false) ? '&amp;' : '?') . 'file=' . \System::urlEncode($objFile->value);
+		$strHrefFile = \System::urlEncode($objFile->value);
 
 		$this->Template->link = $this->linkTitle;
 		$this->Template->title = specialchars($this->titleText ?: sprintf($GLOBALS['TL_LANG']['MSC']['download'], $objFile->basename));
 		$this->Template->href = $strHref;
+		$this->Template->hreffile = $strHrefFile;
 		$this->Template->filesize = $this->getReadableSize($objFile->filesize, 1);
 		$this->Template->icon = TL_ASSETS_URL . 'assets/contao/images/' . $objFile->icon;
 		$this->Template->mime = $objFile->mime;

--- a/system/modules/core/elements/ContentDownloads.php
+++ b/system/modules/core/elements/ContentDownloads.php
@@ -162,6 +162,7 @@ class ContentDownloads extends \ContentElement
 				}
 
 				$strHref .= ((\Config::get('disableAlias') || strpos($strHref, '?') !== false) ? '&amp;' : '?') . 'file=' . \System::urlEncode($objFiles->path);
+				$strHrefFile = \System::urlEncode($objFiles->path);
 
 				// Add the image
 				$files[$objFiles->path] = array
@@ -173,6 +174,7 @@ class ContentDownloads extends \ContentElement
 					'link'      => $arrMeta['title'],
 					'caption'   => $arrMeta['caption'],
 					'href'      => $strHref,
+					'hreffile'  => $strHrefFile,
 					'filesize'  => $this->getReadableSize($objFile->filesize, 1),
 					'icon'      => TL_ASSETS_URL . 'assets/contao/images/' . $objFile->icon,
 					'mime'      => $objFile->mime,
@@ -238,6 +240,7 @@ class ContentDownloads extends \ContentElement
 					}
 
 					$strHref .= ((\Config::get('disableAlias') || strpos($strHref, '?') !== false) ? '&amp;' : '?') . 'file=' . \System::urlEncode($objSubfiles->path);
+					$strHrefFile = \System::urlEncode($objSubfiles->path);
 
 					// Add the image
 					$files[$objSubfiles->path] = array
@@ -249,6 +252,7 @@ class ContentDownloads extends \ContentElement
 						'link'      => $arrMeta['title'],
 						'caption'   => $arrMeta['caption'],
 						'href'      => $strHref,
+						'hreffile'  => $strHrefFile,
 						'filesize'  => $this->getReadableSize($objFile->filesize, 1),
 						'icon'      => TL_ASSETS_URL . 'assets/contao/images/' . $objFile->icon,
 						'mime'      => $objFile->mime,


### PR DESCRIPTION
I wanted to directly link to a file with ce_downloads without missing its features (Fileicon, filesize, etc.).
This could be easily done with an additional template variable which gives the direct Link to the file (files/folder/xxxx.xyz) without xxxx?file=files/folder/xxxx.xyz.
I call this var "hreffile".

Edit your ce_downloads Template like that:

```
<?php $this->extend('block_searchable'); ?>
<?php $this->block('content'); ?>
  <?php echo $this->v2warning; ?>
  <ul>
    <?php foreach ($this->files as $file): ?>
      <li><img src="<?php echo $file['icon']; ?>" width="18" height="18" alt="" class="mime_icon"> <a href="<?php echo $file['hreffile']; ?>" title="<?php echo $file['title']; ?>"><?php echo $file['link']; ?> <span class="size">(<?php echo $file['filesize']; ?>)</span></a></li>
    <?php endforeach; ?>
  </ul>
<?php $this->endblock(); ?>
```

This gives more freedom how to display the downloads.

Already requested/discussed here:
https://community.contao.org/de/showthread.php?54333
https://community.contao.org/de/showthread.php?54376
