### PR TITLE
Use a double pipe as logical OR for the version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": "^5.4|^7.0",
+		"php": "^5.4 || ^7.0",
 		"contao-components/compass": "^0.12",
 		"ircmaxell/password-compat": "^1.0",
 		"leafo/scssphp": "^0.6",


### PR DESCRIPTION
The single pipe `|` operator is considered deprecated but retained for backwards compatibility. For the logical OR version comparison, it is recommended to use the double pipe `||` operator in the `composer.json` as per the [official Composer documentation](https://getcomposer.org/doc/articles/versions.md#version-range).