### PR TITLE
Do not convert paths to uuid for paths outside of the upload path.

### DIFF
--- a/system/modules/core/widgets/FileSelector.php
+++ b/system/modules/core/widgets/FileSelector.php
@@ -456,6 +456,12 @@ class FileSelector extends \Widget
 			return;
 		}
 
+		// Do not convert values if path is not in the upload path
+		if ($this->path !== \Config::get('uploadPath'))
+		{
+			return;
+		}
+
 		// Ignore the numeric IDs when in switch mode (TinyMCE)
 		if (\Input::get('switch'))
 		{

--- a/system/modules/core/widgets/FileSelector.php
+++ b/system/modules/core/widgets/FileSelector.php
@@ -457,7 +457,7 @@ class FileSelector extends \Widget
 		}
 
 		// Do not convert values if path is not in the upload path
-		if ($this->path !== \Config::get('uploadPath'))
+		if (strncmp($this->path, \Config::get('uploadPath'), strlen(\Config::get('uploadPath'))) !== 0)
 		{
 			return;
 		}


### PR DESCRIPTION
This PR fixes the issue that values get lost when using the file selector for paths outside of the upload path (dbafs).