### PR TITLE
Update robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -11,3 +11,4 @@ Disallow: /composer.lock
 Disallow: /README.md
 Allow: /system/cron/cron.txt
 Allow: /system/modules/*/assets/
+Allow: /system/modules/*/html/


### PR DESCRIPTION
fix #7943 

Quote:
Some still working extensions use the non standard `/system/modules/*/html/` folder for assets. Actually Google send some mails that the bot can't crawl to this ressource. We block this with the line `Disallow: /system/`.

It is useful to add `Allow: /system/modules/*/html/` to the robots.txt.
