### PR TITLE
Don' t ignore the custom template in image hyperlinks (fixes #7964)

### DIFF
--- a/system/modules/core/elements/ContentHyperlink.php
+++ b/system/modules/core/elements/ContentHyperlink.php
@@ -64,8 +64,10 @@ class ContentHyperlink extends \ContentElement
 			}
 			elseif (is_file(TL_ROOT . '/' . $objModel->path))
 			{
+				$strTemplate = ($this->customTpl != '') ? $this->customTpl : 'ce_hyperlink_image';
+
 				/** @var \FrontendTemplate|object $objTemplate */
-				$objTemplate = new \FrontendTemplate('ce_hyperlink_image');
+				$objTemplate = new \FrontendTemplate($strTemplate);
 
 				$this->Template = $objTemplate;
 				$this->Template->setData($this->arrData);


### PR DESCRIPTION
Using the custom templates if provided, when generating an image hyperlink template.
