### PR TITLE
[RFC] Fixed simple tokens

### DIFF
--- a/system/modules/core/library/Contao/StringUtil.php
+++ b/system/modules/core/library/Contao/StringUtil.php
@@ -491,13 +491,22 @@ class StringUtil
 		// Replace the tags
 		foreach ($arrTags as $strTag)
 		{
-			if (strncmp($strTag, '{if', 3) === 0)
+			if (strncmp($strTag, '{if', 3) === 0 || strncmp($strTag, '{elseif', 7) === 0)
 			{
-				$strReturn .= preg_replace('/\{if ([A-Za-z0-9_]+)([=!<>]+)([^;$\(\)\[\]\}]+).*\}/i', '<?php if ($arrData[\'$1\'] $2 $3): ?>', $strTag);
-			}
-			elseif (strncmp($strTag, '{elseif', 7) === 0)
-			{
-				$strReturn .= preg_replace('/\{elseif ([A-Za-z0-9_]+)([=!<>]+)([^;$\(\)\[\]\}]+).*\}/i', '<?php elseif ($arrData[\'$1\'] $2 $3): ?>', $strTag);
+				$strReturn .= preg_replace_callback(
+					'/{(if|elseif) ([^=!<>]+)([=!<>]+)([^;$\\(\\)\\[\\]\\}]+).*\\}/i',
+					function (array $matches) use ($arrData)
+					{
+						if (!array_key_exists($matches[2], $arrData))
+						{
+							System::log(sprintf('Tried to evaluate (%s statement) unkown simple token "%s".', $matches[1], $matches[2]), __METHOD__, TL_ERROR);
+							return sprintf('<?php %s (false): ?>', $matches[1]);
+						}
+
+						return sprintf('<?php %s ($arrData[\'%s\'] %s %s): ?>', $matches[1], addslashes($matches[2]), $matches[3], $matches[4]);
+					},
+					$strTag
+				);
 			}
 			elseif (strncmp($strTag, '{else', 5) === 0)
 			{
@@ -515,7 +524,20 @@ class StringUtil
 
 		// Replace tokens
 		$strReturn = str_replace('?><br />', '?>', $strReturn);
-		$strReturn = preg_replace('/##([A-Za-z0-9_]+)##/i', '<?php echo $arrData[\'$1\']; ?>', $strReturn);
+		$strReturn = preg_replace_callback(
+			'/##([^#\s]+)##/i',
+			function (array $matches) use ($arrData)
+			{
+				if (!array_key_exists($matches[1], $arrData))
+				{
+					System::log(sprintf('Tried to parse unknown simple token "%s".', $matches[1]), __METHOD__, TL_ERROR);
+					return '##' . $matches[1] . '##';
+				}
+
+				return $arrData[$matches[1]];
+			},
+			$strReturn
+		);
 		$strReturn = str_replace("]; ?>\n", '] . "\n"; ?>' . "\n", $strReturn); // see #7178
 
 		// Eval the code


### PR DESCRIPTION
 Fixed simple tokens parsing ignoring certain characters for now reason and without a trace in the logs.

This is now logged as follows:

![bildschirmfoto 2016-08-12 um 12 05 50](https://cloud.githubusercontent.com/assets/481937/17619470/de393260-6085-11e6-94e4-f253d90aa4dd.png)

Moreover, any character is now allowed for tokens. You can use `-` without any problem. Even using `'` works even though this is very uncommon :-)

Obviously you cannot use any of these characters because they are used for comparison: `=!<>`.
