### PR TITLE
Only treat size as an array, if it's not numeric

### DIFF
--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -1463,12 +1463,18 @@ abstract class Controller extends \System
 		}
 
 		$imgSize = $objFile->imageSize;
-		$size = $arrItem['size'];
+		$size = deserialize($arrItem['size']);
 
-		if (!is_numeric($size))
+		if (is_numeric($size))
 		{
-			$size = deserialize($arrItem['size'], true) + array(0, 0, 'crop');
+			$size = array(0, 0, (int) $size);
 		}
+		elseif (!is_array($size))
+		{
+			$size = array();
+		}
+
+		$size += array(0, 0, 'crop');
 
 		if ($intMaxWidth === null)
 		{

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -1463,7 +1463,7 @@ abstract class Controller extends \System
 		}
 
 		$imgSize = $objFile->imageSize;
-		$size = deserialize($arrItem['size']);
+		$size = $arrItem['size'];
 
 		if (!is_numeric($size))
 		{

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -1463,7 +1463,12 @@ abstract class Controller extends \System
 		}
 
 		$imgSize = $objFile->imageSize;
-		$size = deserialize($arrItem['size'], true) + array(0, 0, 'crop');
+		$size = deserialize($arrItem['size']);
+
+		if (!is_numeric($size))
+		{
+			$size = deserialize($arrItem['size'], true) + array(0, 0, 'crop');
+		}
 
 		if ($intMaxWidth === null)
 		{


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/contao/core/commit/4fdbe3fdf8e53e6954bfc48121ebf994749d98b3#commitcomment-16430718):
Before 3.5.7 it was possible to pass `$arrItem['size']` in `addImageToTemplate` as an `ID` from `tl_image_size`.

This change allows to pass an `ID` and makes it an array for an empty size (see #8197).
