### PR TITLE
Fix the Widget::getAttributesFromDca() for "time" rgxp.

### DIFF
--- a/system/modules/core/library/Contao/Widget.php
+++ b/system/modules/core/library/Contao/Widget.php
@@ -1451,7 +1451,7 @@ abstract class Widget extends \BaseTemplate
 		// Convert timestamps
 		if ($varValue != '' && ($arrData['eval']['rgxp'] == 'date' || $arrData['eval']['rgxp'] == 'time' || $arrData['eval']['rgxp'] == 'datim'))
 		{
-			$objDate = new \Date($varValue);
+			$objDate = new \Date($varValue, call_user_func(array('Date', 'getNumeric' . ucfirst($arrData['eval']['rgxp']) . 'Format')));
 			$arrAttributes['value'] = $objDate->{$arrData['eval']['rgxp']};
 		}
 


### PR DESCRIPTION
We have discovered a problem, where a widget with an `rgxp` of "time" refuses to be created.
The problem is, that the `\Date` object is created without format string and therefore uses `date` as fallback.
The result is, that the parsed value is totally wrong (I encountered "00:00:00" for most values) and can even result in a `OutOfBoundsException`.

``` php
\Contao\Config::set('timeFormat', 'H:i:s');
\Contao\Config::set('dateFormat', 'Y-m-d');
\Contao\Config::set('datimFormat', 'Y-m-d H:i:s');

$prepared = Widget::getAttributesFromDca(
array('inputType' => 'text', 'eval' => array('rgxp' => 'time')),
'test',
'12:21'
);
var_dump($prepared['value']);
// Before: string(8) "00:00:00"
// After:  string(8) "12:21:00"

$prepared = Widget::getAttributesFromDca(
array('inputType' => 'text', 'eval' => array('rgxp' => 'time')),
'test',
'12:21:33'
);
var_dump($prepared['value']);
// Before: OutOfBoundsException: Invalid date "11:22:33"
// After:  string(8) "12:21:00"

$prepared = Widget::getAttributesFromDca(
array('inputType' => 'text', 'eval' => array('rgxp' => 'date')),
'test',
'12:21:33'
);
var_dump($prepared['value']);
// Before: OutOfBoundsException: Invalid date "11:22:33"
// After:  OutOfBoundsException: Invalid date "11:22:33"

$prepared = Widget::getAttributesFromDca(
array('inputType' => 'text', 'eval' => array('rgxp' => 'datim')),
'test',
'12:21:11'
);
var_dump($prepared['value']);
// Before: OutOfBoundsException: Invalid date "11:22:33"
// After:  OutOfBoundsException: Invalid date "12:21:11"
```

The behaviour for invalid values is retained but now correct for valid values.
