### PR TITLE
silence mkdir warning that file exists

### DIFF
--- a/system/modules/core/library/Contao/Files/Php.php
+++ b/system/modules/core/library/Contao/Files/Php.php
@@ -30,6 +30,11 @@ class Php extends \Files
 	{
 		$this->validate($strDirectory);
 
+		if (file_exists(TL_ROOT . '/' . $strDirectory))
+		{
+			return false;
+		}
+
 		return @mkdir(TL_ROOT . '/' . $strDirectory);
 	}
 


### PR DESCRIPTION
The warning of the file created by `mkdir` already existing is no longer silenced by `@` in PHP7.
