### PR TITLE
Fixed overrideAll mode

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -2861,6 +2861,23 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				$new = deserialize($varValue, true);
 				$old = deserialize($this->objActiveRecord->{$this->strField}, true);
 
+				// Call load_callback
+				if (is_array($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback']))
+				{
+					foreach ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$this->strField]['load_callback'] as $callback)
+					{
+						if (is_array($callback))
+						{
+							$this->import($callback[0]);
+							$old = $this->$callback[0]->$callback[1]($old, $this);
+						}
+						elseif (is_callable($callback))
+						{
+							$old = $callback($old, $this);
+						}
+					}
+				}
+
 				switch (\Input::post($this->strInputName . '_update'))
 				{
 					case 'add':


### PR DESCRIPTION
Fixed overrideAll mode not calling load_callback for comparison with old values.
Also see #7669
