### PR TITLE
convertRelativeUrls - don't convert tel: & sms: in href

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -1187,7 +1187,7 @@ abstract class Controller extends \System
 			$strAttribute = $arrUrls[$i+2];
 			$strUrl = $arrUrls[$i+3];
 
-			if (!preg_match('@^(https?://|ftp://|mailto:|#)@i', $strUrl))
+			if (!preg_match('@^(https?://|ftp://|mailto:|tel:|sms:|#)@i', $strUrl))
 			{
 				$strUrl = $strBase . (($strUrl != '/') ? $strUrl : '');
 			}


### PR DESCRIPTION
... alternatively we could use a const or else so we are able to put search params in a config
