### PR TITLE
Support post arrays for {{post::*}} InsertTag

### DIFF
--- a/system/modules/core/library/Contao/InsertTags.php
+++ b/system/modules/core/library/Contao/InsertTags.php
@@ -1205,6 +1205,29 @@ class InsertTags extends \Controller
 							$arrCache[$strTag] = \System::getReadableSize($arrCache[$strTag]);
 							break;
 
+						case 'flatten':
+							if (!is_array($arrCache[$strTag]))
+							{
+								break;
+							}
+
+							$it = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($arrCache[$strTag]));
+							$result = array();
+
+							foreach ($it as $leafValue)
+							{
+								$keys = array();
+								foreach (range(0, $it->getDepth()) as $depth)
+								{
+									$keys[] = $it->getSubIterator($depth)->key();
+								}
+
+								$result[] = implode('.', $keys) . ': ' . $leafValue;
+							}
+
+							$arrCache[$strTag] = implode(', ', $result);
+							break;
+
 						// HOOK: pass unknown flags to callback functions
 						default:
 							if (isset($GLOBALS['TL_HOOKS']['insertTagFlags']) && is_array($GLOBALS['TL_HOOKS']['insertTagFlags']))


### PR DESCRIPTION
At the moment I cannot output a simple checkbox wizard form field value on the confirmation page of a form. I know the array is not handled recursively but I don't know if this is needed. However, I think simple arrays should be supported and I even consider this a bug because right now it simply outputs `Array` which is complete nonsense :-)
