### PR TITLE
[RTM] Quote reserved words in database queries

### DIFF
--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -466,7 +466,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 
 				foreach ((array) $value as $v)
 				{
-					$objKey = $this->Database->prepare("SELECT " . $chunks[1] . " AS value FROM " . $chunks[0] . " WHERE id=?")
+					$objKey = $this->Database->prepare("SELECT " . \Database::quoteColumnName($chunks[1]) . " AS value FROM " . $chunks[0] . " WHERE id=?")
 											 ->limit(1)
 											 ->execute($v);
 
@@ -2986,12 +2986,12 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			{
 				if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4)
 				{
-					$this->Database->prepare("UPDATE " . $this->strTable . " SET " . $this->strField . "='' WHERE pid=?")
+					$this->Database->prepare("UPDATE " . $this->strTable . " SET " . \Database::quoteColumnName($this->strField) . "='' WHERE pid=?")
 								   ->execute($this->activeRecord->pid);
 				}
 				else
 				{
-					$this->Database->execute("UPDATE " . $this->strTable . " SET " . $this->strField . "=''");
+					$this->Database->execute("UPDATE " . $this->strTable . " SET " . \Database::quoteColumnName($this->strField) . "=''");
 				}
 			}
 
@@ -3004,7 +3004,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			$arrValues = $this->values;
 			array_unshift($arrValues, $varValue);
 
-			$objUpdateStmt = $this->Database->prepare("UPDATE " . $this->strTable . " SET " . $this->strField . "=? WHERE " . implode(' AND ', $this->procedure))
+			$objUpdateStmt = $this->Database->prepare("UPDATE " . $this->strTable . " SET " . \Database::quoteColumnName($this->strField) . "=? WHERE " . implode(' AND ', $this->procedure))
 											->execute($arrValues);
 
 			if ($objUpdateStmt->affectedRows)
@@ -3349,12 +3349,12 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				{
 					list($t, $f) = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']);
 
-					$objRoot = $this->Database->prepare("SELECT $for FROM {$this->strTable} WHERE (" . sprintf($strPattern, $fld) . " OR " . sprintf($strPattern, "(SELECT $f FROM $t WHERE $t.id={$this->strTable}.$fld)") . ") GROUP BY $for")
+					$objRoot = $this->Database->prepare("SELECT $for FROM {$this->strTable} WHERE (" . sprintf($strPattern, \Database::quoteColumnName($fld)) . " OR " . sprintf($strPattern, "(SELECT ".\Database::quoteColumnName($f)." FROM $t WHERE $t.id={$this->strTable}.".\Database::quoteColumnName($fld).")") . ") GROUP BY $for")
 											  ->execute($session['search'][$this->strTable]['value'], $session['search'][$this->strTable]['value']);
 				}
 				else
 				{
-					$objRoot = $this->Database->prepare("SELECT $for FROM {$this->strTable} WHERE " . sprintf($strPattern, $fld) . " GROUP BY $for")
+					$objRoot = $this->Database->prepare("SELECT $for FROM {$this->strTable} WHERE " . sprintf($strPattern, \Database::quoteColumnName($fld)) . " GROUP BY $for")
 											  ->execute($session['search'][$this->strTable]['value']);
 				}
 			}
@@ -3692,7 +3692,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				list($strKey, $strTable) = explode(':', $v);
 				list($strTable, $strField) = explode('.', $strTable);
 
-				$objRef = $this->Database->prepare("SELECT " . $strField . " FROM " . $strTable . " WHERE id=?")
+				$objRef = $this->Database->prepare("SELECT " . \Database::quoteColumnName($strField) . " FROM " . $strTable . " WHERE id=?")
 										 ->limit(1)
 										 ->execute($objRow->$strKey);
 
@@ -3989,7 +3989,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				{
 					$arrForeignKey = explode('.', $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['foreignKey'], 2);
 
-					$objLabel = $this->Database->prepare("SELECT " . $arrForeignKey[1] . " AS value FROM " . $arrForeignKey[0] . " WHERE id=?")
+					$objLabel = $this->Database->prepare("SELECT " . \Database::quoteColumnName($arrForeignKey[1]) . " AS value FROM " . $arrForeignKey[0] . " WHERE id=?")
 											   ->limit(1)
 											   ->execute($_v);
 
@@ -4095,7 +4095,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['foreignKey']))
 				{
 					$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['foreignKey'], 2);
-					$query = "SELECT *, (SELECT ". $key[1] ." FROM ". $key[0] ." WHERE ". $this->strTable .".". $firstOrderBy ."=". $key[0] .".id) AS foreignKey FROM " . $this->strTable;
+					$query = "SELECT *, (SELECT ". \Database::quoteColumnName($key[1]) ." FROM ". $key[0] ." WHERE ". $this->strTable .".". $firstOrderBy ."=". $key[0] .".id) AS foreignKey FROM " . $this->strTable;
 					$orderBy[0] = 'foreignKey';
 				}
 			}
@@ -4448,7 +4448,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				$firstOrderBy = 'pid';
 				$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
 
-				$query .= " ORDER BY (SELECT " . $showFields[0] . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy);
+				$query .= " ORDER BY (SELECT " . \Database::quoteColumnName($showFields[0]) . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy);
 
 				// Set the foreignKey so that the label is translated (also for backwards compatibility)
 				if ($GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'] == '')
@@ -4593,7 +4593,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 						list($strKey, $strTable) = explode(':', $v);
 						list($strTable, $strField) = explode('.', $strTable);
 
-						$objRef = $this->Database->prepare("SELECT " . $strField . " FROM " . $strTable . " WHERE id=?")
+						$objRef = $this->Database->prepare("SELECT " . \Database::quoteColumnName($strField) . " FROM " . $strTable . " WHERE id=?")
 												 ->limit(1)
 												 ->execute($row[$strKey]);
 
@@ -4957,7 +4957,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			{
 				try
 				{
-					$this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE " . $strField . " REGEXP ?")
+					$this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE " . \Database::quoteColumnName($strField) . " REGEXP ?")
 								   ->limit(1)
 								   ->execute($strKeyword);
 				}
@@ -4988,12 +4988,12 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']))
 			{
 				list($t, $f) = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']);
-				$this->procedure[] = "(" . sprintf($strPattern, $fld) . " OR " . sprintf($strPattern, "(SELECT $f FROM $t WHERE $t.id={$this->strTable}.$fld)") . ")";
+				$this->procedure[] = "(" . sprintf($strPattern, \Database::quoteColumnName($fld)) . " OR " . sprintf($strPattern, "(SELECT ".\Database::quoteColumnName($f)." FROM $t WHERE $t.id={$this->strTable}.".\Database::quoteColumnName($fld).")") . ")";
 				$this->values[] = $session['search'][$this->strTable]['value'];
 			}
 			else
 			{
-				$this->procedure[] = sprintf($strPattern, $fld);
+				$this->procedure[] = sprintf($strPattern, \Database::quoteColumnName($fld));
 			}
 
 			$this->values[] = $session['search'][$this->strTable]['value'];
@@ -5592,7 +5592,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 					{
 						$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey'], 2);
 
-						$objParent = $this->Database->prepare("SELECT " . $key[1] . " AS value FROM " . $key[0] . " WHERE id=?")
+						$objParent = $this->Database->prepare("SELECT " . \Database::quoteColumnName($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
 													->limit(1)
 													->execute($vv);
 
@@ -5619,7 +5619,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 							$showFields[0] = 'id';
 						}
 
-						$objShowFields = $this->Database->prepare("SELECT " . $showFields[0] . " FROM ". $this->ptable . " WHERE id=?")
+						$objShowFields = $this->Database->prepare("SELECT " . \Database::quoteColumnName($showFields[0]) . " FROM ". $this->ptable . " WHERE id=?")
 														->limit(1)
 														->execute($vv);
 
@@ -5743,7 +5743,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 		{
 			$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey'], 2);
 
-			$objParent = $this->Database->prepare("SELECT " . $key[1] . " AS value FROM " . $key[0] . " WHERE id=?")
+			$objParent = $this->Database->prepare("SELECT " . \Database::quoteColumnName($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
 										->limit(1)
 										->execute($value);
 

--- a/system/modules/core/drivers/DC_Table.php
+++ b/system/modules/core/drivers/DC_Table.php
@@ -466,7 +466,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 
 				foreach ((array) $value as $v)
 				{
-					$objKey = $this->Database->prepare("SELECT " . \Database::quoteColumnName($chunks[1]) . " AS value FROM " . $chunks[0] . " WHERE id=?")
+					$objKey = $this->Database->prepare("SELECT " . \Database::quoteIdentifier($chunks[1]) . " AS value FROM " . $chunks[0] . " WHERE id=?")
 											 ->limit(1)
 											 ->execute($v);
 
@@ -2986,12 +2986,12 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			{
 				if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4)
 				{
-					$this->Database->prepare("UPDATE " . $this->strTable . " SET " . \Database::quoteColumnName($this->strField) . "='' WHERE pid=?")
+					$this->Database->prepare("UPDATE " . $this->strTable . " SET " . \Database::quoteIdentifier($this->strField) . "='' WHERE pid=?")
 								   ->execute($this->activeRecord->pid);
 				}
 				else
 				{
-					$this->Database->execute("UPDATE " . $this->strTable . " SET " . \Database::quoteColumnName($this->strField) . "=''");
+					$this->Database->execute("UPDATE " . $this->strTable . " SET " . \Database::quoteIdentifier($this->strField) . "=''");
 				}
 			}
 
@@ -3004,7 +3004,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			$arrValues = $this->values;
 			array_unshift($arrValues, $varValue);
 
-			$objUpdateStmt = $this->Database->prepare("UPDATE " . $this->strTable . " SET " . \Database::quoteColumnName($this->strField) . "=? WHERE " . implode(' AND ', $this->procedure))
+			$objUpdateStmt = $this->Database->prepare("UPDATE " . $this->strTable . " SET " . \Database::quoteIdentifier($this->strField) . "=? WHERE " . implode(' AND ', $this->procedure))
 											->execute($arrValues);
 
 			if ($objUpdateStmt->affectedRows)
@@ -3349,12 +3349,12 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				{
 					list($t, $f) = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']);
 
-					$objRoot = $this->Database->prepare("SELECT $for FROM {$this->strTable} WHERE (" . sprintf($strPattern, \Database::quoteColumnName($fld)) . " OR " . sprintf($strPattern, "(SELECT ".\Database::quoteColumnName($f)." FROM $t WHERE $t.id={$this->strTable}.".\Database::quoteColumnName($fld).")") . ") GROUP BY $for")
+					$objRoot = $this->Database->prepare("SELECT $for FROM {$this->strTable} WHERE (" . sprintf($strPattern, \Database::quoteIdentifier($fld)) . " OR " . sprintf($strPattern, "(SELECT ".\Database::quoteIdentifier($f)." FROM $t WHERE $t.id={$this->strTable}.".\Database::quoteIdentifier($fld).")") . ") GROUP BY $for")
 											  ->execute($session['search'][$this->strTable]['value'], $session['search'][$this->strTable]['value']);
 				}
 				else
 				{
-					$objRoot = $this->Database->prepare("SELECT $for FROM {$this->strTable} WHERE " . sprintf($strPattern, \Database::quoteColumnName($fld)) . " GROUP BY $for")
+					$objRoot = $this->Database->prepare("SELECT $for FROM {$this->strTable} WHERE " . sprintf($strPattern, \Database::quoteIdentifier($fld)) . " GROUP BY $for")
 											  ->execute($session['search'][$this->strTable]['value']);
 				}
 			}
@@ -3692,7 +3692,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				list($strKey, $strTable) = explode(':', $v);
 				list($strTable, $strField) = explode('.', $strTable);
 
-				$objRef = $this->Database->prepare("SELECT " . \Database::quoteColumnName($strField) . " FROM " . $strTable . " WHERE id=?")
+				$objRef = $this->Database->prepare("SELECT " . \Database::quoteIdentifier($strField) . " FROM " . $strTable . " WHERE id=?")
 										 ->limit(1)
 										 ->execute($objRow->$strKey);
 
@@ -3989,7 +3989,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				{
 					$arrForeignKey = explode('.', $GLOBALS['TL_DCA'][$this->ptable]['fields'][$v]['foreignKey'], 2);
 
-					$objLabel = $this->Database->prepare("SELECT " . \Database::quoteColumnName($arrForeignKey[1]) . " AS value FROM " . $arrForeignKey[0] . " WHERE id=?")
+					$objLabel = $this->Database->prepare("SELECT " . \Database::quoteIdentifier($arrForeignKey[1]) . " AS value FROM " . $arrForeignKey[0] . " WHERE id=?")
 											   ->limit(1)
 											   ->execute($_v);
 
@@ -4095,7 +4095,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['foreignKey']))
 				{
 					$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$firstOrderBy]['foreignKey'], 2);
-					$query = "SELECT *, (SELECT ". \Database::quoteColumnName($key[1]) ." FROM ". $key[0] ." WHERE ". $this->strTable .".". $firstOrderBy ."=". $key[0] .".id) AS foreignKey FROM " . $this->strTable;
+					$query = "SELECT *, (SELECT ". \Database::quoteIdentifier($key[1]) ." FROM ". $key[0] ." WHERE ". $this->strTable .".". $firstOrderBy ."=". $key[0] .".id) AS foreignKey FROM " . $this->strTable;
 					$orderBy[0] = 'foreignKey';
 				}
 			}
@@ -4448,7 +4448,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 				$firstOrderBy = 'pid';
 				$showFields = $GLOBALS['TL_DCA'][$table]['list']['label']['fields'];
 
-				$query .= " ORDER BY (SELECT " . \Database::quoteColumnName($showFields[0]) . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy);
+				$query .= " ORDER BY (SELECT " . \Database::quoteIdentifier($showFields[0]) . " FROM " . $this->ptable . " WHERE " . $this->ptable . ".id=" . $this->strTable . ".pid), " . implode(', ', $orderBy);
 
 				// Set the foreignKey so that the label is translated (also for backwards compatibility)
 				if ($GLOBALS['TL_DCA'][$table]['fields']['pid']['foreignKey'] == '')
@@ -4593,7 +4593,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 						list($strKey, $strTable) = explode(':', $v);
 						list($strTable, $strField) = explode('.', $strTable);
 
-						$objRef = $this->Database->prepare("SELECT " . \Database::quoteColumnName($strField) . " FROM " . $strTable . " WHERE id=?")
+						$objRef = $this->Database->prepare("SELECT " . \Database::quoteIdentifier($strField) . " FROM " . $strTable . " WHERE id=?")
 												 ->limit(1)
 												 ->execute($row[$strKey]);
 
@@ -4957,7 +4957,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			{
 				try
 				{
-					$this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE " . \Database::quoteColumnName($strField) . " REGEXP ?")
+					$this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE " . \Database::quoteIdentifier($strField) . " REGEXP ?")
 								   ->limit(1)
 								   ->execute($strKeyword);
 				}
@@ -4988,12 +4988,12 @@ class DC_Table extends \DataContainer implements \listable, \editable
 			if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']))
 			{
 				list($t, $f) = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$fld]['foreignKey']);
-				$this->procedure[] = "(" . sprintf($strPattern, \Database::quoteColumnName($fld)) . " OR " . sprintf($strPattern, "(SELECT ".\Database::quoteColumnName($f)." FROM $t WHERE $t.id={$this->strTable}.".\Database::quoteColumnName($fld).")") . ")";
+				$this->procedure[] = "(" . sprintf($strPattern, \Database::quoteIdentifier($fld)) . " OR " . sprintf($strPattern, "(SELECT ".\Database::quoteIdentifier($f)." FROM $t WHERE $t.id={$this->strTable}.".\Database::quoteIdentifier($fld).")") . ")";
 				$this->values[] = $session['search'][$this->strTable]['value'];
 			}
 			else
 			{
-				$this->procedure[] = sprintf($strPattern, \Database::quoteColumnName($fld));
+				$this->procedure[] = sprintf($strPattern, \Database::quoteIdentifier($fld));
 			}
 
 			$this->values[] = $session['search'][$this->strTable]['value'];
@@ -5592,7 +5592,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 					{
 						$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey'], 2);
 
-						$objParent = $this->Database->prepare("SELECT " . \Database::quoteColumnName($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
+						$objParent = $this->Database->prepare("SELECT " . \Database::quoteIdentifier($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
 													->limit(1)
 													->execute($vv);
 
@@ -5619,7 +5619,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 							$showFields[0] = 'id';
 						}
 
-						$objShowFields = $this->Database->prepare("SELECT " . \Database::quoteColumnName($showFields[0]) . " FROM ". $this->ptable . " WHERE id=?")
+						$objShowFields = $this->Database->prepare("SELECT " . \Database::quoteIdentifier($showFields[0]) . " FROM ". $this->ptable . " WHERE id=?")
 														->limit(1)
 														->execute($vv);
 
@@ -5743,7 +5743,7 @@ class DC_Table extends \DataContainer implements \listable, \editable
 		{
 			$key = explode('.', $GLOBALS['TL_DCA'][$this->strTable]['fields'][$field]['foreignKey'], 2);
 
-			$objParent = $this->Database->prepare("SELECT " . \Database::quoteColumnName($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
+			$objParent = $this->Database->prepare("SELECT " . \Database::quoteIdentifier($key[1]) . " AS value FROM " . $key[0] . " WHERE id=?")
 										->limit(1)
 										->execute($value);
 

--- a/system/modules/core/library/Contao/Database.php
+++ b/system/modules/core/library/Contao/Database.php
@@ -396,7 +396,7 @@ abstract class Database
 	 */
 	public function isUniqueValue($strTable, $strField, $varValue, $intId=null)
 	{
-		$strQuery = "SELECT * FROM $strTable WHERE $strField=?";
+		$strQuery = "SELECT * FROM $strTable WHERE ".static::quoteColumnName($strField)."=?";
 
 		if ($intId !== null)
 		{
@@ -590,6 +590,37 @@ abstract class Database
 	public function getUuid()
 	{
 		return $this->get_uuid();
+	}
+
+
+	/**
+	 * Quote the column name if it a reserved word
+	 *
+	 * @param string $strName
+	 *
+	 * @return string
+	 */
+	public static function quoteColumnName($strName)
+	{
+		if (in_array(strtolower($strName), array('rows'), true))
+		{
+			$strName = '`'.$strName.'`';
+		}
+
+		return $strName;
+	}
+
+
+	/**
+	 * Quote a list of column names
+	 *
+	 * @param string[] $arrNames
+	 *
+	 * @return string[]
+	 */
+	public static function quoteColumnNames(array $arrNames)
+	{
+		return array_map(array(static::class, 'quoteColumnName'), $arrNames);
 	}
 
 

--- a/system/modules/core/library/Contao/Database.php
+++ b/system/modules/core/library/Contao/Database.php
@@ -396,7 +396,7 @@ abstract class Database
 	 */
 	public function isUniqueValue($strTable, $strField, $varValue, $intId=null)
 	{
-		$strQuery = "SELECT * FROM $strTable WHERE ".static::quoteColumnName($strField)."=?";
+		$strQuery = "SELECT * FROM $strTable WHERE ".static::quoteIdentifier($strField)."=?";
 
 		if ($intId !== null)
 		{
@@ -594,33 +594,20 @@ abstract class Database
 
 
 	/**
-	 * Quote the column name if it a reserved word
+	 * Quote an identifier if it is a reserved word
 	 *
 	 * @param string $strName
 	 *
 	 * @return string
 	 */
-	public static function quoteColumnName($strName)
+	public static function quoteIdentifier($strName)
 	{
-		if (in_array(strtolower($strName), array('rows'), true))
+		if ($strName == 'rows')
 		{
 			$strName = '`'.$strName.'`';
 		}
 
 		return $strName;
-	}
-
-
-	/**
-	 * Quote a list of column names
-	 *
-	 * @param string[] $arrNames
-	 *
-	 * @return string[]
-	 */
-	public static function quoteColumnNames(array $arrNames)
-	{
-		return array_map(array(static::class, 'quoteColumnName'), $arrNames);
 	}
 
 

--- a/system/modules/core/library/Contao/Database.php
+++ b/system/modules/core/library/Contao/Database.php
@@ -602,7 +602,7 @@ abstract class Database
 	 */
 	public static function quoteIdentifier($strName)
 	{
-		if ($strName == 'rows')
+		if (strtolower($strName) == 'rows')
 		{
 			$strName = '`'.$strName.'`';
 		}

--- a/system/modules/core/library/Contao/Database/Mysql.php
+++ b/system/modules/core/library/Contao/Database/Mysql.php
@@ -95,7 +95,7 @@ class Mysql extends \Database
 	 */
 	protected function find_in_set($strKey, $varSet, $blnIsField=false)
 	{
-		$strKey = \Database::quoteColumnName($strKey);
+		$strKey = \Database::quoteIdentifier($strKey);
 
 		if ($blnIsField)
 		{

--- a/system/modules/core/library/Contao/Database/Mysql.php
+++ b/system/modules/core/library/Contao/Database/Mysql.php
@@ -95,7 +95,10 @@ class Mysql extends \Database
 	 */
 	protected function find_in_set($strKey, $varSet, $blnIsField=false)
 	{
-		$strKey = \Database::quoteIdentifier($strKey);
+		if (preg_match('/^[A-Za-z0-9_$]+$/', $strKey))
+		{
+			$strKey = static::quoteIdentifier($strKey);
+		}
 
 		if ($blnIsField)
 		{

--- a/system/modules/core/library/Contao/Database/Mysql.php
+++ b/system/modules/core/library/Contao/Database/Mysql.php
@@ -95,6 +95,8 @@ class Mysql extends \Database
 	 */
 	protected function find_in_set($strKey, $varSet, $blnIsField=false)
 	{
+		$strKey = \Database::quoteColumnName($strKey);
+
 		if ($blnIsField)
 		{
 			return "FIND_IN_SET(" . $strKey . ", " . $varSet . ")";

--- a/system/modules/core/library/Contao/Database/Mysql.php
+++ b/system/modules/core/library/Contao/Database/Mysql.php
@@ -95,10 +95,7 @@ class Mysql extends \Database
 	 */
 	protected function find_in_set($strKey, $varSet, $blnIsField=false)
 	{
-		if (preg_match('/^[A-Za-z0-9_$]+$/', $strKey))
-		{
-			$strKey = static::quoteIdentifier($strKey);
-		}
+		$strKey = static::quoteIdentifier($strKey);
 
 		if ($blnIsField)
 		{

--- a/system/modules/core/library/Contao/Database/Mysqli.php
+++ b/system/modules/core/library/Contao/Database/Mysqli.php
@@ -85,10 +85,7 @@ class Mysqli extends \Database
 	 */
 	protected function find_in_set($strKey, $varSet, $blnIsField=false)
 	{
-		if (preg_match('/^[A-Za-z0-9_$]+$/', $strKey))
-		{
-			$strKey = static::quoteIdentifier($strKey);
-		}
+		$strKey = static::quoteIdentifier($strKey);
 
 		if ($blnIsField)
 		{

--- a/system/modules/core/library/Contao/Database/Mysqli.php
+++ b/system/modules/core/library/Contao/Database/Mysqli.php
@@ -85,7 +85,10 @@ class Mysqli extends \Database
 	 */
 	protected function find_in_set($strKey, $varSet, $blnIsField=false)
 	{
-		$strKey = \Database::quoteIdentifier($strKey);
+		if (preg_match('/^[A-Za-z0-9_$]+$/', $strKey))
+		{
+			$strKey = static::quoteIdentifier($strKey);
+		}
 
 		if ($blnIsField)
 		{

--- a/system/modules/core/library/Contao/Database/Mysqli.php
+++ b/system/modules/core/library/Contao/Database/Mysqli.php
@@ -85,6 +85,8 @@ class Mysqli extends \Database
 	 */
 	protected function find_in_set($strKey, $varSet, $blnIsField=false)
 	{
+		$strKey = \Database::quoteColumnName($strKey);
+
 		if ($blnIsField)
 		{
 			return "FIND_IN_SET(" . $strKey . ", " . $varSet . ")";

--- a/system/modules/core/library/Contao/Database/Mysqli.php
+++ b/system/modules/core/library/Contao/Database/Mysqli.php
@@ -85,7 +85,7 @@ class Mysqli extends \Database
 	 */
 	protected function find_in_set($strKey, $varSet, $blnIsField=false)
 	{
-		$strKey = \Database::quoteColumnName($strKey);
+		$strKey = \Database::quoteIdentifier($strKey);
 
 		if ($blnIsField)
 		{

--- a/system/modules/core/library/Contao/Database/Statement.php
+++ b/system/modules/core/library/Contao/Database/Statement.php
@@ -197,7 +197,7 @@ abstract class Statement
 		if (strncasecmp($this->strQuery, 'INSERT', 6) === 0)
 		{
 			$strQuery = sprintf('(%s) VALUES (%s)',
-								implode(', ', array_keys($arrParams)),
+								implode(', ', \Database::quoteColumnNames(array_keys($arrParams))),
 								str_replace('%', '%%', implode(', ', array_values($arrParams))));
 		}
 		// UPDATE
@@ -207,7 +207,7 @@ abstract class Statement
 
 			foreach ($arrParams as $k=>$v)
 			{
-				$arrSet[] = $k . '=' . $v;
+				$arrSet[] = \Database::quoteColumnName($k) . '=' . $v;
 			}
 
 			$strQuery = 'SET ' . str_replace('%', '%%', implode(', ', $arrSet));

--- a/system/modules/core/library/Contao/Database/Statement.php
+++ b/system/modules/core/library/Contao/Database/Statement.php
@@ -197,7 +197,7 @@ abstract class Statement
 		if (strncasecmp($this->strQuery, 'INSERT', 6) === 0)
 		{
 			$strQuery = sprintf('(%s) VALUES (%s)',
-								implode(', ', \Database::quoteColumnNames(array_keys($arrParams))),
+								implode(', ', array_map('Database::quoteIdentifier', array_keys($arrParams))),
 								str_replace('%', '%%', implode(', ', array_values($arrParams))));
 		}
 		// UPDATE
@@ -207,7 +207,7 @@ abstract class Statement
 
 			foreach ($arrParams as $k=>$v)
 			{
-				$arrSet[] = \Database::quoteColumnName($k) . '=' . $v;
+				$arrSet[] = \Database::quoteIdentifier($k) . '=' . $v;
 			}
 
 			$strQuery = 'SET ' . str_replace('%', '%%', implode(', ', $arrSet));

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -470,7 +470,7 @@ abstract class Model
 			}
 
 			// Update the row
-			$objDatabase->prepare("UPDATE " . static::$strTable . " %s WHERE " . static::$strPk . "=?")
+			$objDatabase->prepare("UPDATE " . static::$strTable . " %s WHERE " . \Database::quoteColumnName(static::$strPk) . "=?")
 						->set($arrSet)
 						->execute($intPk);
 
@@ -563,7 +563,7 @@ abstract class Model
 		}
 
 		// Delete the row
-		$intAffected = \Database::getInstance()->prepare("DELETE FROM " . static::$strTable . " WHERE " . static::$strPk . "=?")
+		$intAffected = \Database::getInstance()->prepare("DELETE FROM " . static::$strTable . " WHERE " . \Database::quoteColumnName(static::$strPk) . "=?")
 											   ->execute($intPk)
 											   ->affectedRows;
 
@@ -624,7 +624,7 @@ abstract class Model
 		elseif ($arrRelation['type'] == 'hasMany' || $arrRelation['type'] == 'belongsToMany')
 		{
 			$arrValues = deserialize($this->$strKey, true);
-			$strField = $arrRelation['table'] . '.' . $arrRelation['field'];
+			$strField = $arrRelation['table'] . '.' . \Database::quoteColumnName($arrRelation['field']);
 
 			// Handle UUIDs (see #6525)
 			if ($strField == 'tl_files.uuid')
@@ -668,7 +668,7 @@ abstract class Model
 		}
 
 		// Reload the database record
-		$res = \Database::getInstance()->prepare("SELECT * FROM " . static::$strTable . " WHERE " . static::$strPk . "=?")
+		$res = \Database::getInstance()->prepare("SELECT * FROM " . static::$strTable . " WHERE " . \Database::quoteColumnName(static::$strPk) . "=?")
 									   ->execute($intPk);
 
 		$this->setRow($res->row());

--- a/system/modules/core/library/Contao/Model.php
+++ b/system/modules/core/library/Contao/Model.php
@@ -470,7 +470,7 @@ abstract class Model
 			}
 
 			// Update the row
-			$objDatabase->prepare("UPDATE " . static::$strTable . " %s WHERE " . \Database::quoteColumnName(static::$strPk) . "=?")
+			$objDatabase->prepare("UPDATE " . static::$strTable . " %s WHERE " . \Database::quoteIdentifier(static::$strPk) . "=?")
 						->set($arrSet)
 						->execute($intPk);
 
@@ -563,7 +563,7 @@ abstract class Model
 		}
 
 		// Delete the row
-		$intAffected = \Database::getInstance()->prepare("DELETE FROM " . static::$strTable . " WHERE " . \Database::quoteColumnName(static::$strPk) . "=?")
+		$intAffected = \Database::getInstance()->prepare("DELETE FROM " . static::$strTable . " WHERE " . \Database::quoteIdentifier(static::$strPk) . "=?")
 											   ->execute($intPk)
 											   ->affectedRows;
 
@@ -624,7 +624,7 @@ abstract class Model
 		elseif ($arrRelation['type'] == 'hasMany' || $arrRelation['type'] == 'belongsToMany')
 		{
 			$arrValues = deserialize($this->$strKey, true);
-			$strField = $arrRelation['table'] . '.' . \Database::quoteColumnName($arrRelation['field']);
+			$strField = $arrRelation['table'] . '.' . \Database::quoteIdentifier($arrRelation['field']);
 
 			// Handle UUIDs (see #6525)
 			if ($strField == 'tl_files.uuid')
@@ -668,7 +668,7 @@ abstract class Model
 		}
 
 		// Reload the database record
-		$res = \Database::getInstance()->prepare("SELECT * FROM " . static::$strTable . " WHERE " . \Database::quoteColumnName(static::$strPk) . "=?")
+		$res = \Database::getInstance()->prepare("SELECT * FROM " . static::$strTable . " WHERE " . \Database::quoteIdentifier(static::$strPk) . "=?")
 									   ->execute($intPk);
 
 		$this->setRow($res->row());

--- a/system/modules/core/library/Contao/Model/QueryBuilder.php
+++ b/system/modules/core/library/Contao/Model/QueryBuilder.php
@@ -53,10 +53,10 @@ class QueryBuilder
 
 						foreach (array_keys($objRelated->getFields()) as $strField)
 						{
-							$arrFields[] = 'j' . $intCount . '.' . \Database::quoteColumnName($strField) . ' AS ' . $strKey . '__' . $strField;
+							$arrFields[] = 'j' . $intCount . '.' . \Database::quoteIdentifier($strField) . ' AS ' . $strKey . '__' . $strField;
 						}
 
-						$arrJoins[] = " LEFT JOIN " . $arrConfig['table'] . " j$intCount ON " . $arrOptions['table'] . "." . \Database::quoteColumnName($strKey) . "=j$intCount." . $arrConfig['field'];
+						$arrJoins[] = " LEFT JOIN " . $arrConfig['table'] . " j$intCount ON " . $arrOptions['table'] . "." . \Database::quoteIdentifier($strKey) . "=j$intCount." . $arrConfig['field'];
 					}
 				}
 			}
@@ -68,7 +68,7 @@ class QueryBuilder
 		// Where condition
 		if ($arrOptions['column'] !== null)
 		{
-			$strQuery .= " WHERE " . (is_array($arrOptions['column']) ? implode(" AND ", $arrOptions['column']) : $arrOptions['table'] . '.' . \Database::quoteColumnName($arrOptions['column']) . "=?");
+			$strQuery .= " WHERE " . (is_array($arrOptions['column']) ? implode(" AND ", $arrOptions['column']) : $arrOptions['table'] . '.' . \Database::quoteIdentifier($arrOptions['column']) . "=?");
 		}
 
 		// Group by
@@ -106,7 +106,7 @@ class QueryBuilder
 
 		if ($arrOptions['column'] !== null)
 		{
-			$strQuery .= " WHERE " . (is_array($arrOptions['column']) ? implode(" AND ", $arrOptions['column']) : $arrOptions['table'] . '.' . \Database::quoteColumnName($arrOptions['column']) . "=?");
+			$strQuery .= " WHERE " . (is_array($arrOptions['column']) ? implode(" AND ", $arrOptions['column']) : $arrOptions['table'] . '.' . \Database::quoteIdentifier($arrOptions['column']) . "=?");
 		}
 
 		return $strQuery;

--- a/system/modules/core/library/Contao/Model/QueryBuilder.php
+++ b/system/modules/core/library/Contao/Model/QueryBuilder.php
@@ -53,10 +53,10 @@ class QueryBuilder
 
 						foreach (array_keys($objRelated->getFields()) as $strField)
 						{
-							$arrFields[] = 'j' . $intCount . '.' . $strField . ' AS ' . $strKey . '__' . $strField;
+							$arrFields[] = 'j' . $intCount . '.' . \Database::quoteColumnName($strField) . ' AS ' . $strKey . '__' . $strField;
 						}
 
-						$arrJoins[] = " LEFT JOIN " . $arrConfig['table'] . " j$intCount ON " . $arrOptions['table'] . "." . $strKey . "=j$intCount." . $arrConfig['field'];
+						$arrJoins[] = " LEFT JOIN " . $arrConfig['table'] . " j$intCount ON " . $arrOptions['table'] . "." . \Database::quoteColumnName($strKey) . "=j$intCount." . $arrConfig['field'];
 					}
 				}
 			}
@@ -68,7 +68,7 @@ class QueryBuilder
 		// Where condition
 		if ($arrOptions['column'] !== null)
 		{
-			$strQuery .= " WHERE " . (is_array($arrOptions['column']) ? implode(" AND ", $arrOptions['column']) : $arrOptions['table'] . '.' . $arrOptions['column'] . "=?");
+			$strQuery .= " WHERE " . (is_array($arrOptions['column']) ? implode(" AND ", $arrOptions['column']) : $arrOptions['table'] . '.' . \Database::quoteColumnName($arrOptions['column']) . "=?");
 		}
 
 		// Group by
@@ -106,7 +106,7 @@ class QueryBuilder
 
 		if ($arrOptions['column'] !== null)
 		{
-			$strQuery .= " WHERE " . (is_array($arrOptions['column']) ? implode(" AND ", $arrOptions['column']) : $arrOptions['table'] . '.' . $arrOptions['column'] . "=?");
+			$strQuery .= " WHERE " . (is_array($arrOptions['column']) ? implode(" AND ", $arrOptions['column']) : $arrOptions['table'] . '.' . \Database::quoteColumnName($arrOptions['column']) . "=?");
 		}
 
 		return $strQuery;

--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -522,7 +522,7 @@ abstract class User extends \System
 	 */
 	public function findBy($strColumn, $varValue)
 	{
-		$objResult = $this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE " . \Database::quoteColumnName($strColumn) . "=?")
+		$objResult = $this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE " . \Database::quoteIdentifier($strColumn) . "=?")
 									->limit(1)
 									->execute($varValue);
 

--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -522,7 +522,7 @@ abstract class User extends \System
 	 */
 	public function findBy($strColumn, $varValue)
 	{
-		$objResult = $this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE " . $strColumn . "=?")
+		$objResult = $this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE " . \Database::quoteColumnName($strColumn) . "=?")
 									->limit(1)
 									->execute($varValue);
 

--- a/system/modules/core/widgets/FileSelector.php
+++ b/system/modules/core/widgets/FileSelector.php
@@ -181,7 +181,7 @@ class FileSelector extends \Widget
 					break;
 				}
 
-				$objField = $this->Database->prepare("SELECT " . \Database::quoteColumnName($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
+				$objField = $this->Database->prepare("SELECT " . \Database::quoteIdentifier($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
 										   ->limit(1)
 										   ->execute($this->strId);
 

--- a/system/modules/core/widgets/FileSelector.php
+++ b/system/modules/core/widgets/FileSelector.php
@@ -181,7 +181,7 @@ class FileSelector extends \Widget
 					break;
 				}
 
-				$objField = $this->Database->prepare("SELECT " . $this->strField . " FROM " . $this->strTable . " WHERE id=?")
+				$objField = $this->Database->prepare("SELECT " . \Database::quoteColumnName($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
 										   ->limit(1)
 										   ->execute($this->strId);
 

--- a/system/modules/core/widgets/FileTree.php
+++ b/system/modules/core/widgets/FileTree.php
@@ -66,7 +66,7 @@ class FileTree extends \Widget
 			$this->strOrderName = $this->orderField . str_replace($this->strField, '', $this->strName);
 
 			// Retrieve the order value
-			$objRow = $this->Database->prepare("SELECT ".\Database::quoteColumnName($this->orderField)." FROM {$this->strTable} WHERE id=?")
+			$objRow = $this->Database->prepare("SELECT ".\Database::quoteIdentifier($this->orderField)." FROM {$this->strTable} WHERE id=?")
 									 ->limit(1)
 									 ->execute($this->activeRecord->id);
 

--- a/system/modules/core/widgets/FileTree.php
+++ b/system/modules/core/widgets/FileTree.php
@@ -66,7 +66,7 @@ class FileTree extends \Widget
 			$this->strOrderName = $this->orderField . str_replace($this->strField, '', $this->strName);
 
 			// Retrieve the order value
-			$objRow = $this->Database->prepare("SELECT {$this->orderField} FROM {$this->strTable} WHERE id=?")
+			$objRow = $this->Database->prepare("SELECT ".\Database::quoteColumnName($this->orderField)." FROM {$this->strTable} WHERE id=?")
 									 ->limit(1)
 									 ->execute($this->activeRecord->id);
 

--- a/system/modules/core/widgets/PageSelector.php
+++ b/system/modules/core/widgets/PageSelector.php
@@ -271,7 +271,7 @@ class PageSelector extends \Widget
 					break;
 				}
 
-				$objField = $this->Database->prepare("SELECT " . $this->strField . " FROM " . $this->strTable . " WHERE id=?")
+				$objField = $this->Database->prepare("SELECT " . \Database::quoteColumnName($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
 										   ->limit(1)
 										   ->execute($this->strId);
 

--- a/system/modules/core/widgets/PageSelector.php
+++ b/system/modules/core/widgets/PageSelector.php
@@ -271,7 +271,7 @@ class PageSelector extends \Widget
 					break;
 				}
 
-				$objField = $this->Database->prepare("SELECT " . \Database::quoteColumnName($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
+				$objField = $this->Database->prepare("SELECT " . \Database::quoteIdentifier($this->strField) . " FROM " . $this->strTable . " WHERE id=?")
 										   ->limit(1)
 										   ->execute($this->strId);
 

--- a/system/modules/core/widgets/PageTree.php
+++ b/system/modules/core/widgets/PageTree.php
@@ -64,7 +64,7 @@ class PageTree extends \Widget
 			$this->strOrderName = $this->orderField . str_replace($this->strField, '', $this->strName);
 
 			// Retrieve the order value
-			$objRow = $this->Database->prepare("SELECT {$this->orderField} FROM {$this->strTable} WHERE id=?")
+			$objRow = $this->Database->prepare("SELECT ".\Database::quoteColumnName($this->orderField)." FROM {$this->strTable} WHERE id=?")
 						   ->limit(1)
 						   ->execute($this->activeRecord->id);
 

--- a/system/modules/core/widgets/PageTree.php
+++ b/system/modules/core/widgets/PageTree.php
@@ -64,7 +64,7 @@ class PageTree extends \Widget
 			$this->strOrderName = $this->orderField . str_replace($this->strField, '', $this->strName);
 
 			// Retrieve the order value
-			$objRow = $this->Database->prepare("SELECT ".\Database::quoteColumnName($this->orderField)." FROM {$this->strTable} WHERE id=?")
+			$objRow = $this->Database->prepare("SELECT ".\Database::quoteIdentifier($this->orderField)." FROM {$this->strTable} WHERE id=?")
 						   ->limit(1)
 						   ->execute($this->activeRecord->id);
 

--- a/system/modules/listing/modules/ModuleListing.php
+++ b/system/modules/listing/modules/ModuleListing.php
@@ -120,7 +120,7 @@ class ModuleListing extends \Module
 			if ($strSearch && $strFor)
 			{
 				$varKeyword = '%' . $strFor . '%';
-				$strWhere = (!$this->list_where ? " WHERE " : " AND ") . $strSearch . " LIKE ?";
+				$strWhere = (!$this->list_where ? " WHERE " : " AND ") . \Database::quoteColumnName($strSearch) . " LIKE ?";
 			}
 
 			foreach ($arrSearchFields as $field)
@@ -159,11 +159,11 @@ class ModuleListing extends \Module
 		}
 
 		// Get the selected records
-		$strQuery = "SELECT " . $this->strPk . "," . $this->list_fields;
+		$strQuery = "SELECT " . \Database::quoteColumnName($this->strPk) . "," . implode(',', \Database::quoteColumnNames(trimsplit(',', $this->list_fields)));
 
 		if ($this->list_info_where)
 		{
-			$strQuery .= ", (SELECT COUNT(*) FROM " . $this->list_table . " t2 WHERE t2." . $this->strPk . "=t1." . $this->strPk . " AND " . $this->list_info_where . ") AS _details";
+			$strQuery .= ", (SELECT COUNT(*) FROM " . $this->list_table . " t2 WHERE t2." . \Database::quoteColumnName($this->strPk) . "=t1." . \Database::quoteColumnName($this->strPk) . " AND " . $this->list_info_where . ") AS _details";
 		}
 
 		$strQuery .= " FROM " . $this->list_table . " t1";
@@ -203,7 +203,7 @@ class ModuleListing extends \Module
 			}
 			else
 			{
-				$strQuery .= " ORDER BY " . $order_by . ' ' . $sort;
+				$strQuery .= " ORDER BY " . \Database::quoteColumnName($order_by) . ' ' . $sort;
 			}
 		}
 		elseif ($this->list_sort)
@@ -372,7 +372,7 @@ class ModuleListing extends \Module
 		$this->list_info = deserialize($this->list_info);
 		$this->list_info_where = $this->replaceInsertTags($this->list_info_where, false);
 
-		$objRecord = $this->Database->prepare("SELECT " . $this->list_info . " FROM " . $this->list_table . " WHERE " . (($this->list_info_where != '') ? "(" . $this->list_info_where . ") AND " : "") . $this->strPk . "=?")
+		$objRecord = $this->Database->prepare("SELECT " . implode(',', \Database::quoteColumnNames(trimsplit(',', $this->list_info))) . " FROM " . $this->list_table . " WHERE " . (($this->list_info_where != '') ? "(" . $this->list_info_where . ") AND " : "") . \Database::quoteColumnName($this->strPk) . "=?")
 									->limit(1)
 									->execute($id);
 

--- a/system/modules/listing/modules/ModuleListing.php
+++ b/system/modules/listing/modules/ModuleListing.php
@@ -120,7 +120,7 @@ class ModuleListing extends \Module
 			if ($strSearch && $strFor)
 			{
 				$varKeyword = '%' . $strFor . '%';
-				$strWhere = (!$this->list_where ? " WHERE " : " AND ") . \Database::quoteColumnName($strSearch) . " LIKE ?";
+				$strWhere = (!$this->list_where ? " WHERE " : " AND ") . \Database::quoteIdentifier($strSearch) . " LIKE ?";
 			}
 
 			foreach ($arrSearchFields as $field)
@@ -159,11 +159,11 @@ class ModuleListing extends \Module
 		}
 
 		// Get the selected records
-		$strQuery = "SELECT " . \Database::quoteColumnName($this->strPk) . "," . implode(',', \Database::quoteColumnNames(trimsplit(',', $this->list_fields)));
+		$strQuery = "SELECT " . \Database::quoteIdentifier($this->strPk) . "," . implode(',', array_map('Database::quoteIdentifier', trimsplit(',', $this->list_fields)));
 
 		if ($this->list_info_where)
 		{
-			$strQuery .= ", (SELECT COUNT(*) FROM " . $this->list_table . " t2 WHERE t2." . \Database::quoteColumnName($this->strPk) . "=t1." . \Database::quoteColumnName($this->strPk) . " AND " . $this->list_info_where . ") AS _details";
+			$strQuery .= ", (SELECT COUNT(*) FROM " . $this->list_table . " t2 WHERE t2." . \Database::quoteIdentifier($this->strPk) . "=t1." . \Database::quoteIdentifier($this->strPk) . " AND " . $this->list_info_where . ") AS _details";
 		}
 
 		$strQuery .= " FROM " . $this->list_table . " t1";
@@ -203,7 +203,7 @@ class ModuleListing extends \Module
 			}
 			else
 			{
-				$strQuery .= " ORDER BY " . \Database::quoteColumnName($order_by) . ' ' . $sort;
+				$strQuery .= " ORDER BY " . \Database::quoteIdentifier($order_by) . ' ' . $sort;
 			}
 		}
 		elseif ($this->list_sort)
@@ -372,7 +372,7 @@ class ModuleListing extends \Module
 		$this->list_info = deserialize($this->list_info);
 		$this->list_info_where = $this->replaceInsertTags($this->list_info_where, false);
 
-		$objRecord = $this->Database->prepare("SELECT " . implode(',', \Database::quoteColumnNames(trimsplit(',', $this->list_info))) . " FROM " . $this->list_table . " WHERE " . (($this->list_info_where != '') ? "(" . $this->list_info_where . ") AND " : "") . \Database::quoteColumnName($this->strPk) . "=?")
+		$objRecord = $this->Database->prepare("SELECT " . implode(',', array_map('Database::quoteIdentifier', trimsplit(',', $this->list_info))) . " FROM " . $this->list_table . " WHERE " . (($this->list_info_where != '') ? "(" . $this->list_info_where . ") AND " : "") . \Database::quoteIdentifier($this->strPk) . "=?")
 									->limit(1)
 									->execute($id);
 


### PR DESCRIPTION
As discussed in contao/core-bundle#1106 and the Contao Mumble call, we want to escape all column names that are reserved keywords.

In Contao 4 we will use `\System::getContainer()->get('connection')->getDatabasePlatform()->quoteSingleIdentifier($name);`. In Contao 3.5 (this pull request) we only quote `rows`.

There is no need to fix the install tool in 3.5, as it uses quoted column names already.

@leofeyer Do you have an automated workflow to port this pull request to Contao 4.4, or should I do it by hand?