### PR TITLE
Fix method indexFreeRequest

### DIFF
--- a/system/modules/core/library/Contao/Environment.php
+++ b/system/modules/core/library/Contao/Environment.php
@@ -446,14 +446,7 @@ class Environment
 	 */
 	protected static function indexFreeRequest()
 	{
-		$strRequest = static::get('request');
-
-		if ($strRequest == 'index.php')
-		{
-			return '';
-		}
-
-		return $strRequest;
+		return preg_replace('/index.php(\/)?/', '', static::get('request'));
 	}
 
 


### PR DESCRIPTION
This PR fixes the method `\Environment::get('indexFreeRequest')`.

Before, the method did just nothing when `$strRequest` wasn't matching `index.php`:

``` php
protected static function indexFreeRequest()
    {
        $strRequest = static::get('request');

        if ($strRequest == 'index.php')
        {
            return '';
        }

        return $strRequest;
    }
```
