### PR TITLE
Reset new fields to empty on version restore

### DIFF
--- a/system/modules/core/classes/Versions.php
+++ b/system/modules/core/classes/Versions.php
@@ -252,6 +252,13 @@ class Versions extends \Controller
 				// Unset fields that do not exist (see #5219)
 				$data = array_intersect_key($data, $arrFields);
 
+				// Reset fields added after storing the version to their default value
+				$this->loadDataContainer($this->strTable);
+				foreach (array_diff_key($arrFields, $data) as $k => $v)
+				{
+					$data[$k] = \Widget::getEmptyValueByFieldType($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['sql']);
+				}
+
 				$this->Database->prepare("UPDATE " . $objData->fromTable . " %s WHERE id=?")
 							   ->set($data)
 							   ->execute($this->intPid);

--- a/system/modules/core/classes/Versions.php
+++ b/system/modules/core/classes/Versions.php
@@ -250,13 +250,7 @@ class Versions extends \Controller
 				$arrFields = array_flip($this->Database->getFieldnames($this->strTable));
 
 				// Unset fields that do not exist (see #5219)
-				foreach (array_keys($data) as $k)
-				{
-					if (!isset($arrFields[$k]))
-					{
-						unset($data[$k]);
-					}
-				}
+				$data = array_intersect_key($data, $arrFields);
 
 				$this->Database->prepare("UPDATE " . $objData->fromTable . " %s WHERE id=?")
 							   ->set($data)


### PR DESCRIPTION
If a field is added after storing a version of a record, it's value will stay when restoring. That's incorrect as the version did not contain that value.

see https://github.com/isotope/core/issues/1408#issuecomment-90911149
