### PR TITLE
do not call fclose() with null parameter

### DIFF
--- a/system/modules/core/library/Contao/File.php
+++ b/system/modules/core/library/Contao/File.php
@@ -534,7 +534,12 @@ class File extends \System
 	 */
 	public function close()
 	{
-		$return = $this->Files->fclose($this->resFile);
+		$return = true;
+
+		if (is_resource($this->resFile))
+		{
+			$return = $this->Files->fclose($this->resFile);
+		}
 
 		// Move the temporary file to its destination
 		if ($this->blnDoNotCreate)


### PR DESCRIPTION
When a File object is created and closed without ever being used, `resFile` will be `null` on closing. With PHP7, I now get a warning in the log when this happens:

```
PHP Warning: fclose() expects parameter 1 to be resource, null given
```

This patch fixes the issue by duplicating the `is_resource` test from the destructor.
