### PR TITLE
add logging for IP check

### DIFF
--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -260,8 +260,14 @@ abstract class User extends \System
 		$time = time();
 
 		// Validate the session
-		if ($objSession->sessionID != session_id() || (!\Config::get('disableIpCheck') && $objSession->ip != $this->strIp) || $objSession->hash != $this->strHash || ($objSession->tstamp + \Config::get('sessionTimeout')) < $time)
+		if ($objSession->sessionID != session_id() || $objSession->hash != $this->strHash || ($objSession->tstamp + \Config::get('sessionTimeout')) < $time)
 		{
+			return false;
+		}
+
+		if (!\Config::get('disableIpCheck') && $objSession->ip != $this->strIp)
+		{
+			$this->log('User authentication failed due to IP mismatch. Recorded IP: '.$objSession->ip.'. Current IP: '.$this->strIp, __METHOD__, TL_ERROR);
 			return false;
 		}
 

--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -267,7 +267,7 @@ abstract class User extends \System
 
 		if (!\Config::get('disableIpCheck') && $objSession->ip != $this->strIp)
 		{
-			$this->log('User authentication failed due to IP mismatch; recorded IP: '.$objSession->ip.', Current IP: '.$this->strIp, __METHOD__, TL_ERROR);
+			$this->log('User authentication failed due to IP mismatch; recorded IP: '.$objSession->ip.', current IP: '.$this->strIp, __METHOD__, TL_ERROR);
 			return false;
 		}
 

--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -267,7 +267,7 @@ abstract class User extends \System
 
 		if (!\Config::get('disableIpCheck') && $objSession->ip != $this->strIp)
 		{
-			$this->log('User authentication failed due to IP mismatch. Recorded IP: '.$objSession->ip.'. Current IP: '.$this->strIp, __METHOD__, TL_ERROR);
+			$this->log('User authentication failed due to IP mismatch; recorded IP: '.$objSession->ip.', Current IP: '.$this->strIp, __METHOD__, TL_ERROR);
 			return false;
 		}
 


### PR DESCRIPTION
The IP check of Contao can cause troubles for MacOS users, if their machine has both an IPv4 __and__ an IPv6 address and the host is also accessible via IPv4 __and__ IPv6. In this case MacOS (at least with FireFox, probably all browsers) establishes the HTTP connection randomly either via IPv4 or via IPv6.

So if a user logs in via IPv4 and then at any random time a request in the back end is made via IPv6, the user will be automatically logged out of Contao due to the IP mismatch. The system log will only contain the following entry:
```
User "…" has logged out
```
There will be no log entry at all as to why the user has suddenly been logged out. This PR would add a log entry for the IP check and thus make it at least more clear where the problem is. Log entries for the other cases (session ID check, hash check and timeout) could be added as well of course.