### PR TITLE
Support dimensionless SVG images

### DIFF
--- a/system/modules/core/classes/DataContainer.php
+++ b/system/modules/core/classes/DataContainer.php
@@ -511,7 +511,7 @@ abstract class DataContainer extends \Backend
 
 				if ($objFile->isSvgImage || $objFile->height <= \Config::get('gdMaxImgHeight') && $objFile->width <= \Config::get('gdMaxImgWidth'))
 				{
-					if ($objFile->width > 699 || $objFile->height > 524)
+					if ($objFile->width > 699 || $objFile->height > 524 || !$objFile->width || !$objFile->height)
 					{
 						$image = \Image::get($objFile->path, 699, 524, 'box');
 					}
@@ -525,7 +525,7 @@ abstract class DataContainer extends \Backend
 
 				$strPreview = '
 
-<div id="' . $ctrl . '" class="tl_edit_preview" data-original-width="' . $objFile->width . '" data-original-height="' . $objFile->height . '">
+<div id="' . $ctrl . '" class="tl_edit_preview" data-original-width="' . $objFile->viewWidth . '" data-original-height="' . $objFile->viewHeight . '">
 ' . \Image::getHtml($image) . '
 </div>';
 

--- a/system/modules/core/drivers/DC_Folder.php
+++ b/system/modules/core/drivers/DC_Folder.php
@@ -2395,8 +2395,17 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 			// Generate the thumbnail
 			if ($objFile->isImage && $objFile->viewHeight > 0)
 			{
-				$popupWidth = ($objFile->width > 600) ? ($objFile->width + 61) : 661;
-				$popupHeight = ($objFile->height + 200);
+				if ($objFile->width && $objFile->height)
+				{
+					$popupWidth = ($objFile->width > 600) ? ($objFile->width + 61) : 661;
+					$popupHeight = ($objFile->height + 210);
+				}
+				else
+				{
+					$popupWidth = 661;
+					$popupHeight = 625 / $objFile->viewWidth * $objFile->viewHeight + 210;
+				}
+
 				$thumbnail .= ' <span class="tl_gray">('.$this->getReadableSize($objFile->filesize);
 				if ($objFile->width && $objFile->height)
 				{
@@ -2413,6 +2422,10 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 			}
 			else
 			{
+				if ($objFile->isImage)
+				{
+					$popupHeight = 360;
+				}
 				$thumbnail .= ' <span class="tl_gray">('.$this->getReadableSize($objFile->filesize).')</span>';
 			}
 

--- a/system/modules/core/drivers/DC_Folder.php
+++ b/system/modules/core/drivers/DC_Folder.php
@@ -2393,18 +2393,22 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 			$return .= "\n  " . '<li class="tl_file click2edit toggle_select" onmouseover="Theme.hoverDiv(this,1)" onmouseout="Theme.hoverDiv(this,0)"><div class="tl_left" style="padding-left:'.($intMargin + $intSpacing).'px">';
 
 			// Generate the thumbnail
-			if ($objFile->isImage && $objFile->height > 0)
+			if ($objFile->isImage && $objFile->viewHeight > 0)
 			{
 				$popupWidth = ($objFile->width > 600) ? ($objFile->width + 61) : 661;
 				$popupHeight = ($objFile->height + 200);
-				$thumbnail .= ' <span class="tl_gray">('.$this->getReadableSize($objFile->filesize).', '.$objFile->width.'x'.$objFile->height.' px)</span>';
+				$thumbnail .= ' <span class="tl_gray">('.$this->getReadableSize($objFile->filesize);
+				if ($objFile->width && $objFile->height)
+				{
+					$thumbnail .= ', '.$objFile->width.'x'.$objFile->height.' px';
+				}
+				$thumbnail .= ')</span>';
 
 				if (\Config::get('thumbnails') && ($objFile->isSvgImage || $objFile->height <= \Config::get('gdMaxImgHeight') && $objFile->width <= \Config::get('gdMaxImgWidth')))
 				{
-					$_height = ($objFile->height < 50) ? $objFile->height : 50;
-					$_width = (($objFile->width * $_height / $objFile->height) > 400) ? 90 : '';
+					$_height = ($objFile->height && $objFile->height < 50) ? $objFile->height : 50;
 
-					$thumbnail .= '<br><img src="' . TL_FILES_URL . \Image::get($currentEncoded, $_width, $_height) . '" alt="" style="margin:0 0 2px -19px">';
+					$thumbnail .= '<br><img src="' . TL_FILES_URL . \Image::get($currentEncoded, 400, $_height, 'box') . '" alt="" style="margin:0 0 2px -19px">';
 				}
 			}
 			else

--- a/system/modules/core/library/Contao/File.php
+++ b/system/modules/core/library/Contao/File.php
@@ -272,22 +272,12 @@ class File extends \System
 
 						$svgElement = $doc->documentElement;
 
-						if ($svgElement->getAttribute('width') && $svgElement->getAttribute('height'))
+						if ($svgElement->getAttribute('width') && $svgElement->getAttribute('height') && substr(rtrim($svgElement->getAttribute('width')), -1) !== '%' && substr(rtrim($svgElement->getAttribute('height')), -1) !== '%')
 						{
 							$this->arrImageSize = array
 							(
 								\Image::getPixelValue($svgElement->getAttribute('width')),
 								\Image::getPixelValue($svgElement->getAttribute('height'))
-							);
-						}
-						elseif ($svgElement->getAttribute('viewBox'))
-						{
-							$svgViewBox = preg_split('/[\s,]+/', $svgElement->getAttribute('viewBox'));
-
-							$this->arrImageSize = array
-							(
-								\Image::getPixelValue($svgViewBox[2]),
-								\Image::getPixelValue($svgViewBox[3])
 							);
 						}
 
@@ -314,6 +304,59 @@ class File extends \System
 
 			case 'height':
 				return $this->imageSize[1];
+				break;
+
+			case 'imageViewSize':
+				if (empty($this->arrImageViewSize))
+				{
+					if ($this->imageSize) {
+						$this->arrImageViewSize = array
+						(
+							$this->imageSize[0],
+							$this->imageSize[1]
+						);
+					}
+					elseif ($this->isSvgImage)
+					{
+						$doc = new \DOMDocument();
+
+						if ($this->extension == 'svgz')
+						{
+							$doc->loadXML(gzdecode($this->getContent()));
+						}
+						else
+						{
+							$doc->loadXML($this->getContent());
+						}
+
+						$svgElement = $doc->documentElement;
+
+						if ($svgElement->getAttribute('viewBox'))
+						{
+							$svgViewBox = preg_split('/[\s,]+/', $svgElement->getAttribute('viewBox'));
+
+							$this->arrImageViewSize = array
+							(
+								intval($svgViewBox[2]),
+								intval($svgViewBox[3])
+							);
+						}
+
+						if (!$this->arrImageViewSize || !$this->arrImageViewSize[0] || !$this->arrImageViewSize[1])
+						{
+							$this->arrImageViewSize = false;
+						}
+					}
+				}
+				return $this->arrImageViewSize;
+				break;
+
+			case 'viewWidth':
+				return $this->imageViewSize[0];
+				break;
+
+			case 'viewHeight':
+				return $this->imageViewSize[1];
 				break;
 
 			case 'isImage':

--- a/system/modules/core/library/Contao/Image.php
+++ b/system/modules/core/library/Contao/Image.php
@@ -954,7 +954,7 @@ class Image
 
 
 	/**
-	 * Convert sizes like 2em, 10% or 12pt to pixels
+	 * Convert sizes like 2em, 10cm or 12pt to pixels
 	 *
 	 * @param string $size The size string
 	 *
@@ -1002,6 +1002,7 @@ class Image
 				break;
 
 			case '%':
+				trigger_error('Using Image::getPixelValue() with a percentage value has been deprecated and will no longer work in Contao 5.0.', E_USER_DEPRECATED);
 				return (int) round($value * 16 / 100);
 				break;
 		}

--- a/system/modules/core/widgets/FileSelector.php
+++ b/system/modules/core/widgets/FileSelector.php
@@ -359,16 +359,18 @@ class FileSelector extends \Widget
 				$return .= "\n    " . '<li class="tl_file toggle_select" onmouseover="Theme.hoverDiv(this, 1)" onmouseout="Theme.hoverDiv(this, 0)"><div class="tl_left" style="padding-left:'.($intMargin + $intSpacing).'px">';
 
 				// Generate thumbnail
-				if ($objFile->isImage && $objFile->height > 0)
+				if ($objFile->isImage && $objFile->viewHeight > 0)
 				{
-					$thumbnail .= ' <span class="tl_gray">(' . $objFile->width . 'x' . $objFile->height . ')</span>';
+					if ($objFile->width && $objFile->height)
+					{
+						$thumbnail .= ' <span class="tl_gray">(' . $objFile->width . 'x' . $objFile->height . ')</span>';
+					}
 
 					if (\Config::get('thumbnails') && ($objFile->isSvgImage || $objFile->height <= \Config::get('gdMaxImgHeight') && $objFile->width <= \Config::get('gdMaxImgWidth')))
 					{
-						$_height = ($objFile->height < 50) ? $objFile->height : 50;
-						$_width = (($objFile->width * $_height / $objFile->height) > 400) ? 90 : '';
+						$_height = ($objFile->height && $objFile->height < 50) ? $objFile->height : 50;
 
-						$thumbnail .= '<br><img src="' . TL_FILES_URL . \Image::get($currentEncoded, $_width, $_height) . '" alt="" style="margin:0 0 2px -19px">';
+						$thumbnail .= '<br><img src="' . TL_FILES_URL . \Image::get($currentEncoded, 400, $_height, 'box') . '" alt="" style="margin:0 0 2px -19px">';
 					}
 				}
 

--- a/system/modules/core/widgets/FileTree.php
+++ b/system/modules/core/widgets/FileTree.php
@@ -169,7 +169,7 @@ class FileTree extends \Widget
 							{
 								$image = 'placeholder.png';
 
-								if ($objFile->isSvgImage || $objFile->height <= \Config::get('gdMaxImgHeight') && $objFile->width <= \Config::get('gdMaxImgWidth'))
+								if (($objFile->isSvgImage || $objFile->height <= \Config::get('gdMaxImgHeight') && $objFile->width <= \Config::get('gdMaxImgWidth')) && $objFile->viewWidth && $objFile->viewHeight)
 								{
 									$image = \Image::get($objFiles->path, 80, 60, 'center_center');
 								}
@@ -213,7 +213,7 @@ class FileTree extends \Widget
 									{
 										$image = 'placeholder.png';
 
-										if ($objFile->isSvgImage || $objFile->height <= \Config::get('gdMaxImgHeight') && $objFile->width <= \Config::get('gdMaxImgWidth'))
+										if (($objFile->isSvgImage || $objFile->height <= \Config::get('gdMaxImgHeight') && $objFile->width <= \Config::get('gdMaxImgWidth')) && $objFile->viewWidth && $objFile->viewHeight)
 										{
 											$image = \Image::get($objSubfiles->path, 80, 60, 'center_center');
 										}
@@ -243,7 +243,7 @@ class FileTree extends \Widget
 								{
 									$image = 'placeholder.png';
 
-									if ($objFile->isSvgImage || $objFile->height <= \Config::get('gdMaxImgHeight') && $objFile->width <= \Config::get('gdMaxImgWidth'))
+									if (($objFile->isSvgImage || $objFile->height <= \Config::get('gdMaxImgHeight') && $objFile->width <= \Config::get('gdMaxImgWidth')) && $objFile->viewWidth && $objFile->viewHeight)
 									{
 										$image = \Image::get($objFiles->path, 80, 60, 'center_center');
 									}


### PR DESCRIPTION
There are three types of SVG images regarding dimensions:
1. Fixed dimensions via `width` and `height` in `em`, `ex`, `px`, `pt`, `pc`, `cm`, `mm`, `in` or unitless but not percentage-based.
2. A defined `viewBox` but no or a percentage-based `width` and `height`.
3. No `viewBox` and no or a percentage-based `width` and `height`.

This is how the browsers handles them if you use `<img src="image.svg">`:
1. Shows the image in the specified dimensions.
2. Resizes the image to 100% width and preserves the aspect ratio.
3. Displays the image in the dimensions 300x150

IMO `Image->imageSize` should only work for the first type. Resizing should work for type 1 and 2 because we have a defined aspect ratio. Resizing type 3 should just return the original file.
## What’s in this pull request

`Image->imageSize` now only works for GD images and SVG images of type 1.

Added `Image->imageViewSize` which returns the dimensions of `imageSize` if available or the dimensions of `viewBox` otherwise.

Changed image resizing to work with type 1 and 2 and doesn’t resize type 3.

Updated `Image::getPixelValue()` to `16px = 1em = 2ex = 12pt = 1pc = 1/6in = 2.54/6cm = 25.4/6mm = 100%` but didn’t remove the `%` because this would be a BC break, right? We should remove it in 4.1.0 though.

Updated file manager to work with type 2 and 3.

/cc @toflar
