### PR TITLE
New Function in FilesModel to list Subfolders

### DIFF
--- a/system/modules/core/library/Contao/Automator.php
+++ b/system/modules/core/library/Contao/Automator.php
@@ -114,9 +114,9 @@ class Automator extends \System
 	public function purgeSystemLog()
 	{
 		// HOOK: call before purge
-		if (isset($GLOBALS['TL_HOOKS']['beforeLogPurge']) && is_array($GLOBALS['TL_HOOKS']['beforeLogPurge']))
+		if (isset($GLOBALS['TL_HOOKS']['purgeSystemLog']) && is_array($GLOBALS['TL_HOOKS']['purgeSystemLog']))
 		{
-			foreach ($GLOBALS['TL_HOOKS']['beforeLogPurge'] as $callback)
+			foreach ($GLOBALS['TL_HOOKS']['purgeSystemLog'] as $callback)
 			{
 				$this->import($callback[0]);
 				$this->$callback[0]->$callback[1]();

--- a/system/modules/core/library/Contao/Automator.php
+++ b/system/modules/core/library/Contao/Automator.php
@@ -113,8 +113,6 @@ class Automator extends \System
 	 */
 	public function purgeSystemLog()
 	{
-		$objDatabase = \Database::getInstance();
-
 		// HOOK: call before purge
 		if (isset($GLOBALS['TL_HOOKS']['beforeLogPurge']) && is_array($GLOBALS['TL_HOOKS']['beforeLogPurge']))
 		{
@@ -124,6 +122,8 @@ class Automator extends \System
 				$this->$callback[0]->$callback[1]();
 			}
 		}
+		
+		$objDatabase = \Database::getInstance();
 
 		// Truncate the table
 		$objDatabase->execute("TRUNCATE TABLE tl_log");

--- a/system/modules/core/library/Contao/Automator.php
+++ b/system/modules/core/library/Contao/Automator.php
@@ -115,6 +115,16 @@ class Automator extends \System
 	{
 		$objDatabase = \Database::getInstance();
 
+		// HOOK: call before purge
+		if (isset($GLOBALS['TL_HOOKS']['beforeLogPurge']) && is_array($GLOBALS['TL_HOOKS']['beforeLogPurge']))
+		{
+			foreach ($GLOBALS['TL_HOOKS']['beforeLogPurge'] as $callback)
+			{
+				$this->import($callback[0]);
+				$this->$callback[0]->$callback[1]();
+			}
+		}
+
 		// Truncate the table
 		$objDatabase->execute("TRUNCATE TABLE tl_log");
 

--- a/system/modules/core/library/Contao/Automator.php
+++ b/system/modules/core/library/Contao/Automator.php
@@ -113,15 +113,6 @@ class Automator extends \System
 	 */
 	public function purgeSystemLog()
 	{
-		// HOOK: call before purge
-		if (isset($GLOBALS['TL_HOOKS']['purgeSystemLog']) && is_array($GLOBALS['TL_HOOKS']['purgeSystemLog']))
-		{
-			foreach ($GLOBALS['TL_HOOKS']['purgeSystemLog'] as $callback)
-			{
-				$this->import($callback[0]);
-				$this->$callback[0]->$callback[1]();
-			}
-		}
 		
 		$objDatabase = \Database::getInstance();
 

--- a/system/modules/core/models/FilesModel.php
+++ b/system/modules/core/models/FilesModel.php
@@ -320,6 +320,22 @@ class FilesModel extends \Model
 
 		return static::findBy(array("$t.type='file' AND $t.path LIKE ? AND $t.path NOT LIKE ?"), array($strPath.'/%', $strPath.'/%/%'), $arrOptions);
 	}
+	
+	/**
+	 * Find all folder in a folder
+	 *
+	 * @param string $strPath    The folder path
+	 * @param array  $arrOptions An optional options array
+	 *
+	 * @return \Model\Collection|\FilesModel|null A collection of models or null if there are no matching files
+	 */
+	public static function findMultipleFoldersByFolder($strPath, array $arrOptions=array())
+	{
+		$t = static::$strTable;
+		$strPath = str_replace(array('%', '_'), array('\\%', '\\_'), $strPath);
+
+		return static::findBy(array("$t.type='folder' AND $t.path LIKE ? AND $t.path NOT LIKE ?"), array($strPath.'/%', $strPath.'/%/%'), $arrOptions);
+	}
 
 
 	/**


### PR DESCRIPTION
This would be very usefull if you want to make sure all log entries are stored to a file before cleaning the log.
Many companies have to keep log-files, but dont want the log table to get full.
I have created a log-rotation module, that does that. But the log could be purged before beeing saved to file...

Here is the sorce of my module (unfinished and a little bit insecure up to now..):
https://github.com/christianromeni/cLogRotate

Also, there is only the option to look for multiple files in a folder, but not for multiple folders. This would be a nice feature to look for subfolders. maybe this could be extended to be recursive as well..
