### PR TITLE
fix typo in Widget comment

### DIFF
--- a/system/modules/core/library/Contao/Widget.php
+++ b/system/modules/core/library/Contao/Widget.php
@@ -967,7 +967,7 @@ abstract class Widget extends \BaseTemplate
 					}
 					break;
 
-				// Do not allow any characters that are usually encoded by class Input [=<>()#/])
+				// Do not allow any characters that are usually encoded by class Input [#<>()\=])
 				case 'extnd':
 					if (!\Validator::isExtendedAlphanumeric(html_entity_decode($varInput)))
 					{

--- a/system/modules/core/library/Contao/Widget.php
+++ b/system/modules/core/library/Contao/Widget.php
@@ -967,7 +967,7 @@ abstract class Widget extends \BaseTemplate
 					}
 					break;
 
-				// Do not allow any characters that are usually encoded by class Input [#<>()\=])
+				// Do not allow any characters that are usually encoded by class Input ([#<>()\=])
 				case 'extnd':
 					if (!\Validator::isExtendedAlphanumeric(html_entity_decode($varInput)))
 					{


### PR DESCRIPTION
1. there was a typo in the comment saying that the `extnd` regex disallows `/`, but it actually disallows `\`
2. the order of the symbols is now equal to [Validator::isExtendedAlphanumeric](https://github.com/contao/core/blob/3.5.18/system/modules/core/library/Contao/Validator.php#L95-L105)

Noticed via #8556