### PR TITLE
Prevent warnings when invalidating the cache

### DIFF
--- a/system/modules/core/library/Contao/Config.php
+++ b/system/modules/core/library/Contao/Config.php
@@ -265,7 +265,7 @@ class Config
 		// Reset the Zend OPcache
 		if (function_exists('opcache_invalidate'))
 		{
-			opcache_invalidate(TL_ROOT . '/system/config/localconfig.php', true);
+			@opcache_invalidate(TL_ROOT . '/system/config/localconfig.php', true);
 		}
 
 		// Reset the Zend Optimizer+ cache (unfortunately no API to delete just a single file)


### PR DESCRIPTION
Easyname uses OPcache, but [restricts the opcache_invalidate() usage](https://www.easyname.at/de/support/hosting/183-warum-erhalte-ich-die-warnung-zend-opcache-api-is-restricted). 

Therefore Easyname Hosting the following warning in thrown:

```
Warning: Zend OPcache API is restricted by "restrict_api" configuration directive in system/modules/rocksolid-custom-elements/src/MadeYourDay/Contao/CustomElements.php on line 1262
```

The customer support write:

```
Das Problem ist das die Funktionen ja existieren (opcache_invalidate), aber es kann leider kein Zugriff auf diese Funktionen stattfinden da der opcache von allen Kunden am Webserver geteilt wird.
```
