### PR TITLE
Reset the file pointer when truncating the file

### DIFF
--- a/system/modules/core/library/Contao/File.php
+++ b/system/modules/core/library/Contao/File.php
@@ -401,7 +401,7 @@ class File extends \System
 
 
 	/**
-	 * Truncate the file
+	 * Truncate the file and reset file pointer
 	 *
 	 * @return boolean True if the operation was successful
 	 */
@@ -410,6 +410,7 @@ class File extends \System
 		if (is_resource($this->resFile))
 		{
 			ftruncate($this->resFile, 0);
+            rewind($this->resFile);
 		}
 
 		return $this->write('');

--- a/system/modules/core/library/Contao/File.php
+++ b/system/modules/core/library/Contao/File.php
@@ -410,7 +410,7 @@ class File extends \System
 		if (is_resource($this->resFile))
 		{
 			ftruncate($this->resFile, 0);
-            rewind($this->resFile);
+			rewind($this->resFile);
 		}
 
 		return $this->write('');


### PR DESCRIPTION
Here is the issue:

``` php
$file = new \File('test.txt');
$file->write('foobar');
dump($file->getContent());
$file->truncate();
$file->write('foobaz');
dump($file->getContent());
```

produces:

```
string(6) "foobar"
string(12) "foobaz"
```

So even if the file is being truncated, the file pointer remains at the old place. Thus the next write produces an empty binary string in front of the file (which is length of the previous file content).
