### PR TITLE
Fix search results from different domains

### DIFF
--- a/system/modules/core/modules/ModuleSearch.php
+++ b/system/modules/core/modules/ModuleSearch.php
@@ -252,15 +252,29 @@ class ModuleSearch extends \Module
 				$this->Template->page = $page;
 			}
 
+			// Determine base URL
+			$strBase = '';
+
+			if ($this->rootPage > 0)
+			{
+				$objReference = \PageModel::findWithDetails($this->rootPage);
+
+				// Check if domain from reference page differs from current domain
+				if ($objReference->domain && \Environment::get('host') !== $objReference->domain)
+				{
+					$strBase = ($objReference->rootUseSSL ? 'https://' : 'http://') . $objReference->domain . TL_PATH . '/';
+				}
+			}
+
 			// Get the results
 			for ($i=($from-1); $i<$to && $i<$count; $i++)
 			{
 				/** @var \FrontendTemplate|object $objTemplate */
 				$objTemplate = new \FrontendTemplate($this->searchTpl ?: 'search_default');
 
-				$objTemplate->url = $arrResult[$i]['url'];
+				$objTemplate->url = $strBase . $arrResult[$i]['url'];
 				$objTemplate->link = $arrResult[$i]['title'];
-				$objTemplate->href = $arrResult[$i]['url'];
+				$objTemplate->href = $strBase . $arrResult[$i]['url'];
 				$objTemplate->title = specialchars($arrResult[$i]['title']);
 				$objTemplate->class = (($i == ($from - 1)) ? 'first ' : '') . (($i == ($to - 1) || $i == ($count - 1)) ? 'last ' : '') . (($i % 2 == 0) ? 'even' : 'odd');
 				$objTemplate->relevance = sprintf($GLOBALS['TL_LANG']['MSC']['relevance'], number_format($arrResult[$i]['relevance'] / $arrResult[0]['relevance'] * 100, 2) . '%');


### PR DESCRIPTION
### Problem description

In a multidomain installation, if you happen to have a search module on a page with the refrence page set to a page (or website root) from another domain, the search results will not contain the correct domain (they will be relative to the current domain).
### Proposed fix

In this fix I simply fetch the reference page (if available) and check if its domain differs from the current domain. I think it should be safe to assume that the URL for any search result from that reference page originated from that domain.
### Other ways to fix
- Since the page ID is available for each search result, the domain check could also be done for each individual search result.
- In [FrontendTemplate.php#L321](https://github.com/contao/core/blob/3.5.12/system/modules/core/classes/FrontendTemplate.php#L321)

``` php
'url' => \Environment::get('request'),
```

could be changed to

``` php
'url' => \Environment::get('uri'),
```

so that the saved URL in `tl_search` includes the scheme and host.

---

(Sorry for the mess-up in #8330)
