### PR TITLE
Validate coordinates in Image::setImportantPart()

### DIFF
--- a/system/modules/core/library/Contao/Image.php
+++ b/system/modules/core/library/Contao/Image.php
@@ -166,9 +166,21 @@ class Image
 			{
 				throw new \InvalidArgumentException('Malformed array for setting the important part!');
 			}
+
+			$this->importantPart = array
+			(
+				'x' => max(0, min($this->fileObj->width - 1, (int) $importantPart['x'])),
+				'y' => max(0, min($this->fileObj->height - 1, (int) $importantPart['y'])),
+			);
+			$this->importantPart['width'] = max(1, min($this->fileObj->width - $this->importantPart['x'], (int) $importantPart['width']));
+			$this->importantPart['height'] = max(1, min($this->fileObj->height - $this->importantPart['y'], (int) $importantPart['height']));
+
 		}
 
-		$this->importantPart = $importantPart;
+		else
+		{
+			$this->importantPart = null;
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
Currently an invalid important part results in wrong resized images e.g. with black areas. This pull request fixes that issue.
