### PR TITLE
[RTM] Fix the mandatoriness validation of ImageSize widget

### DIFF
--- a/system/modules/core/widgets/ImageSize.php
+++ b/system/modules/core/widgets/ImageSize.php
@@ -76,7 +76,7 @@ class ImageSize extends \Widget
 
 		if (!is_numeric($varInput[2]))
 		{
-		    $varInput[0] = parent::validator($varInput[0]);
+			$varInput[0] = parent::validator($varInput[0]);
 			$varInput[1] = parent::validator($varInput[1]);
 		}
 

--- a/system/modules/core/widgets/ImageSize.php
+++ b/system/modules/core/widgets/ImageSize.php
@@ -72,12 +72,12 @@ class ImageSize extends \Widget
 	 */
 	protected function validator($varInput)
 	{
-		$varInput[0] = parent::validator($varInput[0]);
+        $varInput[2] = preg_replace('/[^a-z0-9_]+/', '', $varInput[2]);
 
-		if (!is_numeric($varInput[0]))
+		if (!is_numeric($varInput[2]))
 		{
+		    $varInput[0] = parent::validator($varInput[0]);
 			$varInput[1] = parent::validator($varInput[1]);
-			$varInput[2] = preg_replace('/[^a-z0-9_]+/', '', $varInput[2]);
 		}
 
 		return $varInput;

--- a/system/modules/core/widgets/ImageSize.php
+++ b/system/modules/core/widgets/ImageSize.php
@@ -73,8 +73,12 @@ class ImageSize extends \Widget
 	protected function validator($varInput)
 	{
 		$varInput[0] = parent::validator($varInput[0]);
-		$varInput[1] = parent::validator($varInput[1]);
-		$varInput[2] = preg_replace('/[^a-z0-9_]+/', '', $varInput[2]);
+
+		if (!is_numeric($varInput[0]))
+		{
+			$varInput[1] = parent::validator($varInput[1]);
+			$varInput[2] = preg_replace('/[^a-z0-9_]+/', '', $varInput[2]);
+		}
 
 		return $varInput;
 	}

--- a/system/modules/core/widgets/ImageSize.php
+++ b/system/modules/core/widgets/ImageSize.php
@@ -72,7 +72,7 @@ class ImageSize extends \Widget
 	 */
 	protected function validator($varInput)
 	{
-        $varInput[2] = preg_replace('/[^a-z0-9_]+/', '', $varInput[2]);
+		$varInput[2] = preg_replace('/[^a-z0-9_]+/', '', $varInput[2]);
 
 		if (!is_numeric($varInput[2]))
 		{

--- a/system/modules/core/widgets/ImageSize.php
+++ b/system/modules/core/widgets/ImageSize.php
@@ -76,6 +76,29 @@ class ImageSize extends \Widget
 
 		if (!is_numeric($varInput[2]))
 		{
+			switch ($varInput[2])
+			{
+				// Validate relative dimensions - width or height required
+				case 'proportional':
+				case 'box':
+					$this->mandatory = !$varInput[0] && !$varInput[1];
+					break;
+
+				// Validate exact dimensions - width and height required
+				case 'crop':
+				case 'left_top':
+				case 'center_top':
+				case 'right_top':
+				case 'left_center':
+				case 'center_center':
+				case 'right_center':
+				case 'left_bottom':
+				case 'center_bottom':
+				case 'right_bottom':
+					$this->mandatory = !$varInput[0] || !$varInput[1];
+					break;
+			}
+
 			$varInput[0] = parent::validator($varInput[0]);
 			$varInput[1] = parent::validator($varInput[1]);
 		}


### PR DESCRIPTION
Without this fix if you set the field to be mandatory and choose the predefined image size value, you will always get an error as ```$varInput[1]``` will be empty.