### PR TITLE
Correctly return the target path if one is set

### DIFF
--- a/system/modules/core/library/Contao/Image.php
+++ b/system/modules/core/library/Contao/Image.php
@@ -449,7 +449,7 @@ class Image
 			{
 				if (file_exists(TL_ROOT . '/' . $this->getTargetPath()) && $this->fileObj->mtime <= filemtime(TL_ROOT . '/' . $this->getTargetPath()))
 				{
-					$this->resizedPath = \System::urlEncode($this->getOriginalPath());
+					$this->resizedPath = \System::urlEncode($this->getTargetPath());
 
 					return $this;
 				}


### PR DESCRIPTION
The current code always returns the original image path if the target path is overridden, which makes the whole functionality unuseable.

According to @Toflar this was already fixed some time ago but apparently re-appeared for unknown reason. I encountered this bug in Contao 4.0.3 so we need to fix both ;-)
