### PR TITLE
allow <picture> tag in custom HTML

### DIFF
--- a/system/config/default.php
+++ b/system/config/default.php
@@ -99,7 +99,7 @@ $GLOBALS['TL_CONFIG']['allowedTags']
 	. '<map><mark><menu>'
 	. '<nav>'
 	. '<object><ol><optgroup><option><output>'
-	. '<p><param><pre>'
+	. '<p><param><picture><pre>'
 	. '<q>'
 	. '<s><samp><section><select><small><source><span><strong><style><sub><sup>'
 	. '<table><tbody><td><textarea><tfoot><th><thead><time><tr><tt>'


### PR DESCRIPTION
I would like to use the `<picture>` tag in custom HTML. I am not entirely sure, if this is safe to allow by default, but given that `<video>` is already here, I think we should be fine.
