### PR TITLE
Correctly check error_reporting to fix issue #8254

### DIFF
--- a/system/helper/functions.php
+++ b/system/helper/functions.php
@@ -39,8 +39,10 @@ function __error($intType, $strMessage, $strFile, $intLine)
 		E_USER_DEPRECATED   => 'Deprecated notice'
 	);
 
-	// Ignore functions with an error control operator (@function_name)
-	if (ini_get('error_reporting') > 0)
+	// Only log errors that have been configured to get logged.
+	// Functions with an error control operator (@function_name) are also omitted as error_reporting() is 0 in these
+	// cases.
+	if (error_reporting() & $intType)
 	{
 		$e = new Exception();
 


### PR DESCRIPTION
We have to check the error_reporting() that has been set at runtime and
also validate it against the passed error type. Simply checking for a
value greater than 0 is not enough.
