### PR TITLE
Please load langauge after getPageLayout hook

### DIFF
--- a/system/modules/core/pages/PageRegular.php
+++ b/system/modules/core/pages/PageRegular.php
@@ -28,7 +28,6 @@ class PageRegular extends \Frontend
 	public function generate($objPage, $blnCheckRequest=false)
 	{
 		$GLOBALS['TL_KEYWORDS'] = '';
-		$GLOBALS['TL_LANGUAGE'] = $objPage->language;
 
 		// Static URLs
 		$this->setStaticUrls();
@@ -45,7 +44,8 @@ class PageRegular extends \Frontend
 				$this->{$callback[0]}->{$callback[1]}($objPage, $objLayout, $this);
 			}
 		}
-
+		
+		$GLOBALS['TL_LANGUAGE'] = $objPage->language;
 		\System::loadLanguageFile('default');
 
 		/** @var \ThemeModel $objTheme */

--- a/system/modules/core/pages/PageRegular.php
+++ b/system/modules/core/pages/PageRegular.php
@@ -30,8 +30,6 @@ class PageRegular extends \Frontend
 		$GLOBALS['TL_KEYWORDS'] = '';
 		$GLOBALS['TL_LANGUAGE'] = $objPage->language;
 
-		\System::loadLanguageFile('default');
-
 		// Static URLs
 		$this->setStaticUrls();
 
@@ -47,6 +45,8 @@ class PageRegular extends \Frontend
 				$this->{$callback[0]}->{$callback[1]}($objPage, $objLayout, $this);
 			}
 		}
+
+		\System::loadLanguageFile('default');
 
 		/** @var \ThemeModel $objTheme */
 		$objTheme = $objLayout->getRelated('pid');


### PR DESCRIPTION
I am using hook getPageLayout to load language dynamically. Since language is loaded before the hook it did not work. As mention in hooks documentation "It can be used to modify the page or layout object", it should be able to change $objPage->language to new value.
