### PR TITLE
Added a simple event details query cache

### DIFF
--- a/system/modules/calendar/classes/Events.php
+++ b/system/modules/calendar/classes/Events.php
@@ -43,6 +43,12 @@ abstract class Events extends \Module
 	 */
 	protected $arrEvents = array();
 
+	/**
+	 * Has details cache
+	 * @var array
+	 */
+	protected $arrHasDetailsCache = array();
+
 
 	/**
 	 * Sort out protected archives
@@ -336,7 +342,14 @@ abstract class Events extends \Module
 				return $strDetails;
 			};
 
-			$arrEvent['hasDetails'] = (\ContentModel::countPublishedByPidAndTable($id, 'tl_calendar_events') > 0);
+			if (isset($this->arrHasDetailsCache[$id]))
+			{
+				$arrEvent['hasDetails'] = $this->arrHasDetailsCache[$id];
+			}
+			else
+			{
+				$arrEvent['hasDetails'] = $this->arrHasDetailsCache[$id] = (\ContentModel::countPublishedByPidAndTable($id, 'tl_calendar_events') > 0);
+			}
 		}
 
 		// Get todays start and end timestamp


### PR DESCRIPTION
The event class checks if an event has details for every single event. Especially when using repeating events, this causes a lot of unnecessary database queries.
In the Contao demo we have 3 events that are repeated. This simple PR reduced my DB queries from 130 down to 46.