### PR TITLE
fix url-encoding in sitemap [see #8848]

### DIFF
--- a/system/modules/core/library/Contao/Automator.php
+++ b/system/modules/core/library/Contao/Automator.php
@@ -411,9 +411,7 @@ class Automator extends \System
 			// Add pages
 			foreach ($arrPages as $strUrl)
 			{
-				$strUrl = rawurlencode($strUrl);
-				$strUrl = str_replace(array('%2F', '%3F', '%3D', '%26', '%3A//'), array('/', '?', '=', '&', '://'), $strUrl);
-				$strUrl = ampersand($strUrl, true);
+				$strUrl = htmlspecialchars($strUrl, ENT_XML1, 'UTF-8');
 
 				$objFile->append('  <url><loc>' . $strUrl . '</loc></url>');
 			}


### PR DESCRIPTION
to create the sitemap all contao-urls were `rawurlencode`d:
https://github.com/contao/core/blob/c7f0310ebd3f4e8b32a82f10f9ffa6827ab4b2a3/system/modules/core/library/Contao/Automator.php#L414

afterwards, some special entities were recovered (for example slashes and questionmarks):
https://github.com/contao/core/blob/c7f0310ebd3f4e8b32a82f10f9ffa6827ab4b2a3/system/modules/core/library/Contao/Automator.php#L415

however, colons were only recovered in combination with `://`...
thus, if the contao website is running at an unusual port (or behind a reverse proxy etc) all urls may include the port number, such as `:PORT`, which becomes `%3APORT` via `rawurlencode`, which in turn renders the sitemap-urls invalid...

i guess the urls need to be treated specially to obtain valid XML documents?

here i propose to skip the `rawurlencode` plus subsequent recovering of certain entities, and instead encode the urls XML-safe using:

    htmlspecialchars ($string, ENT_XML1, 'UTF-8');

see https://github.com/contao/core/issues/8848