### PR TITLE
Allow IP ranges in trusted proxies

### DIFF
--- a/system/modules/core/library/Contao/Environment.php
+++ b/system/modules/core/library/Contao/Environment.php
@@ -371,15 +371,35 @@ class Environment
 			$arrIps = array($strXip);
 		}
 
-		$arrIps = array_reverse($arrIps);
+		// Filter away the trusted IPs or IP ranges
+		$arrIps = array_filter($arrIps, function($ip) use ($arrTrusted)
+		{
+			foreach ($arrTrusted as $trusted)
+			{
+				if (strpos($trusted, '/') !== false)
+				{
+					list ($subnet, $bits) = explode('/', $trusted);
+					$ip     = ip2long($ip);
+					$subnet = ip2long($subnet);
+					$mask   = -1 << (32 - $bits);
+					$subnet &= $mask;
+
+					if (($ip & $mask) == $subnet) {
+						return false;
+					}
+				}
+				elseif ($ip == $trusted)
+				{
+					return false;
+				}
+			}
+
+			return true;
+		});
 
 		// Return the first untrusted IP address (see #5830)
-		foreach ($arrIps as $strIp)
-		{
-			if (!in_array($strIp, $arrTrusted))
-			{
-				return substr($strIp, 0, 64);
-			}
+		if (!empty($arrIps)) {
+			return substr(array_pop($arrIps), 0, 64);
 		}
 
 		// If all X-Forward-For IPs are trusted, return the remote address

--- a/system/modules/core/library/Contao/Environment.php
+++ b/system/modules/core/library/Contao/Environment.php
@@ -374,17 +374,18 @@ class Environment
 		// Filter away the trusted IPs or IP ranges
 		$arrIps = array_filter($arrIps, function($ip) use ($arrTrusted)
 		{
+			$ip_long = ip2long($ip);
+
 			foreach ($arrTrusted as $trusted)
 			{
 				if (strpos($trusted, '/') !== false)
 				{
 					list ($subnet, $bits) = explode('/', $trusted);
-					$ip     = ip2long($ip);
 					$subnet = ip2long($subnet);
 					$mask   = -1 << (32 - $bits);
 					$subnet &= $mask;
 
-					if (($ip & $mask) == $subnet) {
+					if (($ip_long & $mask) == $subnet) {
 						return false;
 					}
 				}


### PR DESCRIPTION
The `$GLOBALS['TL_CONFIG']['proxyServerIps']` allows for a list of trusted proxy IPs. In my case, I had to whiteliste several subnetworks of proxy servers, so the simple list was only partially useful.

This PR adds support for IPv4 subnetworks in the list of trusted proxies.
Example: `192.168.1.0/24` would white-list IPs ranging from `192.168.1.1` to `192.168.1.254`.
