### PR TITLE
Set field and table when generating widget

### DIFF
--- a/system/modules/core/modules/ModulePersonalData.php
+++ b/system/modules/core/modules/ModulePersonalData.php
@@ -202,7 +202,7 @@ class ModulePersonalData extends \Module
 			}
 
 			/** @var \Widget $objWidget */
-			$objWidget = new $strClass($strClass::getAttributesFromDca($arrData, $field, $varValue, '', '', $this));
+			$objWidget = new $strClass($strClass::getAttributesFromDca($arrData, $field, $varValue, $field, $strTable, $this));
 
 			$objWidget->storeValues = true;
 			$objWidget->rowClass = 'row_' . $row . (($row == 0) ? ' row_first' : '') . ((($row % 2) == 0) ? ' even' : ' odd');


### PR DESCRIPTION
Without setting the table and field, the widget can never get the correct empty value (see https://github.com/aschempp/contao-core/blob/dcd9187b178a57a8c6e378ca0530e24140a508f6/system/modules/core/modules/ModulePersonalData.php#L287).
