### PR TITLE
fix cache key usage

### DIFF
--- a/system/modules/core/classes/FrontendTemplate.php
+++ b/system/modules/core/classes/FrontendTemplate.php
@@ -213,7 +213,7 @@ class FrontendTemplate extends \Template
 			// If the request string is empty, use a special cache tag which considers the page language
 			if (\Environment::get('request') == '' || \Environment::get('request') == 'index.php')
 			{
-				$strCacheKey = \Environment::get('host') . '/empty.' . $objPage->language;
+				$strCacheKey = ($objPage->domain ?: '*') . '/empty.' . $objPage->language;
 			}
 			else
 			{
@@ -251,7 +251,7 @@ class FrontendTemplate extends \Template
 			$strHeader = sprintf
 			(
 				"<?php /* %s */ \$expire = %d; \$content = %s; \$type = %s; \$files = %s; \$assets = %s; ?>\n",
-				$strCacheKey,
+				ltrim($strCacheKey, '*'),
 				(int) $intCache,
 				var_export($this->strContentType, true),
 				var_export($objPage->type, true),

--- a/system/modules/core/classes/FrontendTemplate.php
+++ b/system/modules/core/classes/FrontendTemplate.php
@@ -250,8 +250,8 @@ class FrontendTemplate extends \Template
 			// Add the cache file header
 			$strHeader = sprintf
 			(
-				"<?php /* %s */ \$expire = %d; \$content = %s; \$type = %s; \$files = %s; \$assets = %s; ?>\n",
-				ltrim($strCacheKey, '*'),
+				"<?php\n\n// %s\n\$expire = %d;\n\$content = %s;\n\$type = %s;\n\$files = %s;\n\$assets = %s;\n\n?>\n",
+				$strCacheKey,
 				(int) $intCache,
 				var_export($this->strContentType, true),
 				var_export($objPage->type, true),


### PR DESCRIPTION
This fixes #8694.

Explanation:

* The `Automator` uses `$objPages->dns ?: '*'` [here](https://github.com/contao/core/blob/3.5.25/system/modules/core/library/Contao/Automator.php#L539) for creating the mappings of the _empty request_ cache key.
* However, `FrontendTemplate::addToCache` never actually uses `*` when creating the cache key (for the empty request), see [here](https://github.com/contao/core/blob/3.5.25/system/modules/core/classes/FrontendTemplate.php#L216). Thus the cache key for the empty request will always be `example.org/empty…`.
* Thus `FrontendIndex::outputFromCache` never actually finds a cache entry for the empty request [here](https://github.com/contao/core/blob/3.5.25/system/modules/core/controllers/FrontendIndex.php#L318-L431) since it will always be looking for `*/empty…` due to the mapping (if no DNS setting was made in the root page).

_Note:_ if the internal cache is __not__ in use or created, then [this Problem](https://github.com/contao/core/issues/7618#issuecomment-292555484) still remains.