### PR TITLE
Cache fallback pages

### DIFF
--- a/system/modules/core/models/PageModel.php
+++ b/system/modules/core/models/PageModel.php
@@ -723,7 +723,7 @@ class PageModel extends \Model
 	/**
 	 * Register the contao.dns-fallback alias when the model is attached to the registry
 	 *
-	 * @param \Model\Registry|\Contao\Model\Registry $registry The model registry
+	 * @param \Model\Registry $registry The model registry
 	 */
 	public function onRegister(\Model\Registry $registry)
 	{
@@ -740,7 +740,7 @@ class PageModel extends \Model
 	/**
 	 * Unregister the contao.dns-fallback alias when the model is detached from the registry
 	 *
-	 * @param \Model\Registry|\Contao\Model\Registry $registry The model registry
+	 * @param \Model\Registry $registry The model registry
 	 */
 	public function onUnregister(\Model\Registry $registry)
 	{

--- a/system/modules/core/models/PageModel.php
+++ b/system/modules/core/models/PageModel.php
@@ -730,12 +730,9 @@ class PageModel extends \Model
 		parent::onRegister($registry);
 
 		// Register this model as being the fallback page for a given dns
-		if ($this->fallback)
+		if ($this->fallback && !$registry->isRegisteredAlias($this, 'dns-fallback', $this->dns))
 		{
-			if (!$registry->isRegisteredAlias($this, 'dns-fallback', $this->dns))
-			{
-				$registry->registerAlias($this, 'dns-fallback', $this->dns);
-			}
+			$registry->registerAlias($this, 'dns-fallback', $this->dns);
 		}
 	}
 

--- a/system/modules/core/models/PageModel.php
+++ b/system/modules/core/models/PageModel.php
@@ -628,10 +628,10 @@ class PageModel extends \Model
 	 */
 	public static function findPublishedFallbackByHostname($strHost, array $arrOptions=array())
 	{
-		// Try to load from the registry
+		// Try to load from the registry (see #8544)
 		if (empty($arrOptions))
 		{
-			$objModel = \Model\Registry::getInstance()->fetch(static::$strTable, $strHost, 'dns-fallback');
+			$objModel = \Model\Registry::getInstance()->fetch(static::$strTable, $strHost, 'contao.dns-fallback');
 
 			if ($objModel !== null)
 			{
@@ -721,7 +721,7 @@ class PageModel extends \Model
 
 
 	/**
-	 * Called when the model is attached to the model registry
+	 * Register the contao.dns-fallback alias when the model is attached to the registry
 	 *
 	 * @param \Model\Registry|\Contao\Model\Registry $registry The model registry
 	 */
@@ -730,15 +730,15 @@ class PageModel extends \Model
 		parent::onRegister($registry);
 
 		// Register this model as being the fallback page for a given dns
-		if ($this->fallback && $this->type == 'root' && !$registry->isRegisteredAlias($this, 'dns-fallback', $this->dns))
+		if ($this->fallback && $this->type == 'root' && !$registry->isRegisteredAlias($this, 'contao.dns-fallback', $this->dns))
 		{
-			$registry->registerAlias($this, 'dns-fallback', $this->dns);
+			$registry->registerAlias($this, 'contao.dns-fallback', $this->dns);
 		}
 	}
 
 
 	/**
-	 * Called when the model is detached from the model registry
+	 * Unregister the contao.dns-fallback alias when the model is detached from the registry
 	 *
 	 * @param \Model\Registry|\Contao\Model\Registry $registry The model registry
 	 */
@@ -747,9 +747,9 @@ class PageModel extends \Model
 		parent::onUnregister($registry);
 
 		// Unregister the fallback page
-		if ($this->fallback && $this->type == 'root' && $registry->isRegisteredAlias($this, 'dns-fallback', $this->dns))
+		if ($this->fallback && $this->type == 'root' && $registry->isRegisteredAlias($this, 'contao.dns-fallback', $this->dns))
 		{
-			$registry->unregisterAlias($this, 'dns-fallback', $this->dns);
+			$registry->unregisterAlias($this, 'contao.dns-fallback', $this->dns);
 		}
 	}
 

--- a/system/modules/core/models/PageModel.php
+++ b/system/modules/core/models/PageModel.php
@@ -728,6 +728,23 @@ class PageModel extends \Model
 
 
 	/**
+	 * Called when the model is detached from the model registry
+	 *
+	 * @param \Model\Registry|\Contao\Model\Registry $registry The model registry
+	 */
+	public function onUnregister(\Model\Registry $registry)
+	{
+		parent::onUnregister($registry);
+
+		// Unregister the fallback page
+		if ($registry->isRegisteredAlias($this, 'dns-fallback', $this->dns))
+		{
+			$registry->unregisterAlias($this, 'dns-fallback', $this->dns);
+		}
+	}
+
+
+	/**
 	 * Get the details of a page including inherited parameters
 	 *
 	 * @return \PageModel The page model

--- a/system/modules/core/models/PageModel.php
+++ b/system/modules/core/models/PageModel.php
@@ -628,6 +628,17 @@ class PageModel extends \Model
 	 */
 	public static function findPublishedFallbackByHostname($strHost, array $arrOptions=array())
 	{
+		// Try to load from the registry
+		if (empty($arrOptions))
+		{
+			$objModel = \Model\Registry::getInstance()->fetch(static::$strTable, $strHost, 'dns-fallback');
+
+			if ($objModel !== null)
+			{
+				return $objModel;
+			}
+		}
+
 		$t = static::$strTable;
 		$arrColumns = array("$t.dns=? AND $t.fallback='1'");
 
@@ -637,7 +648,14 @@ class PageModel extends \Model
 			$arrColumns[] = "($t.start='' OR $t.start<='$time') AND ($t.stop='' OR $t.stop>'" . ($time + 60) . "') AND $t.published='1'";
 		}
 
-		return static::findOneBy($arrColumns, $strHost, $arrOptions);
+		$objModel = static::findOneBy($arrColumns, $strHost, $arrOptions);
+
+		if (empty($arrOptions))
+		{
+			\Model\Registry::getInstance()->registerAlias($objModel, 'dns-fallback', $strHost);
+		}
+
+		return $objModel;
 	}
 
 

--- a/system/modules/core/models/PageModel.php
+++ b/system/modules/core/models/PageModel.php
@@ -730,7 +730,7 @@ class PageModel extends \Model
 		parent::onRegister($registry);
 
 		// Register this model as being the fallback page for a given dns
-		if ($this->fallback && !$registry->isRegisteredAlias($this, 'dns-fallback', $this->dns))
+		if ($this->fallback && $this->type == 'root' && !$registry->isRegisteredAlias($this, 'dns-fallback', $this->dns))
 		{
 			$registry->registerAlias($this, 'dns-fallback', $this->dns);
 		}
@@ -747,7 +747,7 @@ class PageModel extends \Model
 		parent::onUnregister($registry);
 
 		// Unregister the fallback page
-		if ($registry->isRegisteredAlias($this, 'dns-fallback', $this->dns))
+		if ($this->fallback && $this->type == 'root' && $registry->isRegisteredAlias($this, 'dns-fallback', $this->dns))
 		{
 			$registry->unregisterAlias($this, 'dns-fallback', $this->dns);
 		}

--- a/system/modules/core/models/PageModel.php
+++ b/system/modules/core/models/PageModel.php
@@ -648,14 +648,7 @@ class PageModel extends \Model
 			$arrColumns[] = "($t.start='' OR $t.start<='$time') AND ($t.stop='' OR $t.stop>'" . ($time + 60) . "') AND $t.published='1'";
 		}
 
-		$objModel = static::findOneBy($arrColumns, $strHost, $arrOptions);
-
-		if (empty($arrOptions))
-		{
-			\Model\Registry::getInstance()->registerAlias($objModel, 'dns-fallback', $strHost);
-		}
-
-		return $objModel;
+		return static::findOneBy($arrColumns, $strHost, $arrOptions);
 	}
 
 
@@ -724,6 +717,26 @@ class PageModel extends \Model
 		}
 
 		return $objPage->loadDetails();
+	}
+
+
+	/**
+	 * Called when the model is attached to the model registry
+	 *
+	 * @param \Model\Registry|\Contao\Model\Registry $registry The model registry
+	 */
+	public function onRegister(\Model\Registry $registry)
+	{
+		parent::onRegister($registry);
+
+		// Register this model as being the fallback page for a given dns
+		if ($this->fallback)
+		{
+			if (!$registry->isRegisteredAlias($this, 'dns-fallback', $this->dns))
+			{
+				$registry->registerAlias($this, 'dns-fallback', $this->dns);
+			}
+		}
 	}
 
 


### PR DESCRIPTION
I noticed that `PageModel::findWithDetails()` executes a lot of very identical queries. I figured it was the query to fetch the fallback page. As you can see, whenever you call `findWithDetails()`, Contao works up the tree and calls the fallback page for every page again, even though the information is already there. I inspected an Isotope installation where there was some heavy querying going on because of that. To give you some numbers: With this fix, the number of queries dropped from 1121 for a page to 394 ;-) So I consider this a quite important bugfix that should go into 3.5.
