### PR TITLE
Fixed support for PHP 7.2 so that Argon2 works too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4.0",
+		"php": "^5.4|^7.0",
 		"leafo/scssphp": "^0.6",
 		"michelf/php-markdown": "^1.4",
 		"matthiasmullie/minify": "^1.3.35",
@@ -20,7 +20,8 @@
 		"swiftmailer/swiftmailer": "^5.4",
 		"tecnickcom/tcpdf": "^6.0",
 		"true/punycode": "^1.0",
-		"contao-components/compass": "^0.12"
+		"contao-components/compass": "^0.12",
+		"ircmaxell/password-compat": "^1.0"
 	},
 	"conflict": {
 		"swiftmailer/swiftmailer": "<5.4.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0c99b37386ebd85c322fd7afaec56d8",
+    "content-hash": "f03266f19337d2c2e0706615992433c2",
     "packages": [
         {
             "name": "contao-components/compass",
@@ -33,6 +33,48 @@
             ],
             "description": "Compass integration for Contao Open Source CMS",
             "time": "2016-07-07T11:45:34+00:00"
+        },
+        {
+            "name": "ircmaxell/password-compat",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/password_compat.git",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/password_compat/zipball/5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/password.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@php.net",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A compatibility library for the proposed simplified password hashing algorithm: https://wiki.php.net/rfc/password_hash",
+            "homepage": "https://github.com/ircmaxell/password_compat",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "time": "2014-11-20T16:49:30+00:00"
         },
         {
             "name": "leafo/scssphp",

--- a/system/config/default.php
+++ b/system/config/default.php
@@ -180,7 +180,6 @@ $GLOBALS['TL_CONFIG']['ftpPort'] = 21;
 $GLOBALS['TL_CONFIG']['encryptionKey']    = '';
 $GLOBALS['TL_CONFIG']['encryptionMode']   = 'cfb';
 $GLOBALS['TL_CONFIG']['encryptionCipher'] = 'rijndael-256';
-$GLOBALS['TL_CONFIG']['bcryptCost']       = 10;
 
 
 /**

--- a/system/modules/core/controllers/BackendInstall.php
+++ b/system/modules/core/controllers/BackendInstall.php
@@ -343,7 +343,7 @@ class BackendInstall extends \Backend
 		// The password has been generated with crypt()
 		if (\Encryption::test(\Config::get('installPassword')))
 		{
-			if (\Encryption::verify(\Input::postUnsafeRaw('password'), \Config::get('installPassword')))
+			if (password_verify(\Input::postUnsafeRaw('password'), \Config::get('installPassword')))
 			{
 				$this->setAuthCookie();
 				\Config::persist('installCount', 0);
@@ -358,8 +358,7 @@ class BackendInstall extends \Backend
 
 			if ($blnAuthenticated)
 			{
-				// Store a crypt() version of the password
-				$strPassword = \Encryption::hash(\Input::postUnsafeRaw('password'));
+				$strPassword = password_hash(\Input::postUnsafeRaw('password'), PASSWORD_DEFAULT);
 				\Config::persist('installPassword', $strPassword);
 
 				$this->setAuthCookie();
@@ -398,7 +397,7 @@ class BackendInstall extends \Backend
 		// Save the password
 		else
 		{
-			$strPassword = \Encryption::hash($strPassword);
+			$strPassword = password_hash($strPassword, PASSWORD_DEFAULT);
 			\Config::persist('installPassword', $strPassword);
 
 			$this->reload();
@@ -768,7 +767,7 @@ class BackendInstall extends \Backend
 				elseif (\Input::post('name') != '' && \Input::post('email', true) != '' && \Input::post('username', true) != '')
 				{
 					$time = time();
-					$strPassword = \Encryption::hash(\Input::postUnsafeRaw('pass'));
+					$strPassword = password_hash(\Input::postUnsafeRaw('pass'), PASSWORD_DEFAULT);
 
 					$this->Database->prepare("INSERT INTO tl_user (tstamp, name, email, username, password, language, backendTheme, admin, showHelp, useRTE, useCE, thumbnails, dateAdded) VALUES ($time, ?, ?, ?, ?, ?, ?, 1, 1, 1, 1, 1, $time)")
 								   ->execute(\Input::post('name'), \Input::post('email', true), \Input::post('username', true), $strPassword, str_replace('-', '_', $GLOBALS['TL_LANGUAGE']), \Config::get('backendTheme'));

--- a/system/modules/core/controllers/BackendPassword.php
+++ b/system/modules/core/controllers/BackendPassword.php
@@ -72,7 +72,7 @@ class BackendPassword extends \Backend
 			else
 			{
 				// Make sure the password has been changed
-				if (\Encryption::verify($pw, $this->User->password))
+				if (password_verify($pw, $this->User->password))
 				{
 					\Message::addError($GLOBALS['TL_LANG']['MSC']['pw_change']);
 				}
@@ -99,7 +99,7 @@ class BackendPassword extends \Backend
 
 					$objUser = \UserModel::findByPk($this->User->id);
 					$objUser->pwChange = '';
-					$objUser->password = \Encryption::hash($pw);
+					$objUser->password = password_hash($pw, PASSWORD_DEFAULT);
 					$objUser->save();
 
 					\Message::addConfirmation($GLOBALS['TL_LANG']['MSC']['pw_changed']);

--- a/system/modules/core/dca/tl_member.php
+++ b/system/modules/core/dca/tl_member.php
@@ -334,7 +334,7 @@ $GLOBALS['TL_DCA']['tl_member'] = array
 			(
 				array('tl_member', 'setNewPassword')
 			),
-			'sql'                     => "varchar(128) NOT NULL default ''"
+			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'assignDir' => array
 		(

--- a/system/modules/core/dca/tl_user.php
+++ b/system/modules/core/dca/tl_user.php
@@ -242,7 +242,7 @@ $GLOBALS['TL_DCA']['tl_user'] = array
 			'exclude'                 => true,
 			'inputType'               => 'password',
 			'eval'                    => array('mandatory'=>true, 'preserveTags'=>true, 'minlength'=>Config::get('minPasswordLength')),
-			'sql'                     => "varchar(128) NOT NULL default ''"
+			'sql'                     => "varchar(255) NOT NULL default ''"
 		),
 		'pwChange' => array
 		(

--- a/system/modules/core/forms/FormPassword.php
+++ b/system/modules/core/forms/FormPassword.php
@@ -137,7 +137,7 @@ class FormPassword extends \Widget
 		{
 			$this->blnSubmitInput = true;
 
-			return \Encryption::hash($varInput);
+			return password_hash($varInput, PASSWORD_DEFAULT);
 		}
 
 		return '';

--- a/system/modules/core/library/Contao/Encryption.php
+++ b/system/modules/core/library/Contao/Encryption.php
@@ -201,10 +201,9 @@ class Encryption
 	 */
 	public static function test($strHash)
 	{
-		// We had SHA1, SHA256 and SHA512 before switching to password API compatible
-		// algorithms (first crypt() and later password_*()) so if it is was not one
-		// of the SHA algorithms, it is compatible.
-		return !(\in_array(\strlen($strHash), [40, 64, 128], true) && ctype_xdigit($strHash));
+		$info = password_get_info($strHash);
+
+		return 0 !== $info['algo'];
 	}
 
 

--- a/system/modules/core/library/Contao/Encryption.php
+++ b/system/modules/core/library/Contao/Encryption.php
@@ -185,61 +185,26 @@ class Encryption
 	 */
 	public static function hash($strPassword)
 	{
-		$intCost = \Config::get('bcryptCost') ?: 10;
+		@trigger_error('Using Encryption::hash() has been deprecated and will no longer work in Contao 5.0. Use password_hash() instead.', E_USER_DEPRECATED);
 
-		if ($intCost < 4 || $intCost > 31)
-		{
-			throw new \Exception("The bcrypt cost has to be between 4 and 31, $intCost given");
-		}
-
-		if (function_exists('password_hash'))
-		{
-			return password_hash($strPassword, PASSWORD_BCRYPT, array('cost'=>$intCost));
-		}
-		elseif (CRYPT_BLOWFISH == 1)
-		{
-			return crypt($strPassword, '$2y$' . sprintf('%02d', $intCost) . '$' . md5(uniqid(mt_rand(), true)) . '$');
-		}
-		elseif (CRYPT_SHA512 == 1)
-		{
-			return crypt($strPassword, '$6$' . md5(uniqid(mt_rand(), true)) . '$');
-		}
-		elseif (CRYPT_SHA256 == 1)
-		{
-			return crypt($strPassword, '$5$' . md5(uniqid(mt_rand(), true)) . '$');
-		}
-
-		throw new \Exception('None of the required crypt() algorithms is available');
+		return password_hash($strPassword, PASSWORD_DEFAULT);
 	}
 
 
 	/**
-	 * Test whether a password hash has been generated with crypt()
+	 * Test whether a password hash has been generated with a password API compatible
+	 * algorithm.
 	 *
 	 * @param string $strHash The password hash
 	 *
-	 * @return boolean True if the password hash has been generated with crypt()
+	 * @return boolean True if compatible
 	 */
 	public static function test($strHash)
 	{
-		if (strncmp($strHash, '$2y$', 4) === 0)
-		{
-			return true;
-		}
-		elseif (strncmp($strHash, '$2a$', 4) === 0)
-		{
-			return true;
-		}
-		elseif (strncmp($strHash, '$6$', 3) === 0)
-		{
-			return true;
-		}
-		elseif (strncmp($strHash, '$5$', 3) === 0)
-		{
-			return true;
-		}
-
-		return false;
+		// We had SHA1, SHA256 and SHA512 before switching to password API compatible
+		// algorithms (first crypt() and later password_*()) so if it is was not one
+		// of the SHA algorithms, it is compatible.
+		return !(\in_array(\strlen($strHash), [40, 64, 128], true) && ctype_xdigit($strHash));
 	}
 
 
@@ -255,30 +220,9 @@ class Encryption
 	 */
 	public static function verify($strPassword, $strHash)
 	{
-		if (function_exists('password_verify'))
-		{
-			return password_verify($strPassword, $strHash);
-		}
+		@trigger_error('Using Encryption::verify() has been deprecated and will no longer work in Contao 5.0. Use password_verify() instead.', E_USER_DEPRECATED);
 
-		$getLength = function($str) {
-			return extension_loaded('mbstring') ? mb_strlen($str, '8bit') : strlen($str);
-		};
-
-		$newHash = crypt($strPassword, $strHash);
-
-		if (!is_string($newHash) || $getLength($newHash) != $getLength($strHash) || $getLength($newHash) <= 13)
-		{
-			return false;
-		}
-
-		$intStatus = 0;
-
-		for ($i=0; $i<$getLength($newHash); $i++)
-		{
-			$intStatus |= (ord($newHash[$i]) ^ ord($strHash[$i]));
-		}
-
-		return $intStatus === 0;
+		return password_verify($strPassword, $strHash);
 	}
 
 

--- a/system/modules/core/library/Contao/User.php
+++ b/system/modules/core/library/Contao/User.php
@@ -381,7 +381,7 @@ abstract class User extends \System
 		// The password has been generated with crypt()
 		if (\Encryption::test($this->password))
 		{
-			$blnAuthenticated = \Encryption::verify(\Input::postUnsafeRaw('password'), $this->password);
+			$blnAuthenticated = password_verify(\Input::postUnsafeRaw('password'), $this->password);
 		}
 		else
 		{
@@ -391,7 +391,7 @@ abstract class User extends \System
 			// Store a SHA-512 encrpyted version of the password
 			if ($blnAuthenticated)
 			{
-				$this->password = \Encryption::hash(\Input::postUnsafeRaw('password'));
+				$this->password = password_hash(\Input::postUnsafeRaw('password'), PASSWORD_DEFAULT);
 			}
 		}
 

--- a/system/modules/core/modules/ModuleChangePassword.php
+++ b/system/modules/core/modules/ModuleChangePassword.php
@@ -148,7 +148,7 @@ class ModuleChangePassword extends \Module
 				{
 					if (\Encryption::test($objMember->password))
 					{
-						$blnAuthenticated = \Encryption::verify($objWidget->value, $objMember->password);
+						$blnAuthenticated = password_verify($objWidget->value, $objMember->password);
 					}
 					else
 					{

--- a/system/modules/core/modules/ModuleCloseAccount.php
+++ b/system/modules/core/modules/ModuleCloseAccount.php
@@ -87,7 +87,7 @@ class ModuleCloseAccount extends \Module
 				// The password has been generated with crypt()
 				if (\Encryption::test($this->User->password))
 				{
-					$blnAuthenticated = \Encryption::verify($objWidget->value, $this->User->password);
+					$blnAuthenticated = password_verify($objWidget->value, $this->User->password);
 				}
 				else
 				{

--- a/system/modules/core/modules/ModuleRegistration.php
+++ b/system/modules/core/modules/ModuleRegistration.php
@@ -209,7 +209,7 @@ class ModuleRegistration extends \Module
 				$varValue = $objWidget->value;
 
 				// Check whether the password matches the username
-				if ($objWidget instanceof \FormPassword && \Encryption::verify(\Input::post('username'), $varValue))
+				if ($objWidget instanceof \FormPassword && password_verify(\Input::post('username'), $varValue))
 				{
 					$objWidget->addError($GLOBALS['TL_LANG']['ERR']['passwordName']);
 				}


### PR DESCRIPTION
With the release of PHP 7.2, there's a new password hashing algorithm Argon2 available. Our `Encryption::test()` currently does not recognize that because it's built the wrong way around. It should not check for the ones it knows are password api compatible but check for the ones it knows are not. That ensures that we do not have to extend that check every time a new algorithm is introduced. The password api does that itself internally. 
I also removed all the legacy code which is handled way better by the `password-compat` polyfill so we know it behaves the same as does the core of php.

I also removed the bcrypt cost configuration. PHP itself defaults to a sane cost, I see no reason why we should not go with what the responsible crypto experts recommend.

This should also go to Contao 4.4 but without the polyfill as we require a php version >= 5.5 where the password api was introduced in php.