### PR TITLE
Security hardening: Set secure cookie flag when using SSL

### DIFF
--- a/system/modules/core/classes/Frontend.php
+++ b/system/modules/core/classes/Frontend.php
@@ -549,7 +549,7 @@ abstract class Frontend extends \Controller
 		$_SESSION['TL_USER_LOGGED_IN'] = false; // backwards compatibility
 
 		// Remove the cookie if it is invalid to enable loading cached pages
-		$this->setCookie($strCookie, $hash, (time() - 86400), null, null, false, true);
+		$this->setCookie($strCookie, $hash, (time() - 86400), null, null, (\Environment::get('ssl')) ? true : false, true);
 
 		return false;
 	}

--- a/system/modules/core/classes/FrontendUser.php
+++ b/system/modules/core/classes/FrontendUser.php
@@ -190,7 +190,7 @@ class FrontendUser extends \User
 			}
 
 			// Remove the cookie if it is invalid to enable loading cached pages
-			$this->setCookie('FE_AUTO_LOGIN', $strCookie, (time() - 86400), null, null, false, true);
+			$this->setCookie('FE_AUTO_LOGIN', $strCookie, (time() - 86400), null, null, (\Environment::get('ssl')) ? true : false, true);
 		}
 
 		return false;
@@ -220,7 +220,7 @@ class FrontendUser extends \User
 			$this->autologin = $strToken;
 			$this->save();
 
-			$this->setCookie('FE_AUTO_LOGIN', $strToken, ($time + \Config::get('autologin')), null, null, false, true);
+			$this->setCookie('FE_AUTO_LOGIN', $strToken, ($time + \Config::get('autologin')), null, null, (\Environment::get('ssl')) ? true : false, true);
 		}
 
 		return true;
@@ -249,7 +249,7 @@ class FrontendUser extends \User
 		}
 
 		// Remove the auto login cookie
-		$this->setCookie('FE_AUTO_LOGIN', $this->autologin, (time() - 86400), null, null, false, true);
+		$this->setCookie('FE_AUTO_LOGIN', $this->autologin, (time() - 86400), null, null, (\Environment::get('ssl')) ? true : false, true);
 
 		return true;
 	}

--- a/system/modules/core/classes/RebuildIndex.php
+++ b/system/modules/core/classes/RebuildIndex.php
@@ -91,7 +91,7 @@ class RebuildIndex extends \Backend implements \executable
 			$this->Automator->purgeSearchTables();
 
 			// Hide unpublished elements
-			$this->setCookie('FE_PREVIEW', 0, ($time - 86400));
+			$this->setCookie('FE_PREVIEW', 0, ($time - 86400), null, null, (\Environment::get('ssl')) ? true : false);
 
 			// Calculate the hash
 			$strHash = sha1(session_id() . (!\Config::get('disableIpCheck') ? \Environment::get('ip') : '') . 'FE_USER_AUTH');
@@ -108,15 +108,15 @@ class RebuildIndex extends \Backend implements \executable
 							   ->execute(\Input::get('user'), $time, 'FE_USER_AUTH', session_id(), \Environment::get('ip'), $strHash);
 
 				// Set the cookie
-				$this->setCookie('FE_USER_AUTH', $strHash, ($time + \Config::get('sessionTimeout')), null, null, false, true);
+				$this->setCookie('FE_USER_AUTH', $strHash, ($time + \Config::get('sessionTimeout')), null, null, (\Environment::get('ssl')) ? true : false, true);
 			}
 
 			// Log out the front end user
 			else
 			{
 				// Unset the cookies
-				$this->setCookie('FE_USER_AUTH', $strHash, ($time - 86400), null, null, false, true);
-				$this->setCookie('FE_AUTO_LOGIN', \Input::cookie('FE_AUTO_LOGIN'), ($time - 86400), null, null, false, true);
+				$this->setCookie('FE_USER_AUTH', $strHash, ($time - 86400), null, null, (\Environment::get('ssl')) ? true : false, true);
+				$this->setCookie('FE_AUTO_LOGIN', \Input::cookie('FE_AUTO_LOGIN'), ($time - 86400), null, null, (\Environment::get('ssl')) ? true : false, true);
 			}
 
 			$strBuffer = '';

--- a/system/modules/core/classes/StyleSheets.php
+++ b/system/modules/core/classes/StyleSheets.php
@@ -1326,7 +1326,7 @@ class StyleSheets extends \Backend
 			}
 
 			// Redirect
-			\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+			\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 			$this->redirect(str_replace('&key=import', '', \Environment::get('request')));
 		}
 

--- a/system/modules/core/classes/Theme.php
+++ b/system/modules/core/classes/Theme.php
@@ -685,7 +685,7 @@ class Theme extends \Backend
 			unset($tl_files, $tl_theme, $tl_style_sheet, $tl_style, $tl_module, $tl_layout, $tl_image_size, $tl_image_size_item);
 		}
 
-		\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+		\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 		$this->Session->remove('uploaded_themes');
 
 		// Redirect

--- a/system/modules/core/controllers/BackendInstall.php
+++ b/system/modules/core/controllers/BackendInstall.php
@@ -821,7 +821,7 @@ class BackendInstall extends \Backend
 	{
 		$_SESSION['TL_INSTALL_EXPIRE'] = (time() + 300);
 		$_SESSION['TL_INSTALL_AUTH'] = md5(uniqid(mt_rand(), true) . (!\Config::get('disableIpCheck') ? \Environment::get('ip') : '') . session_id());
-		$this->setCookie('TL_INSTALL_AUTH', $_SESSION['TL_INSTALL_AUTH'], $_SESSION['TL_INSTALL_EXPIRE'], null, null, false, true);
+		$this->setCookie('TL_INSTALL_AUTH', $_SESSION['TL_INSTALL_AUTH'], $_SESSION['TL_INSTALL_EXPIRE'], null, null, (\Environment::get('ssl')) ? true : false, true);
 	}
 
 

--- a/system/modules/core/controllers/BackendPreview.php
+++ b/system/modules/core/controllers/BackendPreview.php
@@ -83,7 +83,7 @@ class BackendPreview extends \Backend
 							   ->execute($objUser->id, time(), 'FE_USER_AUTH', session_id(), \Environment::get('ip'), $strHash);
 
 				// Set the cookie
-				$this->setCookie('FE_USER_AUTH', $strHash, (time() + \Config::get('sessionTimeout')), null, null, false, true);
+				$this->setCookie('FE_USER_AUTH', $strHash, (time() + \Config::get('sessionTimeout')), null, null, (\Environment::get('ssl')) ? true : false, true);
 				$objTemplate->user = \Input::post('user');
 			}
 		}

--- a/system/modules/core/controllers/BackendSwitch.php
+++ b/system/modules/core/controllers/BackendSwitch.php
@@ -78,14 +78,14 @@ class BackendSwitch extends \Backend
 			// Hide unpublished elements
 			if (\Input::post('unpublished') == 'hide')
 			{
-				$this->setCookie('FE_PREVIEW', 0, ($time - 86400));
+				$this->setCookie('FE_PREVIEW', 0, ($time - 86400), null, null, (\Environment::get('ssl')) ? true : false);
 				$objTemplate->show = 0;
 			}
 
 			// Show unpublished elements
 			else
 			{
-				$this->setCookie('FE_PREVIEW', 1, ($time + \Config::get('sessionTimeout')));
+				$this->setCookie('FE_PREVIEW', 1, ($time + \Config::get('sessionTimeout')), null, null, (\Environment::get('ssl')) ? true : false);
 				$objTemplate->show = 1;
 			}
 
@@ -108,7 +108,7 @@ class BackendSwitch extends \Backend
 									   ->execute($objUser->id, $time, 'FE_USER_AUTH', session_id(), \Environment::get('ip'), $strHash);
 
 						// Set the cookie
-						$this->setCookie('FE_USER_AUTH', $strHash, ($time + \Config::get('sessionTimeout')), null, null, false, true);
+						$this->setCookie('FE_USER_AUTH', $strHash, ($time + \Config::get('sessionTimeout')), null, null, (\Environment::get('ssl')) ? true : false, true);
 						$objTemplate->user = \Input::post('user');
 					}
 				}
@@ -117,7 +117,7 @@ class BackendSwitch extends \Backend
 				else
 				{
 					// Remove cookie
-					$this->setCookie('FE_USER_AUTH', $strHash, ($time - 86400), null, null, false, true);
+					$this->setCookie('FE_USER_AUTH', $strHash, ($time - 86400), null, null, (\Environment::get('ssl')) ? true : false, true);
 					$objTemplate->user = '';
 				}
 			}

--- a/system/modules/core/drivers/DC_File.php
+++ b/system/modules/core/drivers/DC_File.php
@@ -340,7 +340,7 @@ class DC_File extends \DataContainer implements \editable
 			if (\Input::post('saveNclose'))
 			{
 				\Message::reset();
-				\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+				\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 				$this->redirect($this->getReferer());
 			}
 

--- a/system/modules/core/drivers/DC_Folder.php
+++ b/system/modules/core/drivers/DC_Folder.php
@@ -1326,7 +1326,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 			if (\Input::post('saveNclose'))
 			{
 				\Message::reset();
-				\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+				\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 				$this->redirect($this->getReferer());
 			}
 
@@ -1605,7 +1605,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 			{
 				if (\Input::post('saveNclose'))
 				{
-					\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+					\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 					$this->redirect($this->getReferer());
 				}
 
@@ -1798,7 +1798,7 @@ class DC_Folder extends \DataContainer implements \listable, \editable
 
 			if (\Input::post('saveNclose'))
 			{
-				\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+				\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 				$this->redirect($this->getReferer());
 			}
 

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -2089,14 +2089,14 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			if (isset($_POST['saveNclose']))
 			{
 				\Message::reset();
-				\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+				\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 
 				$this->redirect($this->getReferer());
 			}
 			elseif (isset($_POST['saveNedit']))
 			{
 				\Message::reset();
-				\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+				\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 
 				$strUrl = $this->addToUrl($GLOBALS['TL_DCA'][$this->strTable]['list']['operations']['edit']['href'], false);
 				$strUrl = preg_replace('/&(amp;)?(s2e|act|mode|pid)=[^&]*/i', '', $strUrl);
@@ -2106,7 +2106,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			elseif (isset($_POST['saveNback']))
 			{
 				\Message::reset();
-				\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+				\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 
 				if ($this->ptable == '')
 				{
@@ -2125,7 +2125,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			elseif (isset($_POST['saveNcreate']))
 			{
 				\Message::reset();
-				\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+				\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 
 				$strUrl = TL_SCRIPT . '?do=' . \Input::get('do');
 
@@ -2480,7 +2480,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			{
 				if (\Input::post('saveNclose'))
 				{
-					\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+					\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 					$this->redirect($this->getReferer());
 				}
 
@@ -2789,7 +2789,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			{
 				if (\Input::post('saveNclose'))
 				{
-					\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+					\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 					$this->redirect($this->getReferer());
 				}
 

--- a/system/modules/core/elements/ContentTable.php
+++ b/system/modules/core/elements/ContentTable.php
@@ -61,7 +61,7 @@ class ContentTable extends \ContentElement
 
 					if (\Input::cookie($co) == '')
 					{
-						\System::setCookie($co, $i . '|' . $so, 0);
+						\System::setCookie($co, $i . '|' . $so, 0, null, null, (\Environment::get('ssl')) ? true : false);
 					}
 				}
 

--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -279,7 +279,7 @@ abstract class User extends \System
 		$this->Database->prepare("UPDATE tl_session SET tstamp=$time WHERE hash=?")
 					   ->execute($this->strHash);
 
-		$this->setCookie($this->strCookie, $this->strHash, ($time + \Config::get('sessionTimeout')), null, null, false, true);
+		$this->setCookie($this->strCookie, $this->strHash, ($time + \Config::get('sessionTimeout')), null, null, (\Environment::get('ssl')) ? true : false, true);
 
 		// HOOK: post authenticate callback
 		if (isset($GLOBALS['TL_HOOKS']['postAuthenticate']) && is_array($GLOBALS['TL_HOOKS']['postAuthenticate']))
@@ -568,7 +568,7 @@ abstract class User extends \System
 					   ->execute($this->intId, $time, $this->strCookie, session_id(), $this->strIp, $this->strHash);
 
 		// Set the authentication cookie
-		$this->setCookie($this->strCookie, $this->strHash, ($time + \Config::get('sessionTimeout')), null, null, false, true);
+		$this->setCookie($this->strCookie, $this->strHash, ($time + \Config::get('sessionTimeout')), null, null, (\Environment::get('ssl')) ? true : false, true);
 
 		// Set the login status (backwards compatibility)
 		$_SESSION['TL_USER_LOGGED_IN'] = true;
@@ -609,7 +609,7 @@ abstract class User extends \System
 					   ->execute($this->strHash);
 
 		// Remove cookie and hash
-		$this->setCookie($this->strCookie, $this->strHash, ($time - 86400), null, null, false, true);
+		$this->setCookie($this->strCookie, $this->strHash, ($time - 86400), null, null, (\Environment::get('ssl')) ? true : false, true);
 		$this->strHash = '';
 
 		// Destroy the current session

--- a/system/modules/core/pages/PageRegular.php
+++ b/system/modules/core/pages/PageRegular.php
@@ -207,11 +207,11 @@ class PageRegular extends \Frontend
 		{
 			if (\Input::get('toggle_view') == 'mobile')
 			{
-				$this->setCookie('TL_VIEW', 'mobile', 0);
+				$this->setCookie('TL_VIEW', 'mobile', 0, null, null, (\Environment::get('ssl')) ? true : false);
 			}
 			else
 			{
-				$this->setCookie('TL_VIEW', 'desktop', 0);
+				$this->setCookie('TL_VIEW', 'desktop', 0, null, null, (\Environment::get('ssl')) ? true : false);
 			}
 
 			$this->redirect($this->getReferer());

--- a/system/modules/core/widgets/ListWizard.php
+++ b/system/modules/core/widgets/ListWizard.php
@@ -229,7 +229,7 @@ class ListWizard extends \Widget
 			$this->Database->prepare("UPDATE " . $dc->table . " SET listitems=? WHERE id=?")
 						   ->execute(serialize($arrList), \Input::get('id'));
 
-			\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+			\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 			$this->redirect(str_replace('&key=list', '', \Environment::get('request')));
 		}
 

--- a/system/modules/core/widgets/TableWizard.php
+++ b/system/modules/core/widgets/TableWizard.php
@@ -311,7 +311,7 @@ class TableWizard extends \Widget
 			$this->Database->prepare("UPDATE " . $dc->table . " SET tableitems=? WHERE id=?")
 						   ->execute(serialize($arrTable), \Input::get('id'));
 
-			\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+			\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 			$this->redirect(str_replace('&key=table', '', \Environment::get('request')));
 		}
 

--- a/system/modules/newsletter/classes/Newsletter.php
+++ b/system/modules/newsletter/classes/Newsletter.php
@@ -521,7 +521,7 @@ class Newsletter extends \Backend
 				\Message::addInfo(sprintf($GLOBALS['TL_LANG']['tl_newsletter_recipients']['invalid'], $intInvalid));
 			}
 
-			\System::setCookie('BE_PAGE_OFFSET', 0, 0);
+			\System::setCookie('BE_PAGE_OFFSET', 0, 0, null, null, (\Environment::get('ssl')) ? true : false);
 			$this->reload();
 		}
 


### PR DESCRIPTION
Even if a website is already accessible via HTTPS most setups provide a
fallback for HTTP users to redirect to HTTPS.

In this scenario Contao can leak sensible *_USER_AUTH cookies: Imagine a
user is in the same network like an attacker. If the attacker manages to
trick the user to access the Contao website via HTTP the attacker can
capture the user's session.

This commit mitigates the problem by activating the secure flag for cookies
when using SSL.

Tested against v3.5.16.
