### PR TITLE
Always trigger onversion_callback

### DIFF
--- a/system/modules/calendar/dca/tl_calendar_events.php
+++ b/system/modules/calendar/dca/tl_calendar_events.php
@@ -1059,7 +1059,7 @@ class tl_calendar_events extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_calendar_events', $intId);
+		$objVersions = new Versions('tl_calendar_events', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/calendar/dca/tl_content.php
+++ b/system/modules/calendar/dca/tl_content.php
@@ -273,7 +273,7 @@ class tl_content_calendar extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_content', $intId);
+		$objVersions = new Versions('tl_content', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/comments/dca/tl_comments.php
+++ b/system/modules/comments/dca/tl_comments.php
@@ -638,7 +638,7 @@ class tl_comments extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_comments', $intId);
+		$objVersions = new Versions('tl_comments', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/classes/Ajax.php
+++ b/system/modules/core/classes/Ajax.php
@@ -349,7 +349,7 @@ class Ajax extends \Backend
 
 					if (method_exists($dca, 'toggleFeatured'))
 					{
-						$dca->toggleFeatured(\Input::post('id'), ((\Input::post('state') == 1) ? true : false));
+						$dca->toggleFeatured(\Input::post('id'), ((\Input::post('state') == 1) ? true : false), $dc);
 					}
 				}
 				exit; break;

--- a/system/modules/core/dca/tl_article.php
+++ b/system/modules/core/dca/tl_article.php
@@ -858,11 +858,12 @@ class tl_article extends Backend
 	/**
 	 * Automatically generate the folder URL aliases
 	 *
-	 * @param array $arrButtons
+	 * @param array         $arrButtons
+	 * @param DataContainer $dc
 	 *
 	 * @return array
 	 */
-	public function addAliasButton($arrButtons)
+	public function addAliasButton($arrButtons, DataContainer $dc=null)
 	{
 		// Generate the aliases
 		if (Input::post('FORM_SUBMIT') == 'tl_select' && isset($_POST['alias']))
@@ -889,7 +890,7 @@ class tl_article extends Backend
 				}
 
 				// Initialize the version manager
-				$objVersions = new Versions('tl_article', $id);
+				$objVersions = new Versions('tl_article', $id, $dc);
 				$objVersions->initialize();
 
 				// Store the new alias
@@ -983,7 +984,7 @@ class tl_article extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_article', $intId);
+		$objVersions = new Versions('tl_article', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/dca/tl_content.php
+++ b/system/modules/core/dca/tl_content.php
@@ -1774,7 +1774,7 @@ class tl_content extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_content', $intId);
+		$objVersions = new Versions('tl_content', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/dca/tl_form_field.php
+++ b/system/modules/core/dca/tl_form_field.php
@@ -708,7 +708,7 @@ class tl_form_field extends Backend
 
 		$this->checkPermission();
 
-		$objVersions = new Versions('tl_form_field', $intId);
+		$objVersions = new Versions('tl_form_field', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/dca/tl_image_size_item.php
+++ b/system/modules/core/dca/tl_image_size_item.php
@@ -351,7 +351,7 @@ class tl_image_size_item extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_image_size_item', $intId);
+		$objVersions = new Versions('tl_image_size_item', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/dca/tl_member.php
+++ b/system/modules/core/dca/tl_member.php
@@ -692,7 +692,7 @@ class tl_member extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_member', $intId);
+		$objVersions = new Versions('tl_member', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/dca/tl_member_group.php
+++ b/system/modules/core/dca/tl_member_group.php
@@ -272,7 +272,7 @@ class tl_member_group extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_member_group', $intId);
+		$objVersions = new Versions('tl_member_group', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/dca/tl_page.php
+++ b/system/modules/core/dca/tl_page.php
@@ -1576,7 +1576,7 @@ class tl_page extends Backend
 				}
 
 				// Initialize the version manager
-				$objVersions = new Versions('tl_page', $id);
+				$objVersions = new Versions('tl_page', $id, $dc);
 				$objVersions->initialize();
 
 				// Store the new alias
@@ -1682,7 +1682,7 @@ class tl_page extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_page', $intId);
+		$objVersions = new Versions('tl_page', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/dca/tl_style.php
+++ b/system/modules/core/dca/tl_style.php
@@ -804,7 +804,7 @@ class tl_style extends Backend
 
 		$this->checkPermission();
 
-		$objVersions = new Versions('tl_style', $intId);
+		$objVersions = new Versions('tl_style', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/dca/tl_user.php
+++ b/system/modules/core/dca/tl_user.php
@@ -887,7 +887,7 @@ class tl_user extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_user', $intId);
+		$objVersions = new Versions('tl_user', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/dca/tl_user_group.php
+++ b/system/modules/core/dca/tl_user_group.php
@@ -417,7 +417,7 @@ class tl_user_group extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_user_group', $intId);
+		$objVersions = new Versions('tl_user_group', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/core/drivers/DC_Folder.php
+++ b/system/modules/core/drivers/DC_Folder.php
@@ -1092,7 +1092,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 			$this->blnCreateNewVersion = false;
 
 			/** @var \FilesModel $objFile */
-			$objVersions = new \Versions($this->strTable, $objFile->id);
+			$objVersions = new \Versions($this->strTable, $objFile->id, $this);
 
 			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'])
 			{
@@ -1316,25 +1316,6 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 			if ($this->blnCreateNewVersion && $objFile !== null)
 			{
 				$objVersions->create();
-
-				// Call the onversion_callback
-				if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
-				{
-					foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] as $callback)
-					{
-						if (is_array($callback))
-						{
-							$this->import($callback[0]);
-							$this->{$callback[0]}->{$callback[1]}($this->strTable, $objFile->id, $this);
-						}
-						elseif (is_callable($callback))
-						{
-							$callback($this->strTable, $objFile->id, $this);
-						}
-					}
-				}
-
-				$this->log('A new version of file "'.$objFile->path.'" has been created', __METHOD__, TL_GENERAL);
 			}
 
 			// Set the current timestamp (-> DO NOT CHANGE THE ORDER version - timestamp)
@@ -1435,7 +1416,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 					$this->blnCreateNewVersion = false;
 
 					/** @var \FilesModel $objFile */
-					$objVersions = new \Versions($this->strTable, $objFile->id);
+					$objVersions = new \Versions($this->strTable, $objFile->id, $this);
 					$objVersions->initialize();
 				}
 				else
@@ -1537,25 +1518,6 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 					if ($this->blnCreateNewVersion && $objFile !== null)
 					{
 						$objVersions->create();
-
-						// Call the onversion_callback
-						if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
-						{
-							foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] as $callback)
-							{
-								if (is_array($callback))
-								{
-									$this->import($callback[0]);
-									$this->{$callback[0]}->{$callback[1]}($this->strTable, $objFile->id, $this);
-								}
-								elseif (is_callable($callback))
-								{
-									$callback($this->strTable, $objFile->id, $this);
-								}
-							}
-						}
-
-						$this->log('A new version of file "'.$objFile->path.'" has been created', __METHOD__, TL_GENERAL);
 					}
 
 					// Set the current timestamp (-> DO NOT CHANGE ORDER version - timestamp)
@@ -1752,7 +1714,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 				$objMeta = \Dbafs::addResource($objFile->value);
 			}
 
-			$objVersions = new \Versions($this->strTable, $objMeta->id);
+			$objVersions = new \Versions($this->strTable, $objMeta->id, $this);
 
 			if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'])
 			{

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -1791,7 +1791,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 		$this->procedure[] = 'id=?';
 
 		$this->blnCreateNewVersion = false;
-		$objVersions = new \Versions($this->strTable, $this->intId);
+		$objVersions = new \Versions($this->strTable, $this->intId, $this);
 
 		if (!$GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'])
 		{
@@ -2060,25 +2060,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			if ($this->blnCreateNewVersion)
 			{
 				$objVersions->create();
-
-				// Call the onversion_callback
-				if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
-				{
-					foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] as $callback)
-					{
-						if (is_array($callback))
-						{
-							$this->import($callback[0]);
-							$this->{$callback[0]}->{$callback[1]}($this->strTable, $this->intId, $this);
-						}
-						elseif (is_callable($callback))
-						{
-							$callback($this->strTable, $this->intId, $this);
-						}
-					}
-				}
-
-				$this->log('A new version of record "'.$this->strTable.'.id='.$this->intId.'" has been created'.$this->getParentEntries($this->strTable, $this->intId), __METHOD__, TL_GENERAL);
 			}
 
 			// Set the current timestamp (-> DO NOT CHANGE THE ORDER version - timestamp)
@@ -2233,7 +2214,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				$this->blnCreateNewVersion = false;
 				$this->strPalette = trimsplit('[;,]', $this->getPalette());
 
-				$objVersions = new \Versions($this->strTable, $this->intId);
+				$objVersions = new \Versions($this->strTable, $this->intId, $this);
 				$objVersions->initialize();
 
 				// Add meta fields if the current user is an administrator
@@ -2401,25 +2382,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 					if ($this->blnCreateNewVersion)
 					{
 						$objVersions->create();
-
-						// Call the onversion_callback
-						if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
-						{
-							foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] as $callback)
-							{
-								if (is_array($callback))
-								{
-									$this->import($callback[0]);
-									$this->{$callback[0]}->{$callback[1]}($this->strTable, $this->intId, $this);
-								}
-								elseif (is_callable($callback))
-								{
-									$callback($this->strTable, $this->intId, $this);
-								}
-							}
-						}
-
-						$this->log('A new version of record "'.$this->strTable.'.id='.$this->intId.'" has been created'.$this->getParentEntries($this->strTable, $this->intId), __METHOD__, TL_GENERAL);
 					}
 
 					// Set the current timestamp (-> DO NOT CHANGE ORDER version - timestamp)
@@ -2637,7 +2599,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 					// Store the active record
 					$this->objActiveRecord = $objRow;
 
-					$objVersions = new \Versions($this->strTable, $this->intId);
+					$objVersions = new \Versions($this->strTable, $this->intId, $this);
 					$objVersions->initialize();
 
 					// Store all fields
@@ -2684,25 +2646,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 						if ($this->blnCreateNewVersion)
 						{
 							$objVersions->create();
-
-							// Call the onversion_callback
-							if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
-							{
-								foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] as $callback)
-								{
-									if (is_array($callback))
-									{
-										$this->import($callback[0]);
-										$this->{$callback[0]}->{$callback[1]}($this->strTable, $this->intId, $this);
-									}
-									elseif (is_callable($callback))
-									{
-										$callback($this->strTable, $this->intId, $this);
-									}
-								}
-							}
-
-							$this->log('A new version of record "'.$this->strTable.'.id='.$this->intId.'" has been created'.$this->getParentEntries($this->strTable, $this->intId), __METHOD__, TL_GENERAL);
 						}
 
 						// Set the current timestamp (-> DO NOT CHANGE ORDER version - timestamp)

--- a/system/modules/core/widgets/ListWizard.php
+++ b/system/modules/core/widgets/ListWizard.php
@@ -223,7 +223,7 @@ class ListWizard extends \Widget
 				}
 			}
 
-			$objVersions = new \Versions($dc->table, \Input::get('id'));
+			$objVersions = new \Versions($dc->table, \Input::get('id'), $dc);
 			$objVersions->create();
 
 			$this->Database->prepare("UPDATE " . $dc->table . " SET listitems=? WHERE id=?")

--- a/system/modules/core/widgets/TableWizard.php
+++ b/system/modules/core/widgets/TableWizard.php
@@ -305,7 +305,7 @@ class TableWizard extends \Widget
 				}
 			}
 
-			$objVersions = new \Versions($dc->table, \Input::get('id'));
+			$objVersions = new \Versions($dc->table, \Input::get('id'), $dc);
 			$objVersions->create();
 
 			$this->Database->prepare("UPDATE " . $dc->table . " SET tableitems=? WHERE id=?")

--- a/system/modules/faq/dca/tl_faq.php
+++ b/system/modules/faq/dca/tl_faq.php
@@ -509,7 +509,7 @@ class tl_faq extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_faq', $intId);
+		$objVersions = new Versions('tl_faq', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/news/dca/tl_content.php
+++ b/system/modules/news/dca/tl_content.php
@@ -273,7 +273,7 @@ class tl_content_news extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_content', $intId);
+		$objVersions = new Versions('tl_content', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/news/dca/tl_news.php
+++ b/system/modules/news/dca/tl_news.php
@@ -838,7 +838,7 @@ class tl_news extends Backend
 	{
 		if (strlen(Input::get('fid')))
 		{
-			$this->toggleFeatured(Input::get('fid'), (Input::get('state') == 1));
+			$this->toggleFeatured(Input::get('fid'), (Input::get('state') == 1), (@func_get_arg(12) ?: null));
 			$this->redirect($this->getReferer());
 		}
 
@@ -862,12 +862,13 @@ class tl_news extends Backend
 	/**
 	 * Feature/unfeature a news item
 	 *
-	 * @param integer $intId
-	 * @param boolean $blnVisible
+	 * @param integer       $intId
+	 * @param boolean       $blnVisible
+	 * @param DataContainer $dc
 	 *
 	 * @return string
 	 */
-	public function toggleFeatured($intId, $blnVisible)
+	public function toggleFeatured($intId, $blnVisible, DataContainer $dc=null)
 	{
 		// Check permissions to edit
 		Input::setGet('id', $intId);
@@ -881,7 +882,7 @@ class tl_news extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_news', $intId);
+		$objVersions = new Versions('tl_news', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback
@@ -892,7 +893,7 @@ class tl_news extends Backend
 				if (is_array($callback))
 				{
 					$this->import($callback[0]);
-					$blnVisible = $this->{$callback[0]}->{$callback[1]}($blnVisible, $this);
+					$blnVisible = $this->{$callback[0]}->{$callback[1]}($blnVisible, ($dc ?: $this));
 				}
 				elseif (is_callable($callback))
 				{
@@ -993,7 +994,7 @@ class tl_news extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_news', $intId);
+		$objVersions = new Versions('tl_news', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback

--- a/system/modules/newsletter/dca/tl_newsletter_recipients.php
+++ b/system/modules/newsletter/dca/tl_newsletter_recipients.php
@@ -450,7 +450,7 @@ class tl_newsletter_recipients extends Backend
 			$this->redirect('contao/main.php?act=error');
 		}
 
-		$objVersions = new Versions('tl_newsletter_recipients', $intId);
+		$objVersions = new Versions('tl_newsletter_recipients', $intId, $dc);
 		$objVersions->initialize();
 
 		// Trigger the save_callback


### PR DESCRIPTION
The `onversion_callback` is currently triggered by the DC driver. This means they are not always triggered when creating a new version, e.g. when toggling a published button.

No idea why the `onrestore_callback` was already triggered by the `Versions` class but `onversion_callback` is not …
