### PR TITLE
Skip forward pages entirely in the book navigation module

### DIFF
--- a/system/docs/CHANGELOG.md
+++ b/system/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ Version 3.5.10 (2016-XX-XX)
 ---------------------------
 
 ### Fixed
+Skip forward pages entirely in the book navigation module (see #5074).
+
+### Fixed
 Determine the search index checksum in a more reliable way (see #7652).
 
 

--- a/system/modules/core/modules/ModuleBooknav.php
+++ b/system/modules/core/modules/ModuleBooknav.php
@@ -124,7 +124,14 @@ class ModuleBooknav extends \Module
 		// Previous page
 		if ($intCurrent > 0)
 		{
-			$intKey = $arrLookup[($intCurrent - 1)];
+			$current = $intCurrent;
+			$intKey = $arrLookup[($current - 1)];
+
+			// Skip forward pages (see #5074)
+			while ($this->arrPages[$intKey]->type == 'forward' && isset($arrLookup[--$current]))
+			{
+				$intKey = $arrLookup[($current - 1)];
+			}
 
 			$this->Template->hasPrev = true;
 			$this->Template->prevHref = $this->arrPages[$intKey]->getFrontendUrl();
@@ -136,7 +143,14 @@ class ModuleBooknav extends \Module
 		// Next page
 		if ($intCurrent < (count($arrLookup) - 1))
 		{
-			$intKey = $arrLookup[($intCurrent + 1)];
+			$current = $intCurrent;
+			$intKey = $arrLookup[($current + 1)];
+
+			// Skip forward pages (see #5074)
+			while ($this->arrPages[$intKey]->type == 'forward' && isset($arrLookup[++$current]))
+			{
+				$intKey = $arrLookup[($current + 1)];
+			}
 
 			$this->Template->hasNext = true;
 			$this->Template->nextHref = $this->arrPages[$intKey]->getFrontendUrl();


### PR DESCRIPTION
This PR implements a possible fix for #5074.
