### PR TITLE
Vastly improved performance by only calling the error handler if needed

### DIFF
--- a/system/initialize.php
+++ b/system/initialize.php
@@ -61,10 +61,11 @@ require TL_ROOT . '/system/helper/exception.php';
 
 
 /**
- * Set the error and exception handler
+ * Set the default error and exception handlers to make sure
+ * nothing is printed out to the world
  */
-@set_error_handler('__error');
-@set_exception_handler('__exception');
+set_error_handler('__error');
+set_exception_handler('__exception');
 
 
 /**
@@ -89,6 +90,11 @@ require TL_ROOT . '/system/modules/core/library/Contao/ModuleLoader.php';
 class_alias('Contao\\ModuleLoader', 'ModuleLoader');
 
 Config::preload(); // see #5872
+
+/**
+ * Adjust the error handler to the desired error types
+ */
+set_error_handler('__error', Config::get('errorReporting'));
 
 
 /**


### PR DESCRIPTION
This pull request improves the performance of **all** Contao installations by an incredible amount of time! I noticed gains in speed of around `50 ms` for a regular Contao setup and up to `100 ms` for setups with a few extensions!!
### How come?

Contao uses a custom error handler named `__error()` and does set it in the `initialize.php` using `set_error_handler()`. Within that handler, it ignores notices (`E_NOTICE`) completely.
However, whenever a notice is raised, the custom error handler is called, because it's set to handle **all** types of errors:

``` php
set_error_handler('__error');
```

Considering that we're talking about thousands (!!) of notices, mainly caused by `Undefined index` notices because of a missing `isset()`, this also equals thousands of calls of `__error()`!
### Solution

`set_error_handler()` accepts a second parameter where you can specify the error levels you want to register your custom handler for. In our case, we only need it to register for the ones specified in the configuration:

``` php
set_error_handler('__error', Config::get('errorReporting'));
```

Boom! All the calls for notices have gone and with them a few thousand - completely redundant - calls of `__error()`!

_Note:_ I had to move the `set_error_handler()` call down a bit so that `Config::preload()` is called first.
### Credits

I was able to spot that issue thanks to the [PHP profiler blackfire.io](https://blackfire.io) and I would like to thank the developers at SensioLabs for making this excellent product available to everyone!
