### PR TITLE
Bugfix: Only add nofollow Attribute to navigation links if the target Site has 'noindex,nofollow'

### DIFF
--- a/system/modules/core/modules/Module.php
+++ b/system/modules/core/modules/Module.php
@@ -461,7 +461,7 @@ abstract class Module extends \Frontend
 				$row['pageTitle'] = specialchars($objSubpage->pageTitle, true);
 				$row['link'] = $objSubpage->title;
 				$row['href'] = $href;
-				$row['nofollow'] = (strncmp($objSubpage->robots, 'noindex', 7) === 0);
+				$row['nofollow'] = (strncmp($objSubpage->robots, 'noindex,nofollow', 16) === 0);
 				$row['target'] = '';
 				$row['description'] = str_replace(array("\n", "\r"), array(' ' , ''), $objSubpage->description);
 

--- a/system/modules/core/modules/ModuleCustomnav.php
+++ b/system/modules/core/modules/ModuleCustomnav.php
@@ -166,7 +166,7 @@ class ModuleCustomnav extends \Module
 					$row['pageTitle'] = specialchars($objModel->pageTitle, true);
 					$row['link'] = $objModel->title;
 					$row['href'] = $href;
-					$row['nofollow'] = (strncmp($objModel->robots, 'noindex', 7) === 0);
+					$row['nofollow'] = (strncmp($objModel->robots, 'noindex,nofollow', 16) === 0);
 					$row['target'] = '';
 					$row['description'] = str_replace(array("\n", "\r"), array(' ' , ''), $objModel->description);
 
@@ -192,7 +192,7 @@ class ModuleCustomnav extends \Module
 					$row['pageTitle'] = specialchars($objModel->pageTitle, true);
 					$row['link'] = $objModel->title;
 					$row['href'] = $href;
-					$row['nofollow'] = (strncmp($objModel->robots, 'noindex', 7) === 0);
+					$row['nofollow'] = (strncmp($objModel->robots, 'noindex,nofollow', 16) === 0);
 					$row['target'] = '';
 					$row['description'] = str_replace(array("\n", "\r"), array(' ' , ''), $objModel->description);
 


### PR DESCRIPTION
This topic was already brought up in 2011 #3424

The assumption made was not correct for closing the issue.

**Current status:**
We've four **Robots tag** to choose from: 
- index,follow
- index,nofollow
- noindex,follow
- noindex,nofollow

At the moment the nofollow rel attribute gets set on the last two ones. 

**Issue/Claim:**
Setting it for **noindex,follow** is not correct. 

**Why is the current implementation wrong:**
The robots tags tell the robots how to handle the site when they're already on it. 
If 'noindex,follow' is set the robot is expected to **crawl** the site and **search for links to follow** but to not index the current site for search results. 
The current implementation prevents the robots from crawling _noindex,follow_ Sites

**Example:**
An example for this could be a overview page with with a collection of Products linking to their respective details pages. 
If those links are only on the overview page, and the overview page is only linked via it's navigation link, a robot will not be able to find the product details pages (which could have _index,follow_ set).

**Further references:**
See also Matt Cuts from google on it:
https://www.youtube.com/watch?v=ZjRGkc__FwQ
