### PR TITLE
[RTM] Improve model registry

### DIFF
--- a/system/modules/core/dca/tl_files.php
+++ b/system/modules/core/dca/tl_files.php
@@ -146,7 +146,8 @@ $GLOBALS['TL_DCA']['tl_files'] = array
 		),
 		'path' => array
 		(
-			'sql'                     => "varchar(1022) NOT NULL default ''"
+			'eval'                    => array('unique'=>true),
+			'sql'                     => "varchar(1022) NOT NULL default ''",
 		),
 		'extension' => array
 		(

--- a/system/modules/core/library/Contao/DcaExtractor.php
+++ b/system/modules/core/library/Contao/DcaExtractor.php
@@ -513,7 +513,7 @@ class DcaExtractor extends \Controller
 			{
 				$this->arrKeys[$field] = $type;
 
-				if ($type === 'unique')
+				if ($type == 'unique')
 				{
 					$this->arrUniqueFields[] = $field;
 				}

--- a/system/modules/core/library/Contao/DcaExtractor.php
+++ b/system/modules/core/library/Contao/DcaExtractor.php
@@ -69,6 +69,12 @@ class DcaExtractor extends \Controller
 	protected $arrOrderFields = array();
 
 	/**
+	 * Unique fields
+	 * @var array
+	 */
+	protected $arrUniqueFields = array();
+
+	/**
 	 * Keys
 	 * @var array
 	 */
@@ -205,6 +211,28 @@ class DcaExtractor extends \Controller
 	public function hasOrderFields()
 	{
 		return !empty($this->arrOrderFields);
+	}
+
+
+	/**
+	 * Return an array of unique columns
+	 *
+	 * @return array
+	 */
+	public function getUniqueFields()
+	{
+		return $this->arrUniqueFields;
+	}
+
+
+	/**
+	 * Return true if there are unique fields
+	 *
+	 * @return boolean True if there are unique fields
+	 */
+	public function hasUniqueFields()
+	{
+		return !empty($this->arrUniqueFields);
 	}
 
 
@@ -468,6 +496,11 @@ class DcaExtractor extends \Controller
 				{
 					$this->arrOrderFields[] = $config['eval']['orderField'];
 				}
+
+				if (isset($config['eval']['unique']) && $config['eval']['unique'] === true)
+				{
+					$this->arrUniqueFields[] = $field;
+				}
 			}
 		}
 
@@ -479,6 +512,11 @@ class DcaExtractor extends \Controller
 			foreach ($sql['keys'] as $field=>$type)
 			{
 				$this->arrKeys[$field] = $type;
+
+				if ($type === 'unique')
+				{
+					$this->arrUniqueFields[] = $field;
+				}
 			}
 		}
 
@@ -498,6 +536,7 @@ class DcaExtractor extends \Controller
 			}
 		}
 
+		$this->arrUniqueFields = array_unique($this->arrUniqueFields);
 		$this->blnIsDbTable = true;
 	}
 }

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -66,6 +66,12 @@ abstract class Model
 	protected static $strPk = 'id';
 
 	/**
+	 * Class name cache
+	 * @var array
+	 */
+	protected static $arrClassNames = array();
+
+	/**
 	 * Data
 	 * @var array
 	 */
@@ -1140,9 +1146,15 @@ abstract class Model
 	 */
 	public static function getClassFromTable($strTable)
 	{
+		if (isset(static::$arrClassNames[$strTable]))
+		{
+			return static::$arrClassNames[$strTable];
+		}
+
 		if (isset($GLOBALS['TL_MODELS'][$strTable]))
 		{
-			return $GLOBALS['TL_MODELS'][$strTable]; // see 4796
+			static::$arrClassNames[$strTable] = $GLOBALS['TL_MODELS'][$strTable]; // see 4796
+			return static::$arrClassNames[$strTable];
 		}
 		else
 		{
@@ -1153,7 +1165,8 @@ abstract class Model
 				array_shift($arrChunks);
 			}
 
-			return implode('', array_map('ucfirst', $arrChunks)) . 'Model';
+			static::$arrClassNames[$strTable] = implode('', array_map('ucfirst', $arrChunks)) . 'Model';
+			return static::$arrClassNames[$strTable];
 		}
 	}
 

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -273,12 +273,7 @@ abstract class Model
 	{
 		$objDca = \DcaExtractor::getInstance(static::getTable());
 
-		if ($objDca->hasUniqueFields())
-		{
-			return $objDca->getUniqueFields();
-		}
-
-		return array();
+		return $objDca->getUniqueFields();
 	}
 
 

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -710,7 +710,7 @@ abstract class Model
 	public function onRegister(\Model\Registry $registry)
 	{
 		// Register aliases to unique fields
-		foreach ($this->getUniqueFields() as $strColumn)
+		foreach (static::getUniqueFields() as $strColumn)
 		{
 			$varAliasValue = $this->{$strColumn};
 			if (!$registry->isAliasRegistered($this, $strColumn, $varAliasValue))
@@ -729,7 +729,7 @@ abstract class Model
 	public function onUnregister(\Model\Registry $registry)
 	{
 		// Unregister aliases to unique fields
-		foreach ($this->getUniqueFields() as $strColumn)
+		foreach (static::getUniqueFields() as $strColumn)
 		{
 			$varAliasValue = $this->{$strColumn};
 			if ($registry->isAliasRegistered($this, $strColumn, $varAliasValue))

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -703,6 +703,44 @@ abstract class Model
 
 
 	/**
+	 * Called when the model is attached/registered to the model registry
+	 *
+	 * @param \Model\Registry
+	 */
+	public function onRegister(\Model\Registry $registry)
+	{
+		// Register aliases to unique fields
+		foreach ($this->getUniqueFields() as $strColumn)
+		{
+			$varAliasValue = $this->{$strColumn};
+			if (!$registry->isAliasRegistered($this, $strColumn, $varAliasValue))
+			{
+				$registry->registerAlias($this, $strColumn, $varAliasValue);
+			}
+		}
+	}
+
+
+	/**
+	 * Called when the model is detached/unregistered from the model registry
+	 *
+	 * @param \Model\Registry
+	 */
+	public function onUnregister(\Model\Registry $registry)
+	{
+		// Unregister aliases to unique fields
+		foreach ($this->getUniqueFields() as $strColumn)
+		{
+			$varAliasValue = $this->{$strColumn};
+			if ($registry->isAliasRegistered($this, $strColumn, $varAliasValue))
+			{
+				$registry->unregisterAlias($this, $strColumn, $varAliasValue);
+			}
+		}
+	}
+
+
+	/**
 	 * Prevent saving the model
 	 *
 	 * @param boolean $blnKeepClone Keeps a clone of the model in the registry

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -713,7 +713,7 @@ abstract class Model
 		foreach (static::getUniqueFields() as $strColumn)
 		{
 			$varAliasValue = $this->{$strColumn};
-			if (!$registry->isAliasRegistered($this, $strColumn, $varAliasValue))
+			if (!$registry->isRegisteredAlias($this, $strColumn, $varAliasValue))
 			{
 				$registry->registerAlias($this, $strColumn, $varAliasValue);
 			}
@@ -732,7 +732,7 @@ abstract class Model
 		foreach (static::getUniqueFields() as $strColumn)
 		{
 			$varAliasValue = $this->{$strColumn};
-			if ($registry->isAliasRegistered($this, $strColumn, $varAliasValue))
+			if ($registry->isRegisteredAlias($this, $strColumn, $varAliasValue))
 			{
 				$registry->unregisterAlias($this, $strColumn, $varAliasValue);
 			}

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -871,23 +871,6 @@ abstract class Model
 	 */
 	public static function findOneBy($strColumn, $varValue, array $arrOptions=array())
 	{
-		// Try to load from the registry
-		if (empty($arrOptions))
-		{
-			$arrColumn = (array) $strColumn;
-
-			if (count($arrColumn) == 1 && $arrColumn[0] == static::$strPk)
-			{
-				$intId = is_array($varValue) ? $varValue[0] : $varValue;
-				$objModel = \Model\Registry::getInstance()->fetch(static::$strTable, $intId);
-
-				if ($objModel !== null)
-				{
-					return $objModel;
-				}
-			}
-		}
-
 		$arrOptions = array_merge
 		(
 			array
@@ -1020,6 +1003,25 @@ abstract class Model
 		if (static::$strTable == '')
 		{
 			return null;
+		}
+
+		if ($arrOptions['return'] === 'Model')
+		{
+			$arrColumn = (array) $arrOptions['column'];
+
+			if (count($arrColumn) == 1)
+			{
+				if ($arrColumn[0] == static::$strPk || in_array($arrColumn[0], static::getUniqueFields()))
+				{
+					$intId = is_array($arrOptions['value']) ? $arrOptions['value'][0] : $arrOptions['value'];
+					$objModel = \Model\Registry::getInstance()->fetch(static::$strTable, $intId, $arrColumn[0]);
+
+					if ($objModel !== null)
+					{
+						return $objModel;
+					}
+				}
+			}
 		}
 
 		$arrOptions['table'] = static::$strTable;

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -258,6 +258,25 @@ abstract class Model
 
 
 	/**
+	 * Return an array of unique field/column names
+	 * Do not include the PK here as this is handled separately
+	 *
+	 * @return array
+	 */
+	public static function getUniqueFields()
+	{
+		$objDca = \DcaExtractor::getInstance(static::getTable());
+
+		if ($objDca->hasUniqueFields())
+		{
+			return $objDca->getUniqueFields();
+		}
+
+		return array();
+	}
+
+
+	/**
 	 * Return the name of the related table
 	 *
 	 * @return string The table name

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -916,13 +916,22 @@ abstract class Model
 	 */
 	public static function findBy($strColumn, $varValue, array $arrOptions=array())
 	{
+		$blnModel = false;
+
+		$arrColumn = (array) $strColumn;
+
+		if (count($arrColumn) == 1 && ($arrColumn[0] === static::getPk() || in_array($arrColumn[0], static::getUniqueFields())))
+		{
+			$blnModel = true;
+		}
+
 		$arrOptions = array_merge
 		(
 			array
 			(
 				'column' => $strColumn,
 				'value'  => $varValue,
-				'return' => 'Collection'
+				'return' => $blnModel ? 'Model' : 'Collection'
 			),
 
 			$arrOptions

--- a/system/modules/core/library/Contao/Model/Registry.php
+++ b/system/modules/core/library/Contao/Model/Registry.php
@@ -226,4 +226,70 @@ class Registry implements \Countable
 
 		return isset($this->arrIdentities[$intObjectId]);
 	}
+
+
+	/**
+	 * Registers an alias for model
+	 *
+	 * @param \Model $objModel The model object
+	 * @param string $strAlias The alias name
+	 * @param mixed  $varValue The value of the alias
+     *
+     * @throws \InvalidArgumentException If the alias is already registered
+	 */
+	public function registerAlias(\Model $objModel, $strAlias, $varValue)
+	{
+		$strTable = $objModel->getTable();
+		$strPk    = $objModel->getPk();
+		$varPk    = $objModel->$strPk;
+
+		if (isset($this->arrRegistryAliases[$strTable][$strAlias][$varValue]))
+		{
+			throw new \InvalidArgumentException("Cannot register already existing alias for $strTable::$strPk($varPk) (Alias/Value: $strAlias/$varValue)");
+		}
+
+		$this->arrRegistryAliases[$strTable][$strAlias][$varValue] = $varPk;
+	}
+
+
+	/**
+	 * Unregister an alias from the registry
+	 *
+	 * @param \Model $objModel The model object
+	 * @param string $strAlias The alias name
+	 * @param mixed  $varValue The value of the alias
+	 *
+	 * @throws \InvalidArgumentException If the alias is not registered
+	 */
+	public function unregisterAlias(\Model $objModel, $strAlias, $varValue)
+	{
+		$strTable = $objModel->getTable();
+
+		if (!isset($this->arrRegistryAliases[$strTable][$strAlias][$varValue]))
+		{
+			$strPk    = $objModel->getPk();
+			$varPk    = $objModel->$strPk;
+			throw new \InvalidArgumentException("Cannot unregister non-existent alias for $strTable::$strPk($varPk) (Alias/Value: $strAlias/$varValue)");
+		}
+
+		unset($this->arrRegistryAliases[$strTable][$strAlias][$varValue]);
+	}
+
+
+
+	/**
+	 * Check if an alias is registered
+	 *
+	 * @param \Model $objModel The model object
+	 * @param string $strAlias The alias name
+	 * @param mixed  $varValue The value of the alias
+	 *
+	 * @return boolean True if the model is registered
+	 */
+	public function isAliasRegistered(\Model $objModel, $strAlias, $varValue)
+	{
+		$strTable = $objModel->getTable();
+
+		return isset($this->arrRegistryAliases[$strTable][$strAlias][$varValue]);
+	}
 }

--- a/system/modules/core/library/Contao/Model/Registry.php
+++ b/system/modules/core/library/Contao/Model/Registry.php
@@ -280,7 +280,7 @@ class Registry implements \Countable
 	 *
 	 * @return boolean True if the model is registered
 	 */
-	public function isAliasRegistered(\Model $objModel, $strAlias, $varValue)
+	public function isRegisteredAlias(\Model $objModel, $strAlias, $varValue)
 	{
 		$strTable = $objModel->getTable();
 

--- a/system/modules/core/library/Contao/Model/Registry.php
+++ b/system/modules/core/library/Contao/Model/Registry.php
@@ -97,23 +97,12 @@ class Registry implements \Countable
 	 */
 	public function fetch($strTable, $varKey, $strAlias = null)
 	{
-		// Default is searching by PK and is the most common case
-		if ($strAlias === null)
-		{
-			if (isset($this->arrRegistry[$strTable][$varKey]))
-			{
-				return $this->arrRegistry[$strTable][$varKey];
-			}
-
-			return null;
-		}
-
 		/** @var \Model $strClass */
 		$strClass = \Model::getClassFromTable($strTable);
 		$strPk = $strClass::getPk();
 
-		// Possible that one passed an alias that is === $strPk
-		if ($strAlias === $strPk)
+		// Default is searching by PK and is the most common case
+		if ($strAlias === null || $strAlias === $strPk)
 		{
 			if (isset($this->arrRegistry[$strTable][$varKey]))
 			{

--- a/system/modules/core/library/Contao/Model/Registry.php
+++ b/system/modules/core/library/Contao/Model/Registry.php
@@ -91,14 +91,14 @@ class Registry implements \Countable
 	 *
 	 * @param string  $strTable     The table name
 	 * @param mixed   $varKey       The key
-	 * @param string  $strColumn    The column name (by default: PK)
+	 * @param string  $strAlias     An optional alias
 	 *
 	 * @return \Model|null The model or null
 	 */
-	public function fetch($strTable, $varKey, $strColumn = null)
+	public function fetch($strTable, $varKey, $strAlias = null)
 	{
-		// Default is PK and is the most common case
-		if ($strColumn === null)
+		// Default is searching by PK and is the most common case
+		if ($strAlias === null)
 		{
 			if (isset($this->arrRegistry[$strTable][$varKey]))
 			{
@@ -112,8 +112,8 @@ class Registry implements \Countable
 		$strClass = \Model::getClassFromTable($strTable);
 		$strPk = $strClass::getPk();
 
-		// Possible that one passed $strColumn === $strPk
-		if ($strColumn === $strPk)
+		// Possible that one passed an alias that is === $strPk
+		if ($strAlias === $strPk)
 		{
 			if (isset($this->arrRegistry[$strTable][$varKey]))
 			{
@@ -124,9 +124,9 @@ class Registry implements \Countable
 		}
 
 		// Try to find in aliases
-		if (isset($this->arrRegistryAliases[$strTable][$strColumn][$varKey]))
+		if (isset($this->arrRegistryAliases[$strTable][$strAlias][$varKey]))
 		{
-			$strPk = $this->arrRegistryAliases[$strTable][$strColumn][$varKey];
+			$strPk = $this->arrRegistryAliases[$strTable][$strAlias][$varKey];
 
 			if (isset($this->arrRegistry[$strTable][$strPk]))
 			{

--- a/system/modules/core/library/Contao/Model/Registry.php
+++ b/system/modules/core/library/Contao/Model/Registry.php
@@ -175,11 +175,8 @@ class Registry implements \Countable
 		$this->arrIdentities[$intObjectId] = $objModel;
 		$this->arrRegistry[$strTable][$varPk] = $objModel;
 
-		// Also store aliases
-		foreach ($objModel->getUniqueFields() as $strColumn)
-		{
-			$this->arrRegistryAliases[$strTable][$strColumn][$objModel->$strColumn] = $varPk;
-		}
+		// Allow the model to modify the registry
+		$objModel->onRegister($this);
 	}
 
 
@@ -205,11 +202,8 @@ class Registry implements \Countable
 		unset($this->arrIdentities[$intObjectId]);
 		unset($this->arrRegistry[$strTable][$intPk]);
 
-		// Unset aliases
-		foreach ($objModel->getUniqueFields() as $strColumn)
-		{
-			unset($this->arrRegistryAliases[$strTable][$strColumn][$objModel->$strColumn]);
-		}
+		// Allow the model to modify the registry
+		$objModel->onUnregister($this);
 	}
 
 

--- a/system/modules/core/library/Contao/Model/Registry.php
+++ b/system/modules/core/library/Contao/Model/Registry.php
@@ -89,9 +89,9 @@ class Registry implements \Countable
 	/**
 	 * Fetch a model by table name and primary key
 	 *
-	 * @param string  $strTable     The table name
-	 * @param mixed   $varKey       The key
-	 * @param string  $strAlias     An optional alias
+	 * @param string  $strTable The table name
+	 * @param mixed   $varKey   The key
+	 * @param string  $strAlias An optional alias
 	 *
 	 * @return \Model|null The model or null
 	 */

--- a/system/modules/core/library/Contao/Model/Registry.php
+++ b/system/modules/core/library/Contao/Model/Registry.php
@@ -113,9 +113,24 @@ class Registry implements \Countable
 		}
 
 		// Try to find in aliases
-		if (isset($this->arrRegistryAliases[$strTable][$strAlias][$varKey]))
+        return $this->fetchByAlias($strTable, $strAlias, $varKey);
+	}
+
+
+	/**
+	 * Fetch a model by an alias
+	 *
+	 * @param string  $strTable The table name
+	 * @param string  $strAlias The alias
+	 * @param mixed   $varValue The alias value
+	 *
+	 * @return \Model|null The model or null
+	 */
+	public function fetchByAlias($strTable, $strAlias, $varValue)
+	{
+		if (isset($this->arrRegistryAliases[$strTable][$strAlias][$varValue]))
 		{
-			$strPk = $this->arrRegistryAliases[$strTable][$strAlias][$varKey];
+			$strPk = $this->arrRegistryAliases[$strTable][$strAlias][$varValue];
 
 			if (isset($this->arrRegistry[$strTable][$strPk]))
 			{


### PR DESCRIPTION
This is my PR to solve #7724 and even more!

Currently, our model registry only allows to register models by their PK which in general is `id`. This causes useless DB queries in a lot of circumstances. The one mentioned in #7724 was `tl_files.path` which is actually unique as well and currently when executing `FilesModel::findByPath('path')` 20 times, there will be 20 queries to the database even though it's always the same.

Note that this happens quite often since Contao 3.4, because our `Image` class does that for every image to check if an important part is set.

Now instead of just solving this issue I tried to find a general solution for those cases :-)
The model registry can now handle aliases that internally point to the ID again.
Let's say we have this in `tl_files`:

| id | path |
| --- | --- |
| 42 | path_to_my_file.jpg |

In Contao 3.4 **AND** my PR (= so it's fully backwards compatible) you can fetch the model from the registry via its ID:

``` php
Model\Registry::getInstance()->fetch('tl_files', 42);
```

With this PR you can now also do this:

``` php
Model\Registry::getInstance()->fetch('tl_files', 'path_to_my_file.jpg', 'path');
```

And thanks to the modifications on the `DcaExtractor` this **automatically** works for all fields that are unique either because of the SQL key definition:

``` php
'sql' => array
(
    'keys' => array
    (
        'uuid' => 'unique'
    )
)
```

or the `eval` section of the field itself:

``` php
'path' => array
(
    'eval'                    => array('unique'=>true),
    'sql'                     => "varchar(1022) NOT NULL default ''",
),
```

Every developer can either do that or override the `getUniqueFields()` method in their model class for full flexibility.

:tada: 
