### PR TITLE
fix MIME type for SVGs in data: URLs

### DIFF
--- a/system/modules/core/classes/StyleSheets.php
+++ b/system/modules/core/classes/StyleSheets.php
@@ -2275,16 +2275,17 @@ class StyleSheets extends \Backend
 			$objImage = new \File($strImage, true);
 			$strExtension = $objImage->extension;
 
-			// Fix the jpg mime type
-			if ($strExtension == 'jpg')
+			switch ($strExtension)
 			{
-				$strExtension = 'jpeg';
+				case 'jpg': $strMimeSubtype = 'jpeg';        break;
+				case 'svg': $strMimeSubtype = 'svg+xml';     break;
+				default:    $strMimeSubtype = $strExtension; break;
 			}
 
 			// Return the data: string
 			if ($objImage->size <= $arrParent['embedImages'])
 			{
-				return 'data:image/' . $strExtension . ';base64,' . base64_encode($objImage->getContent());
+				return 'data:image/' . $strMimeSubtype . ';base64,' . base64_encode($objImage->getContent());
 			}
 		}
 


### PR DESCRIPTION
The feature of inlining small images into style sheets by way of data: URLs does not work for me with SVG images. I test with Safari and it does not show the SVG, because the MIME type in the data: URL is set to image/svg instead of image/svg+xml. With the latter, everything works as expected.

So I took the liberty to add a `switch` statement here, in case more special handling is needed later for other file extensions.
