### PR TITLE
ide_compat: Use fgets instead of fread

### DIFF
--- a/system/bin/ide_compat
+++ b/system/bin/ide_compat
@@ -83,7 +83,7 @@ foreach ($arrModules as $strModule) {
 
 		// Read until a class or interface definition has been found
 		while (!feof($fh) && !preg_match('/(class|interface) ' . preg_quote(basename($strFile, '.php'), '/') . '/', $strBuffer, $arrMatches)) {
-			$strBuffer .= fread($fh, 512);
+			$strBuffer .= fgets($fh, 512);
 		}
 
 		fclose($fh);


### PR DESCRIPTION
`fread()` ignores newlines which can cause problems with very small class files (e.g. Model classes).
The preg_match won't be executed if the filehandler has reached EOF, resulting in ignoring the class. That will lead to missing classes in the `ide_compat.php`.

By using fgets the file reading will also stop when reaching a newline. In that case, even small class files will be added correctly.
