### PR TITLE
Register models only once if they are related

### DIFF
--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -165,8 +165,6 @@ abstract class Model
 						/** @var static $objRelated */
 						$objRelated = new $strClass();
 						$objRelated->setRow($row);
-
-						$objRegistry->register($objRelated);
 					}
 
 					$this->arrRelated[$key] = $objRelated;

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -165,6 +165,8 @@ abstract class Model
 						/** @var static $objRelated */
 						$objRelated = new $strClass();
 						$objRelated->setRow($row);
+						
+						$objRegistry->register($objRelated);
 					}
 
 					$this->arrRelated[$key] = $objRelated;
@@ -172,7 +174,10 @@ abstract class Model
 			}
 
 			$this->setRow($arrData); // see #5439
-			$objRegistry->register($this);
+			
+			if ($objRegistry->fetch(static::$strTable, $this->id) === null) {
+				$objRegistry->register($this);
+			}
 		}
 	}
 


### PR DESCRIPTION
If you have a model related to itself it will be registered twice because the constructor of the model will register it. And this will create an Exception in the registry.
