### PR TITLE
Syntax fixes for PHP 7 compatibility

### DIFF
--- a/system/initialize.php
+++ b/system/initialize.php
@@ -240,7 +240,10 @@ if (isset($GLOBALS['TL_HOOKS']['initializeSystem']) && is_array($GLOBALS['TL_HOO
 {
 	foreach ($GLOBALS['TL_HOOKS']['initializeSystem'] as $callback)
 	{
-		System::importStatic($callback[0])->{$callback[1]}();
+		call_user_func([
+			System::importStatic($callback[0]), 
+			$callback[1]
+		]);
 	}
 }
 


### PR DESCRIPTION
Hello,

I just tested a Contao installation under PHP 7.0.1. The only thing I had to fix to make it mostly run was change the way a method gets called on a static import in `system/initialize.php`, and it worked mostly fine.
- Contao 3.5.6
- Composer extension
- PHP 7.0.1-nmm1
