### PR TITLE
Versions::create Description aus $objRecord->subject

### DIFF
--- a/system/modules/core/classes/Versions.php
+++ b/system/modules/core/classes/Versions.php
@@ -203,6 +203,10 @@ class Versions extends \Controller
 		{
 			$strDescription = $objRecord->selector;
 		}
+		elseif (isset($objRecord->subject))
+		{
+			$strDescription = $objRecord->subject;
+		}
 
 		$this->Database->prepare("UPDATE tl_version SET active='' WHERE pid=? AND fromTable=?")
 					   ->execute($this->intPid, $this->strTable);


### PR DESCRIPTION
Bei Versionen zur Tabelle tl_newsletter fehlt bisher die Beschreibung.
