### PR TITLE
[RFC] clear form session data before setting

### DIFF
--- a/system/modules/core/forms/Form.php
+++ b/system/modules/core/forms/Form.php
@@ -130,10 +130,11 @@ class Form extends \Hybrid
 			}
 		}
 
-		// Delete any session data that was not submitted (#8707)
+		// Delete any session data that was not submitted for the current form (#8707)
 		if (\Input::post('FORM_SUBMIT') == $formId)
 		{
-			$arrKeys = array_diff(array_keys($_SESSION['FORM_DATA']), array_keys($_POST));
+			$arrFieldNames = array_map(function($field) { return $field->name; }, $arrFields);
+			$arrKeys = array_diff($arrFieldNames, array_keys($_POST));
 			foreach ($arrKeys as $key)
 			{
 				unset($_SESSION['FORM_DATA'][$key]);

--- a/system/modules/core/forms/Form.php
+++ b/system/modules/core/forms/Form.php
@@ -130,6 +130,16 @@ class Form extends \Hybrid
 			}
 		}
 
+		// Delete any session data that was not submitted (#8707)
+		if (\Input::post('FORM_SUBMIT') == $formId)
+		{
+			$arrKeys = array_diff(array_keys($_SESSION['FORM_DATA']), array_keys($_POST));
+			foreach ($arrKeys as $key)
+			{
+				unset($_SESSION['FORM_DATA'][$key]);
+			}
+		}
+
 		// Process the fields
 		if (!empty($arrFields) && is_array($arrFields))
 		{


### PR DESCRIPTION
## Problem description

Contao saves the the submitted values of a form from `$_POST` in `$_SESSION`: [Form.php#L219](https://github.com/contao/core/blob/3.5.27/system/modules/core/forms/Form.php#L219) & [Form.php#L509](https://github.com/contao/core/blob/3.5.27/system/modules/core/forms/Form.php#L509). This data is then used by the `Input` class here: [Input.php#L786-L789](https://github.com/contao/core/blob/3.5.27/system/modules/core/library/Contao/Input.php#L786-L789). And I suppose this is done so you can get the `$_POST` values on the subsequent success page of a form too, if you need them.

However, this leads to a problem if you disable input fields conditionally in the front end. Assume you have a form with an `<input>` `A` and `B`. First a user submits data for both `A` and `B`. Then the same user (in the same browser session) visits the form again and this time field `B` will be set to `disabled`. The user only inputs data for field `A` and no data for input field `B` (he can't, it is disabled).

Now, since Contao uses the `Input` class in Widgets to get its submitted data, the Widget of field `B` retrieves the value from the _previous_ form submission from the session - even though the user did not set any data for field `B`.

See also https://github.com/terminal42/contao-conditionalformfields/issues/17

## Reproduction

1. Create a form with the form generator containing two simple `text` input fields called `firstname` and `lastname` for example.
2. Set the form to send its data via email.
3. Integrate the form on a page and visit the page on the front end.
4. Fill the field `firstname` with `Lorem` and the field `lastname` with `Ipsum` and send the data.
5. You will get an email with the following content:
  ```
  firstname: Lorem
  lastname: Ipsum
  ```
6. Visit the page in the same browser session again.
7. This time add the `disabled="disabled"` attribute to the `lastname` input field (via dev tools or JS).
8. Fill the field `firstname` with `Dolor` and submit the form. The other field will be empty.
9. You will get an email with the following content:
  ```
  firstname: Dolor
  lastname: Ipsum
  ```

## Proposed fix

This PR simply compares the submitted form data with the session form data and unsets any keys that are not present in the submitted form data.