### PR TITLE
[RTM] Support cross domain requests when rebuilding the search index

### DIFF
--- a/system/modules/core/controllers/FrontendIndex.php
+++ b/system/modules/core/controllers/FrontendIndex.php
@@ -526,6 +526,9 @@ class FrontendIndex extends \Frontend
 			header('Expires: Fri, 06 Jun 1975 15:10:00 GMT');
 		}
 
+		// CORS support
+		\Controller::setCorsHeaders();
+
 		echo $strBuffer;
 		exit;
 	}

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -996,26 +996,7 @@ abstract class Controller extends \System
 	 */
 	public static function reload()
 	{
-		if (headers_sent())
-		{
-			exit;
-		}
-
-		$strLocation = \Environment::get('uri');
-
-		// Ajax request
-		if (\Environment::get('isAjaxRequest'))
-		{
-			header('HTTP/1.1 204 No Content');
-			header('X-Ajax-Location: ' . $strLocation);
-		}
-		else
-		{
-			header('HTTP/1.1 303 See Other');
-			header('Location: ' . $strLocation);
-		}
-
-		exit;
+		static::redirect(\Environment::get('uri'));
 	}
 
 
@@ -1071,7 +1052,40 @@ abstract class Controller extends \System
 			header('Location: ' . $strLocation);
 		}
 
+		static::setCorsHeaders();
+
 		exit;
+	}
+
+	/**
+	 * Sends the correct HTTP headers for the back end rebuild search index feature.
+	 * To be removed as soon as we have a real web spider.
+	 */
+	public static function setCorsHeaders()
+	{
+		$strOrigin = \Environment::get('httpOrigin');
+
+		// Not a CORS request
+		if (!$strOrigin)
+		{
+			return;
+		}
+
+		$arrAllowedMethods = ['GET', 'HEAD', 'OPTIONS'];
+
+		// Protect and only allow requests from own known hosts and methods
+		if (in_array(\Environment::get('requestMethod'), $arrAllowedMethods))
+		{
+			$blnCheck = \Database::getInstance()->prepare('SELECT id FROM tl_page WHERE type=? AND dns=?')
+				->execute('root', preg_replace('@^https?://@', '', $strOrigin));
+
+			if ($blnCheck->numRows)
+			{
+				header('Access-Control-Allow-Headers: X-Requested-With');
+				header('Access-Control-Allow-Methods: ' . implode(', ', $arrAllowedMethods));
+				header('Access-Control-Allow-Origin: ' . $strOrigin);
+			}
+		}
 	}
 
 

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -1058,8 +1058,7 @@ abstract class Controller extends \System
 	}
 
 	/**
-	 * Sends the correct HTTP headers for the back end rebuild search index feature.
-	 * To be removed as soon as we have a real web spider.
+	 * Send the correct HTTP headers when rebuilding the search index in the back end
 	 */
 	public static function setCorsHeaders()
 	{
@@ -1071,13 +1070,15 @@ abstract class Controller extends \System
 			return;
 		}
 
-		$arrAllowedMethods = ['GET', 'HEAD', 'OPTIONS'];
+		$arrAllowedMethods = array('GET', 'HEAD', 'OPTIONS');
 
 		// Protect and only allow requests from own known hosts and methods
 		if (in_array(\Environment::get('requestMethod'), $arrAllowedMethods))
 		{
-			$blnCheck = \Database::getInstance()->prepare('SELECT id FROM tl_page WHERE type=? AND dns=?')
-				->execute('root', preg_replace('@^https?://@', '', $strOrigin));
+			$blnCheck = \Database::getInstance()
+				->prepare('SELECT id FROM tl_page WHERE type=? AND dns=?')
+				->execute('root', preg_replace('@^https?://@', '', $strOrigin))
+			;
 
 			if ($blnCheck->numRows)
 			{

--- a/system/modules/core/library/Contao/Template.php
+++ b/system/modules/core/library/Contao/Template.php
@@ -294,6 +294,9 @@ abstract class Template extends \BaseTemplate
 		header('Vary: User-Agent', false);
 		header('Content-Type: ' . $this->strContentType . '; charset=' . \Config::get('characterSet'));
 
+		// CORS support
+		\Controller::setCorsHeaders();
+
 		// Add the debug bar
 		if (\Config::get('debugMode') && !\Config::get('hideDebugBar') && !isset($_GET['popup']))
 		{

--- a/system/modules/core/templates/backend/be_rebuild_index.html5
+++ b/system/modules/core/templates/backend/be_rebuild_index.html5
@@ -33,7 +33,7 @@
             },
             onFailure: function(xhr) {
               var status = xhr.status;
-              if (status == 0) {
+              if (status === 0) {
                 status = 'CORS request forbidden';
               }
               el.addClass('tl_red');

--- a/system/modules/core/templates/backend/be_rebuild_index.html5
+++ b/system/modules/core/templates/backend/be_rebuild_index.html5
@@ -32,12 +32,8 @@
               el.addClass('tl_green');
             },
             onFailure: function(xhr) {
-              var status = xhr.status;
-              if (status === 0) {
-                status = 'CORS request forbidden';
-              }
               el.addClass('tl_red');
-              el.set('text', '[' + status + '] ' + el.get('text'));
+              el.set('text', '[' + xhr.status + '] ' + el.get('text'));
             },
             url: el.getAttribute('data-url')
           }));

--- a/system/modules/core/templates/backend/be_rebuild_index.html5
+++ b/system/modules/core/templates/backend/be_rebuild_index.html5
@@ -30,7 +30,6 @@
           el.getAttribute('data-url') && queue.addRequest(i, new Request({
             onSuccess: function() {
               el.addClass('tl_green');
-              el.set('text', '[200] ' + el.get('text'));
             },
             onFailure: function(xhr) {
               var status = xhr.status;

--- a/system/modules/core/templates/backend/be_rebuild_index.html5
+++ b/system/modules/core/templates/backend/be_rebuild_index.html5
@@ -30,10 +30,15 @@
           el.getAttribute('data-url') && queue.addRequest(i, new Request({
             onSuccess: function() {
               el.addClass('tl_green');
+              el.set('text', '[200] ' + el.get('text'));
             },
             onFailure: function(xhr) {
+              var status = xhr.status;
+              if (status == 0) {
+                status = 'CORS request forbidden';
+              }
               el.addClass('tl_red');
-              el.set('text', '[' + xhr.status + '] ' + el.get('text'));
+              el.set('text', '[' + status + '] ' + el.get('text'));
             },
             url: el.getAttribute('data-url')
           }));


### PR DESCRIPTION
This is a PR for https://github.com/contao/core-bundle/issues/633.

Due to the fact that we are requesting using ajax, it's never a simple request CORS case (header `X-Requested-With`) so you should read up upon the general CORS concept and preflighted requests.

This PR

* makes sure CORS headers are only set when a `GET` request is sent together with the `Contao-Rebuild-Search-Index` header.
* for maximum security, the `Access-Control-Allow-Origin` header is only set when there's also a root page responsible for that origin.
* also sets the headers on redirect responses which is currently not supported in the major browsers.

As of today it does not work for pages in the search index that send 3xx redirect headers because the initial standard forbid redirects in preflighted requests. This [has been changed](https://github.com/whatwg/fetch/commit/0d9a4db8bc02251cc9e391543bb3c1322fb882f2) only a few months ago and is not adopted in the browsers yet. Chromium seems to be [about to merge support for the adjusted spec](https://bugs.chromium.org/p/chromium/issues/detail?id=580796).

I ran into that issue because Isotope sends a redirect in the filter module (using `Controller::redirect()`) so you as of today you end up having something like this:

![bildschirmfoto 2016-12-15 um 14 53 14](https://cloud.githubusercontent.com/assets/481937/21226544/3c06e9fc-c2d6-11e6-812e-5bf7c0404f53.png)

So the PR is already prepared and does send the correct headers on redirect responses too but until the browser vendors are adjusting to the updated spec, there might be a few pages failing. Anyway, I think we can live with that as there will be only a little number of pages that fail. :-)

I would like to thank @netzarbeiter for setting up a test environment for me right after we had the Contao call. Open source work at its best 👍 