### PR TITLE
Set default to NULL on copy if nullIfEmpty is set

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -890,7 +890,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 					// Reset doNotCopy and fallback fields to their default value
 					elseif ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['doNotCopy'] || $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['fallback'])
 					{
-						$v = '';
+						$v = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['nullIfEmpty'] ? null : '';
 
 						// Use array_key_exists to allow NULL (see #5252)
 						if (array_key_exists('default', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]))
@@ -1108,7 +1108,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 						// Reset doNotCopy and fallback fields to their default value
 						elseif ($GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['doNotCopy'] || $GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['fallback'])
 						{
-							$vv = '';
+							$vv = $GLOBALS['TL_DCA'][$v]['fields'][$kk]['eval']['nullIfEmpty'] ? null : '';
 
 							// Use array_key_exists to allow NULL (see #5252)
 							if (array_key_exists('default', $GLOBALS['TL_DCA'][$v]['fields'][$kk]))


### PR DESCRIPTION
I have a date field in my DCA which can be NULL and `doNotCopy` enabled. If the record is duplicated, the value currently results in 01.01.1970.
