### PR TITLE
Implemented diff view for templates

### DIFF
--- a/system/modules/core/config/config.php
+++ b/system/modules/core/config/config.php
@@ -47,7 +47,8 @@ $GLOBALS['BE_MOD'] = array
 		'tpl_editor' => array
 		(
 			'tables'      => array('tl_templates'),
-			'new_tpl'     => array('tl_templates', 'addNewTemplate')
+			'new_tpl'     => array('tl_templates', 'addNewTemplate'),
+			'diff'        => array('tl_templates', 'diffTemplate'),
 		)
 	),
 

--- a/system/modules/core/languages/en/tl_templates.xlf
+++ b/system/modules/core/languages/en/tl_templates.xlf
@@ -44,6 +44,18 @@
       <trans-unit id="tl_templates.pasteinto.1">
         <source>Paste into this folder</source>
       </trans-unit>
+      <trans-unit id="tl_templates.diff.0">
+        <source>View differences to another template</source>
+      </trans-unit>
+      <trans-unit id="tl_templates.diff.1">
+        <source>View differences of "%s" to another template.</source>
+      </trans-unit>
+      <trans-unit id="tl_templates.overridesAnotherTpl">
+        <source>This template ("%s") overrides a template from an extension or the core itself. The path to the original template is "%s".</source>
+      </trans-unit>
+      <trans-unit id="tl_templates.standaloneTpl">
+        <source>This template ("%s") is a standalone template and does not override a template from an extension or the core itself.</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/system/modules/core/templates/backend/be_diff.html5
+++ b/system/modules/core/templates/backend/be_diff.html5
@@ -37,11 +37,15 @@
       <form action="<?php echo $this->action; ?>" method="post">
         <div class="formbody">
           <input type="hidden" name="REQUEST_TOKEN" value="<?php echo REQUEST_TOKEN; ?>">
+          <?php if ($this->staticFrom): ?>
+          <span><?php echo $this->staticFrom; ?></span>
+          <?php else: ?>
           <select name="from" id="ctrl_from" class="tl_select">
             <?php foreach ($this->versions as $k=>$v): ?>
               <option value="<?php echo $k; ?>"<?php if ($v['version'] == $this->from): ?> selected="selected"<?php endif; ?>><?php echo $v['info']; ?></option>
             <?php endforeach; ?>
           </select>
+          <?php endif; ?>
           <span class="arrow">→</span>
           <select name="to" id="ctrl_to" class="tl_select">
             <?php foreach ($this->versions as $k=>$v): ?>


### PR DESCRIPTION
This is very helpful to easily diff templates against the original one in the back end. One can see where the differences are with one click only. I often diff when I update Contao installations to see if the changes are still necessary after the update or to know if there is even a difference or I can just delete the template.

This small feature makes it really easy to do so right from within the back end. See the screenshots:

![screen shot 2015-01-27 at 18 30 26](https://cloud.githubusercontent.com/assets/481937/5923404/8a18d9e4-a653-11e4-8ce3-26a51c1a6e53.png)
![screen shot 2015-01-27 at 18 30 38](https://cloud.githubusercontent.com/assets/481937/5923403/8a18cb0c-a653-11e4-8ede-84d551fd8c24.png)
