### PR TITLE
Add possibility to attach an original clone to the registry again

### DIFF
--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -181,6 +181,21 @@ abstract class Model
 
 
 	/**
+	 * Clone a model with exactly the same original values
+	 *
+	 * @return static
+	 */
+	public function cloneOriginal()
+	{
+		$clone = clone $this;
+
+		$clone->setRow($this->originalRow());
+
+		return $clone;
+	}
+
+
+	/**
 	 * Set an object property
 	 *
 	 * @param string $strKey   The property name
@@ -261,6 +276,29 @@ abstract class Model
 	public function row()
 	{
 		return $this->arrData;
+	}
+
+
+	/**
+	 * Return the original values as associative array
+	 *
+	 * @return array The data record
+	 */
+	public function originalRow()
+	{
+		$row = $this->row();
+
+		if (!$this->isModified()) {
+			return $row;
+		}
+
+		$originalRow = array();
+
+		foreach ($row as $k => $v) {
+			$originalRow[$k] = isset($this->arrModified[$k]) ? $this->arrModified[$k] : $v;
+		}
+
+		return $originalRow;
 	}
 
 
@@ -610,19 +648,36 @@ abstract class Model
 
 	/**
 	 * Detach the model from the registry
+	 *
+	 * @param boolean $blnKeepClone Keeps a clone of the model in the registry
 	 */
-	public function detach()
+	public function detach($blnKeepClone = true)
 	{
 		\Model\Registry::getInstance()->unregister($this);
+
+		if ($blnKeepClone) {
+			$this->cloneOriginal()->attach();
+		}
+	}
+
+
+	/**
+	 * Attach the model to the registry
+	 */
+	public function attach()
+	{
+		\Model\Registry::getInstance()->register($this);
 	}
 
 
 	/**
 	 * Prevent saving the model
+	 *
+	 * @param boolean $blnKeepClone Keeps a clone of the model in the registry
 	 */
-	public function preventSaving()
+	public function preventSaving($blnKeepClone = true)
 	{
-		$this->detach();
+		$this->detach($blnKeepClone);
 		$this->blnPreventSaving = true;
 	}
 

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -288,13 +288,15 @@ abstract class Model
 	{
 		$row = $this->row();
 
-		if (!$this->isModified()) {
+		if (!$this->isModified())
+		{
 			return $row;
 		}
 
 		$originalRow = array();
 
-		foreach ($row as $k => $v) {
+		foreach ($row as $k => $v)
+		{
 			$originalRow[$k] = isset($this->arrModified[$k]) ? $this->arrModified[$k] : $v;
 		}
 
@@ -655,7 +657,8 @@ abstract class Model
 	{
 		\Model\Registry::getInstance()->unregister($this);
 
-		if ($blnKeepClone) {
+		if ($blnKeepClone)
+		{
 			$this->cloneOriginal()->attach();
 		}
 	}


### PR DESCRIPTION
I'm a bit on that performance trip lately :)

So I found that on my page there are several identical queries to the database, that look like this:

```
SELECT tl_page.* FROM tl_page WHERE tl_page.id='43' LIMIT 0,1
```

I then found that this is because when you call `PageModel::loadDetails()` or `PageModel::findWithDetails()` (that internally calls `loadDetails()` again), it calls `preventSaving` (see issue https://github.com/contao/core/issues/7199) the model is being detached from the model registry and thus fetched from the database again every time somebody calls `PageModel::findByPk(43)`.

It get's especially costly if somebody calls `PageModel::findWithDetails()` because this will cause Contao do run this very expensive method over and over again.

Needs some good testing and review by @contao/developers, please!
