### PR TITLE
Allow only those roots that are allowed in root nodes in page selector

### DIFF
--- a/system/modules/core/widgets/PageSelector.php
+++ b/system/modules/core/widgets/PageSelector.php
@@ -170,7 +170,7 @@ class PageSelector extends \Widget
 					);
 
 					if (count($root) === 0) {
-						$root = $this->rootNodes;
+						$root = $this->User->hasAccess($this->rootNodes, 'pagemounts') ? $this->rootNodes : [];
 
 						// Hide the breadcrumb
 						$GLOBALS['TL_DCA']['tl_page']['list']['sorting']['breadcrumb'] = '';

--- a/system/modules/core/widgets/PageSelector.php
+++ b/system/modules/core/widgets/PageSelector.php
@@ -159,7 +159,25 @@ class PageSelector extends \Widget
 			// Root nodes (breadcrumb menu)
 			if (!empty($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['root']))
 			{
-				$nodes = $this->eliminateNestedPages($GLOBALS['TL_DCA']['tl_page']['list']['sorting']['root']);
+				$root = $GLOBALS['TL_DCA']['tl_page']['list']['sorting']['root'];
+
+				// Allow only those roots that are allowed in root nodes
+				if (is_array($this->rootNodes))
+				{
+					$root = array_intersect(
+						array_merge($this->rootNodes, $this->Database->getChildRecords($this->rootNodes, 'tl_page')),
+						$root
+					);
+
+					if (count($root) === 0) {
+						$root = $this->rootNodes;
+
+						// Hide the breadcrumb
+						$GLOBALS['TL_DCA']['tl_page']['list']['sorting']['breadcrumb'] = '';
+					}
+				}
+
+				$nodes = $this->eliminateNestedPages($root);
 
 				foreach ($nodes as $node)
 				{


### PR DESCRIPTION
The problem is that the pages outside the `rootNodes` scope of a given field could still be accessed by its page picker if they are set in `$GLOBALS['TL_DCA']['tl_page']['list']['sorting']['root']`, e.g. because of breadcrumb.
