### PR TITLE
[RFC] Add the oncreate_version and onrestore_version callbacks

### DIFF
--- a/system/docs/CHANGELOG.md
+++ b/system/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ Contao Open Source CMS changelog
 Version 3.5.7 (2016-02-XX)
 --------------------------
 
+### New
+Added the "oncreate_version_callback" and "onrestore_version_callback"
+callbacks to the DCA (see #8168).
+
 ### Fixed
 Correctly toggle custom page type icons (see #8236).
 

--- a/system/modules/core/dca/tl_style.php
+++ b/system/modules/core/dca/tl_style.php
@@ -42,7 +42,7 @@ $GLOBALS['TL_DCA']['tl_style'] = array
 		(
 			array('tl_style', 'scheduleUpdate')
 		),
-		'onrestore_callback' => array
+		'onrestore_version_callback' => array
 		(
 			array('tl_style', 'updateAfterRestore')
 		),

--- a/system/modules/core/drivers/DC_Folder.php
+++ b/system/modules/core/drivers/DC_Folder.php
@@ -1320,6 +1320,8 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 				// Call the onversion_callback
 				if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
 				{
+					@trigger_error('Using the onversion_callback has been deprecated and will no longer work in Contao 5.0. Use the oncreate_version_callback instead.', E_USER_DEPRECATED);
+
 					foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] as $callback)
 					{
 						if (is_array($callback))
@@ -1333,8 +1335,6 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 						}
 					}
 				}
-
-				$this->log('A new version of file "'.$objFile->path.'" has been created', __METHOD__, TL_GENERAL);
 			}
 
 			// Set the current timestamp (-> DO NOT CHANGE THE ORDER version - timestamp)
@@ -1541,6 +1541,8 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 						// Call the onversion_callback
 						if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
 						{
+							@trigger_error('Using the onversion_callback has been deprecated and will no longer work in Contao 5.0. Use the oncreate_version_callback instead.', E_USER_DEPRECATED);
+
 							foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] as $callback)
 							{
 								if (is_array($callback))
@@ -1554,8 +1556,6 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 								}
 							}
 						}
-
-						$this->log('A new version of file "'.$objFile->path.'" has been created', __METHOD__, TL_GENERAL);
 					}
 
 					// Set the current timestamp (-> DO NOT CHANGE ORDER version - timestamp)

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -2066,6 +2066,8 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				// Call the onversion_callback
 				if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
 				{
+					@trigger_error('Using the onversion_callback has been deprecated and will no longer work in Contao 5.0. Use the oncreate_version_callback instead.', E_USER_DEPRECATED);
+
 					foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] as $callback)
 					{
 						if (is_array($callback))
@@ -2079,8 +2081,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 						}
 					}
 				}
-
-				$this->log('A new version of record "'.$this->strTable.'.id='.$this->intId.'" has been created'.$this->getParentEntries($this->strTable, $this->intId), __METHOD__, TL_GENERAL);
 			}
 
 			// Set the current timestamp (-> DO NOT CHANGE THE ORDER version - timestamp)
@@ -2407,6 +2407,8 @@ class DC_Table extends \DataContainer implements \listable, \editable
 						// Call the onversion_callback
 						if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
 						{
+							@trigger_error('Using the onversion_callback has been deprecated and will no longer work in Contao 5.0. Use the oncreate_version_callback instead.', E_USER_DEPRECATED);
+
 							foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] as $callback)
 							{
 								if (is_array($callback))
@@ -2420,8 +2422,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 								}
 							}
 						}
-
-						$this->log('A new version of record "'.$this->strTable.'.id='.$this->intId.'" has been created'.$this->getParentEntries($this->strTable, $this->intId), __METHOD__, TL_GENERAL);
 					}
 
 					// Set the current timestamp (-> DO NOT CHANGE ORDER version - timestamp)
@@ -2690,6 +2690,8 @@ class DC_Table extends \DataContainer implements \listable, \editable
 							// Call the onversion_callback
 							if (is_array($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback']))
 							{
+								@trigger_error('Using the onversion_callback has been deprecated and will no longer work in Contao 5.0. Use the oncreate_version_callback instead.', E_USER_DEPRECATED);
+
 								foreach ($GLOBALS['TL_DCA'][$this->strTable]['config']['onversion_callback'] as $callback)
 								{
 									if (is_array($callback))
@@ -2703,8 +2705,6 @@ class DC_Table extends \DataContainer implements \listable, \editable
 									}
 								}
 							}
-
-							$this->log('A new version of record "'.$this->strTable.'.id='.$this->intId.'" has been created'.$this->getParentEntries($this->strTable, $this->intId), __METHOD__, TL_GENERAL);
 						}
 
 						// Set the current timestamp (-> DO NOT CHANGE ORDER version - timestamp)


### PR DESCRIPTION
This PR adds the `oncreate_version_callback` and `onrestore_version_callback` as discussed in #8168. You should probably ignore whitespace when looking at the diff :)

@contao/developers Please review.

Diff view with whitespace ignored: https://github.com/contao/core/pull/8237/files?w=1
