### PR TITLE
always refresh cron.txt

### DIFF
--- a/system/modules/core/controllers/FrontendCron.php
+++ b/system/modules/core/controllers/FrontendCron.php
@@ -148,6 +148,12 @@ class FrontendCron extends \Frontend
 			$return = false;
 		}
 
+		// Otherwise make sure cron.txt contains the correct lastrun-time
+		else
+		{
+			$this->updateCronTxt($objCron->value);
+		}
+
 		$this->Database->unlockTables();
 
 		return $return;

--- a/system/modules/core/controllers/FrontendCron.php
+++ b/system/modules/core/controllers/FrontendCron.php
@@ -146,14 +146,13 @@ class FrontendCron extends \Frontend
 			$return = false;
 		}
 
-		// Otherwise make sure cron.txt contains the correct lastrun-time
+		// Make sure the cron.txt file contains the correct time (see #8838)
 		else
 		{
 			$time = $objCron->value;
 		}
 
 		$this->Database->unlockTables();
-
 		$this->updateCronTxt($time);
 
 		return $return;

--- a/system/modules/core/controllers/FrontendCron.php
+++ b/system/modules/core/controllers/FrontendCron.php
@@ -135,7 +135,6 @@ class FrontendCron extends \Frontend
 		// Add the cron entry
 		if ($objCron->numRows < 1)
 		{
-			$this->updateCronTxt($time);
 			$this->Database->query("INSERT INTO tl_cron (name, value) VALUES ('lastrun', $time)");
 			$return = false;
 		}
@@ -143,7 +142,6 @@ class FrontendCron extends \Frontend
 		// Check the last execution time
 		elseif ($objCron->value <= ($time - $this->getCronTimeout()))
 		{
-			$this->updateCronTxt($time);
 			$this->Database->query("UPDATE tl_cron SET value=$time WHERE name='lastrun'");
 			$return = false;
 		}
@@ -151,10 +149,12 @@ class FrontendCron extends \Frontend
 		// Otherwise make sure cron.txt contains the correct lastrun-time
 		else
 		{
-			$this->updateCronTxt($objCron->value);
+			$time = $objCron->value;
 		}
 
 		$this->Database->unlockTables();
+
+		$this->updateCronTxt($time);
 
 		return $return;
 	}


### PR DESCRIPTION
`cron.txt` contains the timestamp of the last cron run. The file is **only** updated with the current timestamp once cron is actually executed.
However, with Docker use cases you may throw away a container any time and start from a clean Contao instance (eg in case of updates, migrations etc), only mounting/linking persistent stuff into the container.
Therefore, the next cron run may only be in a few hours (database still knows `lastrun`), and the `cron.txt` is not created...
Thus, every browser request will always entail an ugly `404`, until the next cron run...

This patch will always write the `cron.txt` containing:

* the current timestamp, if cron is really executed
* the timestamp from the database, otherwise

Writing the `cron.txt` even if it already exists shouldn't be a big deal..?

See also Docker image at:
https://hub.docker.com/r/binfalse/contao/