### PR TITLE
add .gitignore-files to all subdirectories of assets/images to make sure they are present in git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ nbproject/
 /contao/update.phar.php
 /files/*
 /assets/css/*
-/assets/images/*
 /assets/js/*
 /share/*.xml
 /system/cache/*
@@ -27,9 +26,7 @@ nbproject/
 /system/config/localconfig.php
 /system/config/pathconfig.php
 /system/cron/cron.txt
-/system/logs/*
 /system/modules/!composer
 /system/modules/*/.skip
-/system/tmp/*
 /templates/*
 /vendor/

--- a/assets/images/0/.gitignore
+++ b/assets/images/0/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/0/index.html
+++ b/assets/images/0/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/1/.gitignore
+++ b/assets/images/1/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/1/index.html
+++ b/assets/images/1/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/2/.gitignore
+++ b/assets/images/2/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/2/index.html
+++ b/assets/images/2/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/3/.gitignore
+++ b/assets/images/3/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/3/index.html
+++ b/assets/images/3/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/4/.gitignore
+++ b/assets/images/4/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/4/index.html
+++ b/assets/images/4/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/5/.gitignore
+++ b/assets/images/5/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/5/index.html
+++ b/assets/images/5/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/6/.gitignore
+++ b/assets/images/6/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/6/index.html
+++ b/assets/images/6/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/7/.gitignore
+++ b/assets/images/7/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/7/index.html
+++ b/assets/images/7/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/8/.gitignore
+++ b/assets/images/8/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/8/index.html
+++ b/assets/images/8/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/9/.gitignore
+++ b/assets/images/9/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/9/index.html
+++ b/assets/images/9/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/a/.gitignore
+++ b/assets/images/a/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+.gitignore
+!.gitignore

--- a/assets/images/a/index.html
+++ b/assets/images/a/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/b/.gitignore
+++ b/assets/images/b/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+*
+!.gitignore

--- a/assets/images/b/index.html
+++ b/assets/images/b/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/c/.gitignore
+++ b/assets/images/c/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+*
+!.gitignore

--- a/assets/images/c/index.html
+++ b/assets/images/c/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/d/.gitignore
+++ b/assets/images/d/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+*
+!.gitignore

--- a/assets/images/d/index.html
+++ b/assets/images/d/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/e/.gitignore
+++ b/assets/images/e/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+*
+!.gitignore

--- a/assets/images/e/index.html
+++ b/assets/images/e/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/assets/images/f/.gitignore
+++ b/assets/images/f/.gitignore
@@ -1,0 +1,3 @@
+# Dummy file to make Git create the folder
+*
+!.gitignore

--- a/assets/images/f/index.html
+++ b/assets/images/f/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Blank page</title>
-</head>
-<body>
-</body>
-</html>

--- a/system/initialize.php
+++ b/system/initialize.php
@@ -107,8 +107,11 @@ catch (UnresolvableDependenciesException $e)
 /**
  * Include the Composer autoloader
  */
-require_once TL_ROOT . '/vendor/autoload.php';
 
+if (file_exists(TL_ROOT . '/vendor/autoload.php'))
+{
+	require_once TL_ROOT . '/vendor/autoload.php';
+}
 
 /**
  * Override some SwiftMailer defaults

--- a/system/initialize.php
+++ b/system/initialize.php
@@ -107,11 +107,8 @@ catch (UnresolvableDependenciesException $e)
 /**
  * Include the Composer autoloader
  */
+require_once TL_ROOT . '/vendor/autoload.php';
 
-if (file_exists(TL_ROOT . '/vendor/autoload.php'))
-{
-	require_once TL_ROOT . '/vendor/autoload.php';
-}
 
 /**
  * Override some SwiftMailer defaults


### PR DESCRIPTION
If you download a package form contao.org, initialize a new git-repo for the current project and push it up to a git-repo-server, the folders will not be present anymore. So if you deploy a project based on that remote-repository you will run in problems.
