### PR TITLE
Fix news feeds in multidomain setups (#8327)

### DIFF
--- a/system/modules/news/classes/News.php
+++ b/system/modules/news/classes/News.php
@@ -355,7 +355,7 @@ class News extends \Frontend
 				if (($objTarget = $objItem->getRelated('jumpTo')) !== null)
 				{
 					/** @var \PageModel $objTarget */
-					return $strBase . $objTarget->getFrontendUrl();
+					return $strBase . $objTarget->getAbsoluteUrl();
 				}
 				break;
 
@@ -364,7 +364,7 @@ class News extends \Frontend
 				if (($objArticle = \ArticleModel::findByPk($objItem->articleId, array('eager'=>true))) !== null && ($objPid = $objArticle->getRelated('pid')) !== null)
 				{
 					/** @var \PageModel $objPid */
-					return $strBase . ampersand($objPid->getFrontendUrl('/articles/' . ((!\Config::get('disableAlias') && $objArticle->alias != '') ? $objArticle->alias : $objArticle->id)));
+					return $strBase . ampersand($objPid->getAbsoluteUrl('/articles/' . ((!\Config::get('disableAlias') && $objArticle->alias != '') ? $objArticle->alias : $objArticle->id)));
 				}
 				break;
 		}

--- a/system/modules/news/classes/News.php
+++ b/system/modules/news/classes/News.php
@@ -160,7 +160,7 @@ class News extends \Frontend
 					}
 					else
 					{
-						$arrUrls[$jumpTo] = $objParent->getFrontendUrl((\Config::get('useAutoItem') && !\Config::get('disableAlias')) ? '/%s' : '/items/%s');
+						$arrUrls[$jumpTo] = $objParent->getAbsoluteUrl((\Config::get('useAutoItem') && !\Config::get('disableAlias')) ? '/%s' : '/items/%s');
 					}
 				}
 
@@ -174,7 +174,7 @@ class News extends \Frontend
 				$objItem = new \FeedItem();
 
 				$objItem->title = $objArticle->headline;
-				$objItem->link = $this->getLink($objArticle, $strUrl, $strLink);
+				$objItem->link = $this->getLink($objArticle, $strUrl);
 				$objItem->published = $objArticle->date;
 				$objItem->author = $objArticle->authorName;
 


### PR DESCRIPTION
When using Contao in a multidomain setup, the news feed might contain the wrong links to the items (see #8327). This simple change should fix it completely.
