### PR TITLE
Keep uuid when overriding existing file.

### DIFF
--- a/system/modules/core/forms/FormFileUpload.php
+++ b/system/modules/core/forms/FormFileUpload.php
@@ -279,6 +279,8 @@ class FormFileUpload extends \Widget implements \uploadable
 							$objModel->path   = $strFile;
 							$objModel->hash   = md5_file(TL_ROOT . '/' . $strFile);
 							$objModel->save();
+
+							$strUuid = \StringUtil::binToUuid($objModel->uuid);
 						}
 						else
 						{


### PR DESCRIPTION
Since 3707017547738afd86db5728905dfefdcc6a7ccb the uuid is not passed to the session when an existing file is overridden.
