### PR TITLE
Wrap combined file content with global namespace

### DIFF
--- a/system/modules/core/library/Contao/Automator.php
+++ b/system/modules/core/library/Contao/Automator.php
@@ -494,7 +494,9 @@ class Automator extends \System
 
 			if (file_exists(TL_ROOT . '/' . $strFile))
 			{
-				$objCacheFile->append(static::readPhpFileWithoutTags($strFile));
+				$strBuffer = static::readPhpFileWithoutTags($strFile);
+				$strBuffer = $this->wrapWithGlobalNamespace($strBuffer);
+				$objCacheFile->append($strBuffer);
 			}
 		}
 
@@ -599,7 +601,9 @@ class Automator extends \System
 
 				if (file_exists(TL_ROOT . '/' . $strFile))
 				{
-					$objCacheFile->append(static::readPhpFileWithoutTags($strFile));
+					$strBuffer = static::readPhpFileWithoutTags($strFile);
+					$strBuffer = $this->wrapWithGlobalNamespace($strBuffer);
+					$objCacheFile->append($strBuffer);
 				}
 			}
 
@@ -774,5 +778,17 @@ class Automator extends \System
 
 		// Add a log entry
 		$this->log('Generated the DCA extracts', __METHOD__, TL_CRON);
+	}
+
+	/**
+	 * Wrap content by global namespace
+	 * 
+	 * @param string $strBuffer
+	 *
+	 * @return string
+	 */
+	private function wrapWithGlobalNamespace($strBuffer)
+	{
+		return sprintf ("namespace {\n\n%s\n\n}\n", $strBuffer);
 	}
 }

--- a/system/modules/core/library/Contao/Automator.php
+++ b/system/modules/core/library/Contao/Automator.php
@@ -494,9 +494,7 @@ class Automator extends \System
 
 			if (file_exists(TL_ROOT . '/' . $strFile))
 			{
-				$strBuffer = static::readPhpFileWithoutTags($strFile);
-				$strBuffer = $this->wrapWithGlobalNamespace($strBuffer);
-				$objCacheFile->append($strBuffer);
+				$objCacheFile->append(static::readPhpFileWithoutTags($strFile));
 			}
 		}
 
@@ -523,7 +521,9 @@ class Automator extends \System
 
 			if (file_exists(TL_ROOT . '/' . $strFile))
 			{
-				$objCacheFile->append(static::readPhpFileWithoutTags($strFile));
+				$strBuffer = static::readPhpFileWithoutTags($strFile);
+				$strBuffer = $this->wrapWithGlobalNamespace($strBuffer);
+				$objCacheFile->append($strBuffer);
 			}
 		}
 


### PR DESCRIPTION
Since Contao supports callables for dca callbacks and PHP 5.5 introduced the `Class:class` constant there are valid cases using the `use statement` for namespaced classes in the dca and config files.

At the moment you cannot use the `use statement` because of the danger that the combined files could have duplicate use statements. This pull request fixes it by wrapping each file content in a namespace notation.

So it would get possible to use following code safely:

**DCA file**

``` php
<?php 
// dca/tl_content.php
use Vendor\Namespace\GetTemplatesCallback;

$GLOBALS['TL_DCA']['tl_content']['fields']['customTemplate']['options_callback'] = new GetTemplatesCallback('ce_custom');
```

**Config file**

``` php
<?php 
// config/config.php
use Vendor\Namespace\CustomElement;
$GLOBALS['TL_CTE']['text']['custom'] = CustomElement::class;
```
