### PR TITLE
Do not encode chars from custom code field in exported style sheet

### DIFF
--- a/system/modules/core/classes/StyleSheets.php
+++ b/system/modules/core/classes/StyleSheets.php
@@ -932,7 +932,7 @@ class StyleSheets extends \Backend
 			$own = preg_replace('/url\("(?!data:|\/)/', 'url("' . $strGlue, $own);
 			$own = preg_split('/[\n\r]+/', $own);
 			$own = implode(($blnWriteToFile ? '' : $lb), $own);
-			$return .= $lb . (!$blnWriteToFile ? specialchars($own) : $own);
+			$return .= $lb . ((!$blnWriteToFile && !$export) ? specialchars($own) : $own);
 		}
 
 		// Allow custom definitions


### PR DESCRIPTION
Preservation of HTML entered in the custom code field of a style sheet format definition was implemented here:
https://github.com/contao/core/pull/6667
https://github.com/contao/core/commit/c61c697278ca51f86fca96e08791073b45c197bc
However, the above only applies for the generated asset file. When the "Export style sheet" feature is used, all special characters in the created file will be converted to HTML entities.

To reproduce the issue, create a format definition (e. g. `.foo:before`) and add custom code (e. g. `content: "";`), then go back to the overview of style sheets and select "Export style sheet ID n". The resulting file will contain this:
```
.foo:before {
    content: &quot;&quot;;
}
```

To resolve the issue, check if the definition is not being compiled for export in addition to whether it is not being compiled for writing to a file, only then encode.