### PR TITLE
Do not re-attach clone of non-registered model

### DIFF
--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -682,6 +682,11 @@ abstract class Model
 	 */
 	public function detach($blnKeepClone=true)
 	{
+		if (!\Model\Registry::getInstance()->isRegistered($this))
+		{
+			return;
+		}
+
 		\Model\Registry::getInstance()->unregister($this);
 
 		if ($blnKeepClone)

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -682,12 +682,14 @@ abstract class Model
 	 */
 	public function detach($blnKeepClone=true)
 	{
-		if (!\Model\Registry::getInstance()->isRegistered($this))
+		$registry = \Model\Registry::getInstance();
+
+		if (!$registry->isRegistered($this))
 		{
 			return;
 		}
 
-		\Model\Registry::getInstance()->unregister($this);
+		$registry->unregister($this);
 
 		if ($blnKeepClone)
 		{


### PR DESCRIPTION
Related to https://github.com/isotope/core/issues/1742

If a model is created without fetching from the database and `preventSaving()` is called as in https://github.com/isotope/core/blob/master/system/modules/isotope/library/Isotope/Model/Config.php#L102-L123, the model is unregistered (which does nothing) and re-attached if `$blnKeepClone` is true. This results in duplicate models because the primary key is not set.

I don't think we should keep a clone if the original model was not in the registry previously.