### PR TITLE
Allow flexible attributes for the image in the picture element.

### DIFF
--- a/system/modules/core/templates/picture/picture_default.html5
+++ b/system/modules/core/templates/picture/picture_default.html5
@@ -8,7 +8,7 @@
     <!--[if IE 9]></video><![endif]-->
 <?php endif; ?>
 
-<img src="<?php echo $this->img['src']; ?>"<?php if ($this->img['srcset'] !== $this->img['src']): ?> srcset="<?php echo $this->img['srcset']; ?>"<?php endif; ?><?php if (!empty($this->img['sizes'])): ?> sizes="<?php echo $this->img['sizes']; ?>"<?php elseif (!$this->sources): ?> width="<?php echo $this->img['width']; ?>" height="<?php echo $this->img['height']; ?>"<?php endif; ?> alt="<?php echo $this->alt; ?>"<?php if ($this->title): ?> title="<?php echo $this->title; ?>"<?php endif; ?>>
+<img<?php array_walk($this->img, function($value, $key) { echo sprintf(' %s="%s"', $key, $value); }); ?>>
 
 <?php if ($this->sources): ?>
   </picture>

--- a/system/modules/core/templates/picture/picture_default.xhtml
+++ b/system/modules/core/templates/picture/picture_default.xhtml
@@ -8,7 +8,7 @@
     <!--[if IE 9]></video><![endif]-->
 <?php endif; ?>
 
-<img src="<?php echo $this->img['src']; ?>"<?php if ($this->img['srcset'] !== $this->img['src']): ?> srcset="<?php echo $this->img['srcset']; ?>"<?php endif; ?><?php if (!empty($this->img['sizes'])): ?> sizes="<?php echo $this->img['sizes']; ?>"<?php elseif (!$this->sources): ?> width="<?php echo $this->img['width']; ?>" height="<?php echo $this->img['height']; ?>"<?php endif; ?> alt="<?php echo $this->alt; ?>"<?php if ($this->title): ?> title="<?php echo $this->title; ?>"<?php endif; ?> />
+<img<?php array_walk($this->img, function($value, $key) { echo sprintf(' %s="%s"', $key, $value); }); ?>>
 
 <?php if ($this->sources): ?>
   </picture>


### PR DESCRIPTION
At the moment the image of the picture element is limited to a fixed set of classes. It would be nice if all items of the `img` key are rendered as attributes. So it would be possible that f.e. an class is passed from the outside (wrapper template or hook).

This pr provides the implementation for it.

According to the [allowed attributes](http://de.selfhtml.org/html/referenz/attribute.htm#img) there is only the `ismap` attribute which can be empty. So I decided not to check it. If someone really needs it changing of the template is always possible. 
