### PR TITLE
[RFC] Remove UTF-8 BOM of files before combining them

### DIFF
--- a/system/modules/core/library/Contao/Combiner.php
+++ b/system/modules/core/library/Contao/Combiner.php
@@ -263,6 +263,12 @@ class Combiner extends \System
 		{
 			$content = file_get_contents(TL_ROOT . '/' . $arrFile['name']);
 
+			// Remove UTF-8 BOM
+			if (strncmp($content, "\xEF\xBB\xBF", 3) === 0)
+			{
+				$content = substr($content, 3);
+			}
+
 			// HOOK: modify the file content
 			if (isset($GLOBALS['TL_HOOKS']['getCombinedFile']) && is_array($GLOBALS['TL_HOOKS']['getCombinedFile']))
 			{


### PR DESCRIPTION
I had to answer the question “Why does the first rule of this CSS file get ignored” about a thousand times now. So I think it’s better to fix this in the `Combiner` :)

Steps to reproduce:

1. Create a CSS file with `body { background: red }` and save it as UTF-8 with BOM
2. Select the file as external style sheet in the layout settings.

After that the CSS rule does not get applied because the CSS Parser reads it as `[UTF-8 BOM]body { background: red }` and `[UTF-8 BOM]body` is not a valid selector.