### PR TITLE
Update core-uncompressed.js

### DIFF
--- a/assets/contao/js/core-uncompressed.js
+++ b/assets/contao/js/core-uncompressed.js
@@ -934,7 +934,7 @@ var Backend =
 				field.value = val.join(',');
 				// #8103 explain returnCallback()
 				if (opt.returnCallback instanceof Function) {
-				    field.value = returnCallback(field.value);
+				    field.value = opt.returnCallback(field.value);
 				} else if (frm.document.location.href.indexOf('contao/page.php') != -1) {
 				    field.value = '{{link_url::' + field.value + '}}';
 				}

--- a/assets/contao/js/core-uncompressed.js
+++ b/assets/contao/js/core-uncompressed.js
@@ -914,7 +914,7 @@ var Backend =
 		M.addButton(Contao.lang.apply, 'btn primary', function() {
 			var frm = window.frames['simple-modal-iframe'],
 				val = [], 
-				inp, field, i, insTagStr, addDefaultInsTag;
+				inp, field, i;
 			if (frm === undefined) {
 				alert('Could not find the SimpleModal frame');
 				return;
@@ -925,17 +925,18 @@ var Backend =
 			}
 			inp 	= frm.document.getElementById('tl_select').getElementsByTagName('input');
 			field 	= (opt.tag)? $(opt.tag): $('ctrl_' + opt.id);
-			//new opt.insTagStr
-			addDefaultInsTag = (opt.insTagStr!='')? true: false;
-			insTagStr 	 = (opt.insTagStr)? opt.insTagStr: 'link_url';
+			
 			for (i=0; i<inp.length; i++) {
 				if (!inp[i].checked || inp[i].id.match(/^check_all_/)) continue;
 				if (!inp[i].id.match(/^reset_/)) val.push(inp[i].get('value'));
 			}
 			if (opt.tag) {
 				field.value = val.join(',');
-				if ((frm.document.location.href.indexOf('contao/page.php') != -1) && addDefaultInsTag === true) {
-					field.value = '{{'+insTagStr+'::' + field.value + '}}';
+				// #8103 explain returnCallback()
+				if (opt.returnCallback instanceof Function) {
+				    field.value = returnCallback(field.value);
+				} else if (frm.document.location.href.indexOf('contao/page.php') != -1) {
+				    field.value = '{{link_url::' + field.value + '}}';
 				}
 				opt.self.set('href', opt.self.get('href').replace(/&value=[^&]*/, '&value='+val.join(',')));
 			} else {

--- a/assets/contao/js/core-uncompressed.js
+++ b/assets/contao/js/core-uncompressed.js
@@ -913,7 +913,8 @@ var Backend =
 		});
 		M.addButton(Contao.lang.apply, 'btn primary', function() {
 			var frm = window.frames['simple-modal-iframe'],
-				val = [], inp, field, i;
+				val = [], 
+				inp, field, i, insTagStr, addDefaultInsTag;
 			if (frm === undefined) {
 				alert('Could not find the SimpleModal frame');
 				return;
@@ -922,19 +923,22 @@ var Backend =
 				alert(Contao.lang.picker);
 				return; // see #5704
 			}
-			inp = frm.document.getElementById('tl_select').getElementsByTagName('input');
+			inp 	= frm.document.getElementById('tl_select').getElementsByTagName('input');
+			field 	= (opt.tag)? $(opt.tag): $('ctrl_' + opt.id);
+			//new opt.insTagStr
+			addDefaultInsTag = (opt.insTagStr!='')? true: false;
+			insTagStr 	 = (opt.insTagStr)? opt.insTagStr: 'link_url';
 			for (i=0; i<inp.length; i++) {
 				if (!inp[i].checked || inp[i].id.match(/^check_all_/)) continue;
 				if (!inp[i].id.match(/^reset_/)) val.push(inp[i].get('value'));
 			}
 			if (opt.tag) {
-				$(opt.tag).value = val.join(',');
-				if (frm.document.location.href.indexOf('contao/page.php') != -1) {
-					$(opt.tag).value = '{{link_url::' + $(opt.tag).value + '}}';
+				field.value = val.join(',');
+				if ((frm.document.location.href.indexOf('contao/page.php') != -1) && addDefaultInsTag === true) {
+					field.value = '{{'+insTagStr+'::' + field.value + '}}';
 				}
 				opt.self.set('href', opt.self.get('href').replace(/&value=[^&]*/, '&value='+val.join(',')));
 			} else {
-				field = $('ctrl_' + opt.id);
 				field.value = val.join("\t");
 				var act = (frm.document.location.href.indexOf('contao/page.php') != -1) ? 'reloadPagetree' : 'reloadFiletree';
 				new Request.Contao({
@@ -942,7 +946,7 @@ var Backend =
 					evalScripts: false,
 					onRequest: AjaxRequest.displayBox(Contao.lang.loading + ' …'),
 					onSuccess: function(txt, json) {
-						$('ctrl_'+opt.id).getParent('div').set('html', json.content);
+						field.getParent('div').set('html', json.content);
 						json.javascript && Browser.exec(json.javascript);
 						AjaxRequest.hideBox();
 						window.fireEvent('ajax_change');


### PR DESCRIPTION
I add a new option to openModalSelector() named 'insTagStr'. It's optional. So you can use the pageselector without an inserttag or a custom inserttag. The default inserttag is as it wars 'link_url'. So there won't be conflicts with the new option. I hope you like that and can merge it.
