### PR TITLE
Add HOOK manipulateMailMessage to provide base for feature #7310.

### DIFF
--- a/system/modules/core/library/Contao/Email.php
+++ b/system/modules/core/library/Contao/Email.php
@@ -509,6 +509,16 @@ class Email
 		// Set the return path (see #5004)
 		$this->objMessage->setReturnPath($this->strSender);
 
+		// HOOK: manipulate the message
+		if (isset($GLOBALS['TL_HOOKS']['manipulateMailMessage']) && is_array($GLOBALS['TL_HOOKS']['manipulateMailMessage']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['manipulateMailMessage'] as $callback)
+			{
+				$objHook = (in_array('getInstance', get_class_methods($callback[0]))) ? call_user_func(array($callback[0], 'getInstance')) : new $callback[0]();
+				$objHook->$callback[1]($this->objMessage, $this);
+			}
+		}
+
 		// Send e-mail
 		$intSent = self::$objMailer->send($this->objMessage, $this->arrFailures);
 


### PR DESCRIPTION
Now it is possible to manipulate the SwiftMailer message just before it
get's sent.
This is useful when trying to sign messages etc.

Example code for issue #7310:

config.php:

``` php
$GLOBALS['TL_HOOKS']['manipulateMailMessage'][] =
array('ManipulateMessageHandler', 'signMail');
```

ManipulateMessageHandler.php:

``` php
class ManipulateMessageHandler
{
    public function signMail($message)
    {
        $smimeSigner = Swift_Signers_SMimeSigner::newInstance();
        $smimeSigner->setSignCertificate('/path/to/certificate.pem',
'/path/to/private-key.pem');
        $message->attachSigner($smimeSigner);
    }
}
```
