### PR TITLE
Fix insert_*::*|uncached by adding more data to cache file

### DIFF
--- a/system/modules/core/classes/FrontendTemplate.php
+++ b/system/modules/core/classes/FrontendTemplate.php
@@ -250,13 +250,15 @@ class FrontendTemplate extends \Template
 			// Add the cache file header
 			$strHeader = sprintf
 			(
-				"<?php /* %s */ \$expire = %d; \$content = %s; \$type = %s; \$files = %s; \$assets = %s; ?>\n",
+				"<?php /* %s */ \$expire = %d; \$content = %s; \$type = %s; \$files = %s; \$assets = %s; \$objPageId = %s; \$objPageTemplateGroup = %s; ?>\n",
 				$strCacheKey,
 				(int) $intCache,
 				var_export($this->strContentType, true),
 				var_export($objPage->type, true),
 				var_export(TL_FILES_URL, true),
-				var_export(TL_ASSETS_URL, true)
+				var_export(TL_ASSETS_URL, true),
+				var_export($objPage->id, true),
+				var_export($objPage->templateGroup, true)
 			);
 
 			// Create the cache file

--- a/system/modules/core/controllers/FrontendIndex.php
+++ b/system/modules/core/controllers/FrontendIndex.php
@@ -435,6 +435,10 @@ class FrontendIndex extends \Frontend
 		$type = null;
 		$files = null;
 		$assets = null;
+		global $objPageId;
+		global $objPageTemplateGroup;
+		$objPageId = null;
+		$objPageTemplateGroup = "";
 
 		// Include the file
 		ob_start();
@@ -447,6 +451,7 @@ class FrontendIndex extends \Frontend
 
 			return;
 		}
+
 
 		// Define the static URL constants (see #7914)
 		define('TL_FILES_URL', $files);

--- a/system/modules/core/library/Contao/Controller.php
+++ b/system/modules/core/library/Contao/Controller.php
@@ -61,6 +61,13 @@ abstract class Controller extends \System
 		{
 			/** @var \PageModel $objPage */
 			global $objPage;
+			global $objPageId;
+			global $objPageTemplateGroup;
+			if(	!$objPage instanceof \PageModel && isset($objPageId) && $objPageId !== null && isset($objPageTemplateGroup) && is_string($objPageTemplateGroup))
+			{
+				$objPage = \PageModel::findByPk($objPageId);
+				$objPage->templateGroup = $objPageTemplateGroup;
+			}
 
 			if ($objPage->templateGroup != '')
 			{


### PR DESCRIPTION
Potential fix for #8643 
Added pageId and templateGroup to html cache file and using these in the controller to detect the otherwise missing data.