### PR TITLE
Let Environment::requestUri() handle absolute URI

### DIFF
--- a/system/modules/core/library/Contao/Environment.php
+++ b/system/modules/core/library/Contao/Environment.php
@@ -188,7 +188,7 @@ class Environment
 		if (!empty($_SERVER['REQUEST_URI']))
 		{
 			$arrComponents = parse_url($_SERVER['REQUEST_URI']);
-			$strRequest = $arrComponents['path'] . (strlen($arrComponents['query']) ? '?' . $arrComponents['query'] : '');
+			$strRequest = $arrComponents['path'] . (isset($arrComponents['query']) ? '?' . $arrComponents['query'] : '');
 		}
 		else
 		{

--- a/system/modules/core/library/Contao/Environment.php
+++ b/system/modules/core/library/Contao/Environment.php
@@ -187,7 +187,8 @@ class Environment
 	{
 		if (!empty($_SERVER['REQUEST_URI']))
 		{
-			$strRequest = $_SERVER['REQUEST_URI'];
+			$arrComponents = parse_url($_SERVER['REQUEST_URI']);
+			$strRequest = $arrComponents['path'] . (strlen($arrComponents['query']) ? '?' . $arrComponents['query'] : '');
 		}
 		else
 		{


### PR DESCRIPTION
Hi Contaoists!

Method Environment::requestUri relys on the $_SERVER['REQUEST_URI'] variable containing a URI only in relative-form.

In rfc 7230 section 5.3.2 it's demanded that a "server MUST accept the absolute-form in requests, even though HTTP/1.1 clients will only send them in requests to proxies." Therefore $_SERVER['REQUEST_URI'] may contain a full valid URL including scheme. This happens for instance when using a SSH tunnel as HTTP Proxy, where GET request line doesn't get rewritten as in HTTP Proxies for that purpse.
This has an subsequent effect on e.g. the generation of the action attribute in the backend login form, resulting in an url-encoded full URL (http%3A//...) and disabling login.

May I suggest stripping the hostname and scheme if present?

Regards
Martin