### PR TITLE
Adding method findOne to Model.php

### DIFF
--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -980,6 +980,29 @@ abstract class Model
 
 		return static::find($arrOptions);
 	}
+	
+	/**
+	 * Find the first record
+	 * 
+	 * @param array $arrOptions An optional options array
+	 * 
+	 * @return static|null The Model or null if the result is empty
+	 */
+	public static function findOne(array $arrOptions=array())
+	{
+		$arrOptions = array_merge
+		(
+			array
+			(
+				'limit'	 => 1,
+				'return' => 'Model'
+			),
+			
+			$arrOptions
+		);
+		
+		return static::find($arrOptions);
+	}
 
 
 	/**


### PR DESCRIPTION
The `function find` is **protected** and it cannot be used from outside the Model context. The function `findAll` on the other hand is declared **public** and can be used to search for all occurrences but there is no possiblity (or maybe I overlooked it?) to search for 2 or more fields (e.g. pid and module) in a Standard model like ContentModel and get just **one result**. (I would have to override the Model class just to do some migration steps) So I propose this additional function in the Model.php to enhance the possibilities to query the Database using Models.